### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET with Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/dbalikhin/Sarifintown/security/code-scanning/1](https://github.com/dbalikhin/Sarifintown/security/code-scanning/1)

To fix this, explicitly define minimal `GITHUB_TOKEN` permissions for the workflow or job. The safest, least-privilege baseline for a pure build-and-test pipeline like this is to set `contents: read` at the workflow level so that all jobs inherit it. This does not change existing functionality because the steps only need to check out code and interact with .NET tooling locally; they do not write to the repository or to GitHub resources.

Concretely, in `.github/workflows/dotnet.yml`, add a `permissions:` block near the top level (same indentation level as `on:` and `jobs:`). For example:

```yml
permissions:
  contents: read
```

Place this after the `name:` block and before the `on:` block (or anywhere at the root level before `jobs:`). No imports or additional methods are needed because this is purely a workflow-configuration change. If in the future the workflow needs extra scopes (e.g., `pull-requests: write`), they can be added under the same `permissions:` mapping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
