### PR TITLE
Rename AgentEngine to Engine and update UI project

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Run Playwright E2E tests (Category=Playwright)
       run: |
-        dotnet test Sarifintown.Tests/Sarifintown.Tests.csproj \
+        dotnet test Sarifintown.Tests/Sarifintown.UI.Tests.csproj \
           --configuration Release \
           --no-build \
           --filter "Category=Playwright" \

--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -1,6 +1,6 @@
-# MCP Setup Guide for `Sarifintown.AgentEngine`
+# MCP Setup Guide for `Sarifintown.Engine`
 
-This guide explains how to configure the `Sarifintown.AgentEngine` as an MCP server in AI IDEs.
+This guide explains how to configure the `Sarifintown.Engine` as an MCP server in AI IDEs.
 
 ## What the server does at startup
 
@@ -45,7 +45,7 @@ sarifintown
 ## Option B: run from source
 
 ```bash
-dotnet run --project Sarifintown.AgentEngine/Sarifintown.AgentEngine.csproj
+dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 ```
 
 ## Option C: run with alternate tool command (if present in your environment)
@@ -154,7 +154,7 @@ Notes:
 If `sarifintown` is not installed as a global tool:
 
 ```bash
-dotnet run --project Sarifintown.AgentEngine/Sarifintown.AgentEngine.csproj
+dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 ```
 
 ---
@@ -208,7 +208,7 @@ dotnet run --project Sarifintown.AgentEngine/Sarifintown.AgentEngine.csproj
       "args": [
         "run",
         "--project",
-        "C:/dev/sarifintown/Sarifintown.AgentEngine/Sarifintown.AgentEngine.csproj"
+        "C:/dev/sarifintown/Sarifintown.AgentEngine/Sarifintown.Engine.csproj"
       ],
       "cwd": "C:/dev/sarifintown",
       "env": {

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Sarifintown is a Blazor WebAssembly solution for analyzing SARIF (Static Analysis Results Interchange Format) files and extracting code snippets from source code. 
 
-MCP server support is available via `Sarifintown.AgentEngine`; see the concise setup guide in [`MCP_SETUP.md`](MCP_SETUP.md).
+MCP server support is available via `Sarifintown.Engine`; see the concise setup guide in [`MCP_SETUP.md`](MCP_SETUP.md).
 
 ## Projects
 
-- **Sarifintown**: Blazor WebAssembly app for SARIF analysis and code snippet extraction.
+- **Sarifintown.UI**: Blazor WebAssembly app for SARIF analysis and code snippet extraction.
 - **Sarifintown.Core**: Core library containing models, helpers, and shared logic.
-- **Sarifintown.Tests**: Test project using NUnit, bUnit, and Playwright for automated testing.
+- **Sarifintown.UI.Tests**: Test project using NUnit, bUnit, and Playwright for automated testing.
 
 ## Features
 

--- a/Sarifintown.AgentEngine.Tests/Sarifintown.Engine.Tests.csproj
+++ b/Sarifintown.AgentEngine.Tests/Sarifintown.Engine.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Sarifintown.AgentEngine\Sarifintown.AgentEngine.csproj" />
+    <ProjectReference Include="..\Sarifintown.AgentEngine\Sarifintown.Engine.csproj" />
   </ItemGroup>
 
 <ItemGroup>

--- a/Sarifintown.AgentEngine/Sarifintown.Engine.csproj
+++ b/Sarifintown.AgentEngine/Sarifintown.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>sarifintown-agent</ToolCommandName>
+    <ToolCommandName>sarifintown</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 

--- a/Sarifintown.Tests/Sarifintown.UI.Tests.csproj
+++ b/Sarifintown.Tests/Sarifintown.UI.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Sarifintown\Sarifintown.csproj" />
+    <ProjectReference Include="..\Sarifintown\Sarifintown.UI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sarifintown.sln
+++ b/Sarifintown.sln
@@ -1,11 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.3.11512.155
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarifintown", "Sarifintown\Sarifintown.csproj", "{69ECCA96-E434-49D3-989E-CD6B7773715C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarifintown.UI", "Sarifintown\\Sarifintown.UI.csproj", "{69ECCA96-E434-49D3-989E-CD6B7773715C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Tests", "Sarifintown.Tests\Sarifintown.Tests.csproj", "{75CECCCA-4789-4555-975B-5E772FD99208}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.UI.Tests", "Sarifintown.Tests\\Sarifintown.UI.Tests.csproj", "{75CECCCA-4789-4555-975B-5E772FD99208}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
@@ -26,11 +26,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Core", "Sarifintown.Core\Sarifintown.Core.csproj", "{B2B08E1B-2B6F-4B1C-A3E1-87FB057F2A1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.AgentEngine", "Sarifintown.AgentEngine\Sarifintown.AgentEngine.csproj", "{92D84CDA-6203-9FCF-A448-4BEAB5E92476}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine", "Sarifintown.AgentEngine\\Sarifintown.Engine.csproj", "{92D84CDA-6203-9FCF-A448-4BEAB5E92476}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Core.Tests", "Sarifintown.Core.Tests\Sarifintown.Core.Tests.csproj", "{5539053E-9CDC-4385-8D1B-67F67C5AD5EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.AgentEngine.Tests", "Sarifintown.AgentEngine.Tests\Sarifintown.AgentEngine.Tests.csproj", "{4765B0F9-9B5F-46D0-BCCD-F1AB026C4B77}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine.Tests", "Sarifintown.AgentEngine.Tests\\Sarifintown.Engine.Tests.csproj", "{4765B0F9-9B5F-46D0-BCCD-F1AB026C4B77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Sarifintown/Sarifintown.UI.csproj
+++ b/Sarifintown/Sarifintown.UI.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Sarifintown</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>


### PR DESCRIPTION
Rename and rebrand project artifacts for clarity: Sarifintown.AgentEngine -> Sarifintown.Engine and Sarifintown -> Sarifintown.UI. Updated .csproj filenames and project references, adjusted ToolCommandName to `sarifintown`, and added RootNamespace to the UI project. Updated solution file entries, test project names/references, Playwright workflow to run Sarifintown.UI.Tests, and documentation (README and MCP_SETUP) to reflect the new project paths and names.