### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET with Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,5 +1,8 @@
 name: Playwright E2E Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:      # manual on-demand trigger
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dbalikhin/Sarifintown/security/code-scanning/2](https://github.com/dbalikhin/Sarifintown/security/code-scanning/2)

In general, the problem is fixed by adding an explicit `permissions` block either at the workflow level (top-level) or at the job level (under `jobs.e2e`) to restrict the `GITHUB_TOKEN` to the least privileges required. This job only needs to read repository contents (for checkout) and upload artifacts, which does not require write access to repository resources. Therefore, `contents: read` is sufficient and aligns with CodeQL’s suggested baseline.

The single best way to fix this without changing existing functionality is to add a `permissions` section at the workflow root (just after `name:` and before `on:`). This will apply to all jobs in the workflow (currently only `e2e`) and clearly documents the intent. Concretely, in `.github/workflows/e2e-playwright.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Playwright E2E Tests`) and line 3 (`on:`). No imports or additional definitions are required, and none of the existing steps need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
