### PR TITLE
Add SARIF triage sidecar support

### DIFF
--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -270,6 +270,7 @@ Recommended message envelope for host ↔ UI:
 Common events:
 
 - Host -> UI: `host.ping`, `host.getState`
+- Host -> UI: `host.openFinding` (payload: `resultIdentity`)
 - UI -> Host: `ui.ready`, `ui.pong`, `ui.state`, `ui.request.chatPrompt`
 
 `ui.request.chatPrompt` payload:

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -1,5 +1,6 @@
 ﻿using ModelContextProtocol.Server;
 using Sarifintown.Core;
+using Sarifintown.Helpers;
 using Sarifintown.Models;
 using System.ComponentModel;
 using System.Reflection;
@@ -243,12 +244,16 @@ namespace Sarifintown.AgentEngine
 
                 var content = await FileReader.ReadFileAsync(resolvedSarifPath);
                 var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                var allResults = sarifLog?.Runs.SelectMany(r => r.Results ?? Enumerable.Empty<Result>()).ToList();
+                var flattenedResults = sarifLog?.Runs
+                    .SelectMany(run => (run.Results ?? Enumerable.Empty<Result>()).Select(result => (run, result)))
+                    .ToList();
 
-                if (allResults == null || !int.TryParse(resultId, out int index) || index < 0 || index >= allResults.Count)
+                if (flattenedResults == null || !int.TryParse(resultId, out int index) || index < 0 || index >= flattenedResults.Count)
                     return JsonSerializer.Serialize(new { error = "Invalid resultId or result not found." });
 
-                var targetResult = allResults[index];
+                var targetPair = flattenedResults[index];
+                var targetResult = targetPair.result;
+                var targetRun = targetPair.run;
 
                 if (targetResult.CodeFlows == null || !targetResult.CodeFlows.Any())
                     return JsonSerializer.Serialize(new { message = "No code flow trace is available in the SARIF log for this issue." });
@@ -266,7 +271,11 @@ namespace Sarifintown.AgentEngine
                         var relativePath = physLoc.ArtifactLocation?.Uri;
                         if (string.IsNullOrEmpty(relativePath)) continue;
 
-                        var fullPath = Path.Combine(sourceCodeRoot, relativePath.Replace("file://", "").TrimStart('/'));
+                        var resolvedPath = FileHelper.ResolveArtifactPath(physLoc.ArtifactLocation, targetRun);
+                        var fullPath = Path.IsPathRooted(resolvedPath)
+                            ? resolvedPath
+                            : Path.Combine(sourceCodeRoot, (resolvedPath ?? relativePath).Replace("file://", "").TrimStart('/'));
+
                         string snippetCode = "Source file unavailable";
 
                         if (File.Exists(fullPath))

--- a/Sarifintown.Core.Tests/FileHelperTests.cs
+++ b/Sarifintown.Core.Tests/FileHelperTests.cs
@@ -32,5 +32,59 @@ namespace Sarifintown.Core.Tests
             Assert.That(result.adjustedPath, Is.EqualTo("src/file.cs"));
             Assert.That(result.matchedFolder, Is.EqualTo(folder));
         }
+
+        [Test]
+        public void ResolveArtifactPath_WithOriginalUriBaseId_CombinesToAbsoluteFilePath()
+        {
+            var run = new Run
+            {
+                OriginalUriBaseIds = new Dictionary<string, UriBaseId>
+                {
+                    ["SRCROOT"] = new UriBaseId { Uri = "file:///repo/" }
+                }
+            };
+
+            var artifact = new PhysicalLocation.PhysicalLocationArtifactLocation
+            {
+                Uri = "src/auth.cs",
+                UriBaseId = "SRCROOT"
+            };
+
+            var resolved = FileHelper.ResolveArtifactPath(artifact, run);
+
+            Assert.That(resolved, Is.EqualTo("repo/src/auth.cs"));
+        }
+
+        [Test]
+        public void ResolveArtifactPath_WithArtifactIndex_UsesIndexedLocation()
+        {
+            var run = new Run
+            {
+                Artifacts = new List<Artifact>
+                {
+                    new Artifact
+                    {
+                        Location = new PhysicalLocation.PhysicalLocationArtifactLocation
+                        {
+                            Uri = "src/file.cs"
+                        }
+                    }
+                }
+            };
+
+            var artifact = new PhysicalLocation.PhysicalLocationArtifactLocation { Index = 0 };
+
+            var resolved = FileHelper.ResolveArtifactPath(artifact, run);
+
+            Assert.That(resolved, Is.EqualTo("src/file.cs"));
+        }
+
+        [Test]
+        public void RebaseToWorkspaceRelativePath_WithWorkspaceFolder_ReturnsRelativePart()
+        {
+            var rebased = FileHelper.RebaseToWorkspaceRelativePath("C:/repo/src/a.cs", "repo");
+
+            Assert.That(rebased, Is.EqualTo("src/a.cs"));
+        }
     }
 }

--- a/Sarifintown.Core.Tests/SarifTriageIdentityHelperTests.cs
+++ b/Sarifintown.Core.Tests/SarifTriageIdentityHelperTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+
+namespace Sarifintown.Core.Tests
+{
+    [TestFixture]
+    public class SarifTriageIdentityHelperTests
+    {
+        [Test]
+        public void BuildIdentity_WithPartialFingerprints_ReturnsDeterministicIdentity()
+        {
+            var result = new Result
+            {
+                PartialFingerprints = new Dictionary<string, string>
+                {
+                    ["primaryLocationLineHash"] = "abc",
+                    ["primaryLocationStartColumnFingerprint"] = "42"
+                }
+            };
+
+            var first = SarifTriageIdentityHelper.BuildIdentity(result);
+            var second = SarifTriageIdentityHelper.BuildIdentity(result);
+
+            Assert.That(first, Is.EqualTo(second));
+        }
+
+        [Test]
+        public void BuildIdentity_WithoutFingerprints_UsesFallbackData()
+        {
+            var result = new Result
+            {
+                RuleId = "RULE001",
+                Message = new Result.ResultMessage { Text = "message" },
+                Locations = new List<ResultLocation>
+                {
+                    new ResultLocation
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new PhysicalLocation.PhysicalLocationArtifactLocation
+                            {
+                                Uri = "src/file.cs"
+                            },
+                            Region = new Region
+                            {
+                                StartLine = 1,
+                                StartColumn = 1,
+                                EndLine = 1,
+                                EndColumn = 10
+                            }
+                        }
+                    }
+                }
+            };
+
+            var identity = SarifTriageIdentityHelper.BuildIdentity(result);
+
+            Assert.That(identity, Is.Not.Empty);
+            Assert.That(identity.Length, Is.EqualTo(64));
+        }
+    }
+}

--- a/Sarifintown.Core/Helpers/CodeFlowHelper.cs
+++ b/Sarifintown.Core/Helpers/CodeFlowHelper.cs
@@ -31,7 +31,14 @@ namespace Sarifintown.Helpers
                         if (region == null) 
                             continue;
 
-                        var normalizedPathForPhysicalLocation = FileHelper.NormalizePath(location.PhysicalLocation.ArtifactLocation.Uri);
+                        var normalizedPathForPhysicalLocation = result.ParentRun != null
+                            ? FileHelper.ResolveArtifactPath(location.PhysicalLocation.ArtifactLocation, result.ParentRun)
+                            : string.Empty;
+
+                        if (string.IsNullOrWhiteSpace(normalizedPathForPhysicalLocation))
+                        {
+                            normalizedPathForPhysicalLocation = FileHelper.NormalizePath(location.PhysicalLocation.ArtifactLocation.Uri);
+                        }
 
                         string error;
                         var (adjustedPath, matchedFolder) = FileHelper.AdjustPathToGrantedFolder(normalizedPathForPhysicalLocation, allDirectories, out error);

--- a/Sarifintown.Core/Helpers/FileHelper.cs
+++ b/Sarifintown.Core/Helpers/FileHelper.cs
@@ -38,6 +38,96 @@ namespace Sarifintown.Helpers
             return string.Join("/", stack.Reverse());
         }
 
+        /// <summary>
+        /// Resolves a SARIF artifact location to a normalized path by using URI, artifact index and originalUriBaseIds.
+        /// </summary>
+        public static string ResolveArtifactPath(PhysicalLocation.PhysicalLocationArtifactLocation artifactLocation, Run run)
+        {
+            ArgumentNullException.ThrowIfNull(run);
+
+            if (artifactLocation == null)
+            {
+                return string.Empty;
+            }
+
+            var uri = artifactLocation.Uri;
+            var uriBaseId = artifactLocation.UriBaseId;
+
+            if ((string.IsNullOrWhiteSpace(uri) || string.IsNullOrWhiteSpace(uriBaseId))
+                && artifactLocation.Index.HasValue
+                && run.Artifacts != null
+                && artifactLocation.Index.Value >= 0
+                && artifactLocation.Index.Value < run.Artifacts.Count)
+            {
+                var indexedLocation = run.Artifacts[artifactLocation.Index.Value]?.Location;
+                if (indexedLocation != null)
+                {
+                    uri = string.IsNullOrWhiteSpace(uri) ? indexedLocation.Uri : uri;
+                    uriBaseId = string.IsNullOrWhiteSpace(uriBaseId) ? indexedLocation.UriBaseId : uriBaseId;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                return string.Empty;
+            }
+
+            if (Uri.TryCreate(uri, UriKind.Absolute, out var absoluteUri))
+            {
+                if (absoluteUri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+                {
+                    return NormalizePath(absoluteUri.LocalPath);
+                }
+
+                return NormalizePath(absoluteUri.LocalPath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(uriBaseId)
+                && run.OriginalUriBaseIds != null
+                && run.OriginalUriBaseIds.TryGetValue(uriBaseId, out var baseInfo))
+            {
+                var basePath = ResolveBasePathFromOriginalUriBaseIds(baseInfo, run.OriginalUriBaseIds);
+                if (!string.IsNullOrWhiteSpace(basePath))
+                {
+                    if (Uri.TryCreate(basePath, UriKind.Absolute, out var baseUri) &&
+                        Uri.TryCreate(baseUri, uri, out var combinedUri))
+                    {
+                        if (combinedUri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return NormalizePath(combinedUri.LocalPath);
+                        }
+
+                        return NormalizePath(combinedUri.LocalPath);
+                    }
+
+                    var combinedPath = Path.Combine(basePath.Replace('/', Path.DirectorySeparatorChar), uri.Replace('/', Path.DirectorySeparatorChar));
+                    return NormalizePath(combinedPath);
+                }
+            }
+
+            return NormalizePath(uri);
+        }
+
+        /// <summary>
+        /// Rebases a normalized path to a workspace-relative path by folder segment name.
+        /// </summary>
+        public static string RebaseToWorkspaceRelativePath(string normalizedPath, string workspaceFolderName)
+        {
+            if (string.IsNullOrWhiteSpace(normalizedPath) || string.IsNullOrWhiteSpace(workspaceFolderName))
+            {
+                return normalizedPath;
+            }
+
+            var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var workspaceIndex = LastIndexOfSegment(segments, workspaceFolderName);
+            if (workspaceIndex < 0 || workspaceIndex >= segments.Length - 1)
+            {
+                return normalizedPath;
+            }
+
+            return string.Join('/', segments.Skip(workspaceIndex + 1));
+        }
+
         public static (string adjustedPath, DirectoryPicker matchedFolder) AdjustPathToGrantedFolder(
             string normalizedSarifPath,
             IEnumerable<DirectoryPicker> accessibleFolders,
@@ -167,6 +257,40 @@ namespace Sarifintown.Helpers
                     return i;
             }
             return -1;
+        }
+
+        private static string ResolveBasePathFromOriginalUriBaseIds(UriBaseId baseInfo, IDictionary<string, UriBaseId> allBaseIds)
+        {
+            if (baseInfo == null || string.IsNullOrWhiteSpace(baseInfo.Uri))
+            {
+                return string.Empty;
+            }
+
+            var baseUri = baseInfo.Uri;
+            if (string.IsNullOrWhiteSpace(baseInfo.ParentUriBaseId))
+            {
+                return baseUri;
+            }
+
+            if (!allBaseIds.TryGetValue(baseInfo.ParentUriBaseId, out var parentInfo))
+            {
+                return baseUri;
+            }
+
+            var parentBasePath = ResolveBasePathFromOriginalUriBaseIds(parentInfo, allBaseIds);
+            if (string.IsNullOrWhiteSpace(parentBasePath))
+            {
+                return baseUri;
+            }
+
+            if (Uri.TryCreate(parentBasePath, UriKind.Absolute, out var parentUri)
+                && Uri.TryCreate(parentUri, baseUri, out var combinedUri))
+            {
+                return combinedUri.ToString();
+            }
+
+            var combinedPath = Path.Combine(parentBasePath.Replace('/', Path.DirectorySeparatorChar), baseUri.Replace('/', Path.DirectorySeparatorChar));
+            return NormalizePath(combinedPath);
         }
 
         private sealed class FlexMatch

--- a/Sarifintown.Core/Helpers/SarifTriageIdentityHelper.cs
+++ b/Sarifintown.Core/Helpers/SarifTriageIdentityHelper.cs
@@ -1,0 +1,64 @@
+using Sarifintown.Models;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Sarifintown.Helpers
+{
+    public static class SarifTriageIdentityHelper
+    {
+        /// <summary>
+        /// Builds a stable identity for a SARIF result by preferring SARIF fingerprints and falling back to location and message attributes.
+        /// </summary>
+        public static string BuildIdentity(Result result)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+
+            var fingerprintSource = BuildFingerprintSource(result);
+            if (string.IsNullOrWhiteSpace(fingerprintSource))
+            {
+                var location = result.Locations?.FirstOrDefault()?.PhysicalLocation;
+                var fallbackPath = result.FilenamePath
+                    ?? location?.ArtifactLocation?.Uri
+                    ?? string.Empty;
+
+                var region = location?.Region;
+                fingerprintSource = string.Join('|',
+                    result.RuleId ?? string.Empty,
+                    FileHelper.NormalizePath(fallbackPath),
+                    region?.StartLine ?? 0,
+                    region?.StartColumn ?? 0,
+                    region?.EndLine ?? 0,
+                    region?.EndColumn ?? 0,
+                    result.Message?.Text ?? string.Empty);
+            }
+
+            return ComputeSha256Hex(fingerprintSource);
+        }
+
+        private static string BuildFingerprintSource(Result result)
+        {
+            if (result.PartialFingerprints != null && result.PartialFingerprints.Count > 0)
+            {
+                return "partial|" + string.Join('|', result.PartialFingerprints
+                    .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                    .Select(pair => $"{pair.Key}={pair.Value}"));
+            }
+
+            if (result.Fingerprints != null && result.Fingerprints.Count > 0)
+            {
+                return "full|" + string.Join('|', result.Fingerprints
+                    .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                    .Select(pair => $"{pair.Key}={pair.Value}"));
+            }
+
+            return string.Empty;
+        }
+
+        private static string ComputeSha256Hex(string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            var hash = SHA256.HashData(bytes);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+}

--- a/Sarifintown.Core/Models/SarifLog.cs
+++ b/Sarifintown.Core/Models/SarifLog.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Sarifintown.Models
@@ -24,6 +25,12 @@ namespace Sarifintown.Models
         [JsonPropertyName("results")]
         public List<Result> Results { get; set; }
 
+        [JsonPropertyName("originalUriBaseIds")]
+        public Dictionary<string, UriBaseId> OriginalUriBaseIds { get; set; }
+
+        [JsonPropertyName("artifacts")]
+        public List<Artifact> Artifacts { get; set; }
+
         [JsonIgnore]
         public ResultLevels Levels { get; set; } = new ResultLevels();
 
@@ -40,6 +47,21 @@ namespace Sarifintown.Models
 
         [JsonIgnore]
         public List<RuleWithCount> UsedRules { get; set; }
+    }
+
+    public class UriBaseId
+    {
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; }
+
+        [JsonPropertyName("uriBaseId")]
+        public string ParentUriBaseId { get; set; }
+    }
+
+    public class Artifact
+    {
+        [JsonPropertyName("location")]
+        public PhysicalLocation.PhysicalLocationArtifactLocation Location { get; set; }
     }
 
     public class RuleWithCount
@@ -97,7 +119,8 @@ namespace Sarifintown.Models
             public string Level { get; set; }
         }
 
-        public List<RuleProperty> Properties { get; set; }
+        [JsonPropertyName("properties")]
+        public Dictionary<string, JsonElement> Properties { get; set; }
     }
 
     public class RuleProperty
@@ -158,6 +181,9 @@ namespace Sarifintown.Models
         [JsonIgnore]
         public Rule Rule { get; set; }
 
+        [JsonIgnore]
+        public Run ParentRun { get; set; }
+
         [JsonPropertyName("locations")]
         public List<ResultLocation> Locations { get; set; }
 
@@ -169,6 +195,21 @@ namespace Sarifintown.Models
 
         [JsonPropertyName("properties")]
         public Dictionary<string, object> Properties { get; set; }
+
+        [JsonPropertyName("fingerprints")]
+        public Dictionary<string, string> Fingerprints { get; set; }
+
+        [JsonPropertyName("partialFingerprints")]
+        public Dictionary<string, string> PartialFingerprints { get; set; }
+
+        [JsonPropertyName("guid")]
+        public string Guid { get; set; }
+
+        [JsonPropertyName("kind")]
+        public string Kind { get; set; }
+
+        [JsonPropertyName("baselineState")]
+        public string BaselineState { get; set; }
 
         [JsonPropertyName("suppressions")]
         public List<Suppression> Suppressions { get; set; }
@@ -250,6 +291,9 @@ namespace Sarifintown.Models
 
             [JsonPropertyName("uriBaseId")]
             public string UriBaseId { get; set; }
+
+            [JsonPropertyName("index")]
+            public int? Index { get; set; }
         }
 
         [JsonPropertyName("region")]

--- a/Sarifintown.Core/Models/SarifLog.cs
+++ b/Sarifintown.Core/Models/SarifLog.cs
@@ -47,6 +47,15 @@ namespace Sarifintown.Models
 
         [JsonIgnore]
         public List<RuleWithCount> UsedRules { get; set; }
+
+        [JsonIgnore]
+        public Dictionary<string, HashSet<string>> ResultIdentityBySeverity { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        [JsonIgnore]
+        public Dictionary<string, HashSet<string>> ResultIdentityByRuleId { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        [JsonIgnore]
+        public HashSet<string> AllResultIdentities { get; set; } = new(StringComparer.Ordinal);
     }
 
     public class UriBaseId
@@ -176,10 +185,19 @@ namespace Sarifintown.Models
         public string FilenamePath { get; set; }
 
         [JsonIgnore]
+        public string OriginalFilenamePath { get; set; }
+
+        [JsonIgnore]
         public string FilenameExt { get; set; }
 
         [JsonIgnore]
         public Rule Rule { get; set; }
+
+        [JsonIgnore]
+        public string ResultIdentity { get; set; }
+
+        [JsonIgnore]
+        public bool IsSnippetLoaded { get; set; }
 
         [JsonIgnore]
         public Run ParentRun { get; set; }

--- a/Sarifintown.Core/Models/SarifTriageSidecar.cs
+++ b/Sarifintown.Core/Models/SarifTriageSidecar.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Sarifintown.Models
+{
+    public sealed record SarifTriageSidecar
+    {
+        [JsonPropertyName("schemaVersion")]
+        public int SchemaVersion { get; init; } = 1;
+
+        [JsonPropertyName("suppressions")]
+        public List<SarifTriageSuppressionEntry> Suppressions { get; init; } = new();
+    }
+
+    public sealed record SarifTriageSuppressionEntry
+    {
+        [JsonPropertyName("identity")]
+        public string Identity { get; init; } = string.Empty;
+
+        [JsonPropertyName("ruleId")]
+        public string RuleId { get; init; } = string.Empty;
+
+        [JsonPropertyName("path")]
+        public string Path { get; init; } = string.Empty;
+
+        [JsonPropertyName("startLine")]
+        public int? StartLine { get; init; }
+
+        [JsonPropertyName("updatedUtc")]
+        public DateTime UpdatedUtc { get; init; } = DateTime.UtcNow;
+
+        [JsonPropertyName("suppression")]
+        public Suppression Suppression { get; init; } = new();
+    }
+}

--- a/Sarifintown.Tests/CodeSnippetServiceTests.cs
+++ b/Sarifintown.Tests/CodeSnippetServiceTests.cs
@@ -1,0 +1,104 @@
+using Sarifintown.Core;
+using Sarifintown.Models;
+using Sarifintown.Services;
+
+namespace Sarifintown.Tests
+{
+    [TestFixture]
+    public class CodeSnippetServiceTests
+    {
+        [Test]
+        public async Task EnsureCodeSnippetAsync_WhenCalledTwice_UsesCacheForSecondCall()
+        {
+            var fileReader = new CountingFileReader();
+            fileReader.Files["src/file.cs"] = "line1\nline2\nline3\nline4";
+
+            var localFilesService = new LocalFilesService();
+            localFilesService.AddDirectory(new DirectoryPicker { Id = 1, Name = "src" });
+
+            var service = new CodeSnippetService(fileReader, localFilesService);
+            var run = new Run { Results = new List<Result>() };
+            var result = CreateResult();
+            run.Results.Add(result);
+
+            var first = await service.EnsureCodeSnippetAsync(run, result);
+            var second = await service.EnsureCodeSnippetAsync(run, result);
+
+            Assert.That(first.Success, Is.True);
+            Assert.That(second.Success, Is.True);
+            Assert.That(fileReader.ReadCount, Is.EqualTo(1));
+            Assert.That(result.IsSnippetLoaded, Is.True);
+            Assert.That(result.Locations[0].PhysicalLocation.ExtractedCodeSnippet, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task AddCodeSnippetsToRunAsync_LoadsSnippetsInBatch()
+        {
+            var fileReader = new CountingFileReader();
+            fileReader.Files["src/file1.cs"] = "a\nb\nc\nd\ne";
+            fileReader.Files["src/file2.cs"] = "f\ng\nh\ni\nj";
+
+            var localFilesService = new LocalFilesService();
+            localFilesService.AddDirectory(new DirectoryPicker { Id = 2, Name = "src" });
+
+            var service = new CodeSnippetService(fileReader, localFilesService);
+            var run = new Run
+            {
+                Results =
+                [
+                    CreateResult("src/file1.cs"),
+                    CreateResult("src/file2.cs")
+                ]
+            };
+
+            var callbackCount = 0;
+            var response = await service.AddCodeSnippetsToRunAsync(
+                run,
+                onSnippetAdded: () => callbackCount++,
+                batchSize: 1);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(run.Results.All(result => result.IsSnippetLoaded), Is.True);
+            Assert.That(callbackCount, Is.GreaterThanOrEqualTo(2));
+        }
+
+        private static Result CreateResult(string path = "src/file.cs")
+        {
+            return new Result
+            {
+                RuleId = "RULE001",
+                Level = "warning",
+                Message = new Result.ResultMessage { Text = "issue" },
+                Locations =
+                [
+                    new ResultLocation
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new PhysicalLocation.PhysicalLocationArtifactLocation { Uri = path },
+                            Region = new Region { StartLine = 2, StartColumn = 1, EndLine = 2, EndColumn = 4 }
+                        }
+                    }
+                ]
+            };
+        }
+
+        private sealed class CountingFileReader : IFileReader
+        {
+            public Dictionary<string, string> Files { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+            public int ReadCount { get; private set; }
+
+            public Task<string> ReadFileAsync(string relativePath)
+            {
+                ReadCount++;
+                if (Files.TryGetValue(relativePath, out var content))
+                {
+                    return Task.FromResult(content);
+                }
+
+                return Task.FromResult(string.Empty);
+            }
+        }
+    }
+}

--- a/Sarifintown.Tests/SarifFileServiceTests.cs
+++ b/Sarifintown.Tests/SarifFileServiceTests.cs
@@ -1,0 +1,134 @@
+using Sarifintown.Models;
+using Sarifintown.Services;
+
+namespace Sarifintown.Tests
+{
+    [TestFixture]
+    public class SarifFileServiceTests
+    {
+        [Test]
+        public void AddSarifFile_AssignsIdentityAndOriginalPath()
+        {
+            var service = new SarifFileService();
+            var sarifLog = CreateSarifLog(level: "warning", ruleId: "RULE001", path: "src/auth.cs");
+            var sarifFile = new SarifFile("test.sarif", 123, sarifLog);
+
+            var added = service.AddSarifFile(sarifFile, jsDirectoryId: 7);
+
+            Assert.That(added, Is.True);
+            var result = sarifLog.Runs[0].Results[0];
+            Assert.That(result.ResultIdentity, Is.Not.Null.And.Not.Empty);
+            Assert.That(result.OriginalFilenamePath, Is.EqualTo("src/auth.cs"));
+            Assert.That(sarifLog.Runs[0].JSDirectoryId, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void GetFilteredResultIdentities_WithSeverityAndRule_ReturnsMatchingResultOnly()
+        {
+            var service = new SarifFileService();
+            var sarifLog = new SarifLog
+            {
+                Version = "2.1.0",
+                Runs =
+                [
+                    new Run
+                    {
+                        Tool = new Tool
+                        {
+                            Driver = new Tool.ToolDriver
+                            {
+                                Rule =
+                                [
+                                    new Rule { Id = "RULE001", DefaultConfiguration = new Rule.RuleDefaultConfiguration { Level = "warning" } },
+                                    new Rule { Id = "RULE002", DefaultConfiguration = new Rule.RuleDefaultConfiguration { Level = "error" } }
+                                ]
+                            }
+                        },
+                        Results =
+                        [
+                            CreateResult("RULE001", "warning", "src/a.cs"),
+                            CreateResult("RULE002", "error", "src/b.cs")
+                        ]
+                    }
+                ]
+            };
+
+            service.AddSarifFile(new SarifFile("multi.sarif", 100, sarifLog));
+            var run = sarifLog.Runs[0];
+            var selectedRules = new[] { new RuleWithCount { Rule = new Rule { Id = "RULE002" }, Count = 1 } };
+
+            var filtered = service.GetFilteredResultIdentities(run, new[] { "error" }, selectedRules);
+
+            Assert.That(filtered.Count, Is.EqualTo(1));
+            Assert.That(filtered.Contains(run.Results[1].ResultIdentity), Is.True);
+        }
+
+        [Test]
+        public void FindResultByIdentity_WithKnownIdentity_ReturnsRunAndResult()
+        {
+            var service = new SarifFileService();
+            var sarifLog = CreateSarifLog(level: "note", ruleId: "RULE001", path: "src/file.cs");
+            service.AddSarifFile(new SarifFile("one.sarif", 64, sarifLog));
+
+            var identity = sarifLog.Runs[0].Results[0].ResultIdentity;
+            var found = service.FindResultByIdentity(identity);
+
+            Assert.That(found, Is.Not.Null);
+            Assert.That(found!.Value.Result.RuleId, Is.EqualTo("RULE001"));
+        }
+
+        private static SarifLog CreateSarifLog(string level, string ruleId, string path)
+        {
+            return new SarifLog
+            {
+                Version = "2.1.0",
+                Runs =
+                [
+                    new Run
+                    {
+                        Tool = new Tool
+                        {
+                            Driver = new Tool.ToolDriver
+                            {
+                                Rule =
+                                [
+                                    new Rule
+                                    {
+                                        Id = ruleId,
+                                        DefaultConfiguration = new Rule.RuleDefaultConfiguration { Level = level }
+                                    }
+                                ]
+                            }
+                        },
+                        Results =
+                        [
+                            CreateResult(ruleId, level, path)
+                        ]
+                    }
+                ]
+            };
+        }
+
+        private static Result CreateResult(string ruleId, string level, string path)
+        {
+            return new Result
+            {
+                RuleId = ruleId,
+                RuleIndex = 0,
+                Level = level,
+                Message = new Result.ResultMessage { Text = "issue" },
+                Locations =
+                [
+                    new ResultLocation
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new PhysicalLocation.PhysicalLocationArtifactLocation { Uri = path },
+                            Region = new Region { StartLine = 10, StartColumn = 1, EndLine = 10, EndColumn = 12 }
+                        }
+                    }
+                ]
+            };
+        }
+    }
+}

--- a/Sarifintown.Tests/SarifTriageSidecarServiceTests.cs
+++ b/Sarifintown.Tests/SarifTriageSidecarServiceTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.JSInterop;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+using Sarifintown.Services;
+using System.Text.Json;
+
+namespace Sarifintown.Tests
+{
+    [TestFixture]
+    public class SarifTriageSidecarServiceTests
+    {
+        [Test]
+        public async Task ApplySuppressions_WithMatchingIdentity_AddsSuppressionToResult()
+        {
+            var result = new Result
+            {
+                RuleId = "RULE001",
+                Message = new Result.ResultMessage { Text = "Issue" },
+                Locations = new List<ResultLocation>
+                {
+                    new ResultLocation
+                    {
+                        PhysicalLocation = new PhysicalLocation
+                        {
+                            ArtifactLocation = new PhysicalLocation.PhysicalLocationArtifactLocation { Uri = "src/a.cs" },
+                            Region = new Region { StartLine = 10, StartColumn = 1, EndLine = 10, EndColumn = 20 }
+                        }
+                    }
+                }
+            };
+
+            var identity = SarifTriageIdentityHelper.BuildIdentity(result);
+            var sidecar = new SarifTriageSidecar
+            {
+                Suppressions =
+                [
+                    new SarifTriageSuppressionEntry
+                    {
+                        Identity = identity,
+                        RuleId = "RULE001",
+                        Path = "src/a.cs",
+                        StartLine = 10,
+                        Suppression = new Suppression
+                        {
+                            Kind = "external",
+                            Status = "accepted",
+                            Justification = "Triaged"
+                        }
+                    }
+                ]
+            };
+
+            var sidecarJson = JsonSerializer.Serialize(sidecar);
+            var jsRuntime = new FakeJsRuntime(sidecarJson);
+            var service = new SarifTriageSidecarService(jsRuntime);
+
+            await service.PrimeDirectoryAsync(1);
+
+            var sarifLog = new SarifLog
+            {
+                Version = "2.1.0",
+                Runs =
+                [
+                    new Run
+                    {
+                        Results = [result]
+                    }
+                ]
+            };
+
+            service.ApplySuppressions(sarifLog, 1);
+
+            Assert.That(result.Suppressions, Has.Count.EqualTo(1));
+            Assert.That(result.Suppressions[0].Status, Is.EqualTo("accepted"));
+        }
+
+        private sealed class FakeJsRuntime : IJSRuntime
+        {
+            private readonly string _sidecarJson;
+
+            public FakeJsRuntime(string sidecarJson)
+            {
+                _sidecarJson = sidecarJson;
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+            {
+                return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+            }
+
+            public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+            {
+                if (identifier == "fileSystemHelpers.readTextFile")
+                {
+                    return ValueTask.FromResult((TValue)(object)_sidecarJson);
+                }
+
+                if (identifier == "scriptLoader.ensure")
+                {
+                    return ValueTask.FromResult(default(TValue)!);
+                }
+
+                throw new InvalidOperationException($"Unexpected JS invocation: {identifier}");
+            }
+        }
+    }
+}

--- a/Sarifintown/Pages/Analysis.razor
+++ b/Sarifintown/Pages/Analysis.razor
@@ -3,7 +3,6 @@
 @using Sarifintown.Models
 @using Sarifintown.Services
 @using System.Linq
-@implements IDisposable
 
 @inject SarifFileService SarifFileService
 @inject IJSRuntime JS
@@ -45,12 +44,6 @@ else
                                         <MudButton Size="Size.Small" Variant="Variant.Filled" StartIcon="@Icons.Material.Outlined.Transform" Color="Color.Primary" OnClick="@(() => AddCodeSnippetsAsync(run))" Disabled="@_isLoadingSnippets">
                                             Add Code Snippets
                                         </MudButton>
-                                        @if (_isLoadingSnippets)
-                                        {
-                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning" OnClick="CancelSnippetLoading">
-                                                Cancel Loading
-                                            </MudButton>
-                                        }
                                     </MudButtonGroup>
 
                                     <MudChipSet T="string" SelectionMode="SelectionMode.MultiSelection" CheckMark="true" Variant="Variant.Text" Color="Color.Info" SelectedValuesChanged="SeveritySelectionChanged">
@@ -170,7 +163,6 @@ else
     private readonly Dictionary<Run, (int Version, HashSet<string> Identities)> _runFilterCache = new();
     private int _filterVersion;
     private bool _isLoadingSnippets;
-    private CancellationTokenSource? _snippetLoadingCts;
     private bool _findingHandled;
 
     private IReadOnlyCollection<string>? _selectedSeverity;
@@ -278,9 +270,6 @@ else
 
     private async Task AddCodeSnippetsAsync(Run run)
     {
-        _snippetLoadingCts?.Cancel();
-        _snippetLoadingCts?.Dispose();
-        _snippetLoadingCts = new CancellationTokenSource();
         _isLoadingSnippets = true;
 
         try
@@ -288,8 +277,7 @@ else
             var (success, errorMessage) = await CodeSnippetService.AddCodeSnippetsToRunAsync(
                 run,
                 onSnippetAdded: () => InvokeAsync(StateHasChanged),
-                batchSize: 25,
-                cancellationToken: _snippetLoadingCts.Token);
+                batchSize: 25);
 
             if (!success)
             {
@@ -299,15 +287,8 @@ else
         finally
         {
             _isLoadingSnippets = false;
-            _snippetLoadingCts?.Dispose();
-            _snippetLoadingCts = null;
             await InvokeAsync(StateHasChanged);
         }
-    }
-
-    private void CancelSnippetLoading()
-    {
-        _snippetLoadingCts?.Cancel();
     }
 
     private async Task LoadSnippetAsync(Run run, Result result)
@@ -349,12 +330,5 @@ else
     {
         _filterVersion++;
     }
-
-    public void Dispose()
-    {
-        _snippetLoadingCts?.Cancel();
-        _snippetLoadingCts?.Dispose();
-    }
-
 
 }

--- a/Sarifintown/Pages/Analysis.razor
+++ b/Sarifintown/Pages/Analysis.razor
@@ -3,6 +3,7 @@
 @using Sarifintown.Models
 @using Sarifintown.Services
 @using System.Linq
+@implements IDisposable
 
 @inject SarifFileService SarifFileService
 @inject IJSRuntime JS
@@ -10,6 +11,7 @@
 @inject IDialogService DialogService
 @inject LocalFilesService LocalFilesService
 @inject CodeSnippetService CodeSnippetService
+@inject NavigationManager Navigation
 
 <PageTitle>Analysis</PageTitle>
 
@@ -40,9 +42,15 @@ else
                             {                  
                                 <MudToolBar Class="justify-space-between" Dense >
                                     <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
-                                        <MudButton Size="Size.Small" Variant="Variant.Filled" StartIcon="@Icons.Material.Outlined.Transform" Color="Color.Primary" OnClick="@(() => AddCodeSnippetsAsync(run))">
+                                        <MudButton Size="Size.Small" Variant="Variant.Filled" StartIcon="@Icons.Material.Outlined.Transform" Color="Color.Primary" OnClick="@(() => AddCodeSnippetsAsync(run))" Disabled="@_isLoadingSnippets">
                                             Add Code Snippets
                                         </MudButton>
+                                        @if (_isLoadingSnippets)
+                                        {
+                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning" OnClick="CancelSnippetLoading">
+                                                Cancel Loading
+                                            </MudButton>
+                                        }
                                     </MudButtonGroup>
 
                                     <MudChipSet T="string" SelectionMode="SelectionMode.MultiSelection" CheckMark="true" Variant="Variant.Text" Color="Color.Info" SelectedValuesChanged="SeveritySelectionChanged">
@@ -74,7 +82,7 @@ else
                                              Hideable="true"
                                              Groupable="true"
                                              GroupExpanded="true"                                             
-                                             QuickFilter="FilterBySeverityAndRule"                                             
+                                             QuickFilter="@((result) => FilterBySeverityAndRule(run, result))"                                             
                                              Dense>
                                     <Columns>                                        
                                         <PropertyColumn Property="x => x.FilenamePath" Title="File Path"
@@ -108,6 +116,10 @@ else
                                                             <MudText Class="d-flex align-center ml-14" GutterBottom>                                                                
                                                                 <b>(Line: @context.Item.Locations[0].PhysicalLocation.Region.StartLine) @context.Item.Locations[0].PhysicalLocation.Region.Snippet?.Text</b>
                                                             </MudText>
+
+                                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info" OnClick="@(() => LoadSnippetAsync(run, context.Item))" Disabled="@_isLoadingSnippets">
+                                                                Load Snippet
+                                                            </MudButton>
                                                         }
                                                         @if (context.Item.Locations[0].PhysicalLocation.ExtractedCodeSnippet != null)
                                                         {
@@ -150,15 +162,35 @@ else
 }
 
 @code {
+    [SupplyParameterFromQuery(Name = "findingId")]
+    public string? FindingId { get; set; }
+
     private bool IsGrouped { get; set; } = false;
     private MudDataGrid<Result> dataGrid;
+    private readonly Dictionary<Run, (int Version, HashSet<string> Identities)> _runFilterCache = new();
+    private int _filterVersion;
+    private bool _isLoadingSnippets;
+    private CancellationTokenSource? _snippetLoadingCts;
+    private bool _findingHandled;
 
     private IReadOnlyCollection<string>? _selectedSeverity;
     private IEnumerable<RuleWithCount>? _selectedRules;
 
-    private bool FilterBySeverityAndRule(Result result)
+    private bool FilterBySeverityAndRule(Run run, Result result)
     {
-        return AnalysisHelper.FilterBySeverityAndRule(result, _selectedSeverity, _selectedRules);
+        if (result == null || string.IsNullOrWhiteSpace(result.ResultIdentity))
+        {
+            return false;
+        }
+
+        if (!_runFilterCache.TryGetValue(run, out var cache) || cache.Version != _filterVersion)
+        {
+            var ids = SarifFileService.GetFilteredResultIdentities(run, _selectedSeverity, _selectedRules);
+            cache = (_filterVersion, ids);
+            _runFilterCache[run] = cache;
+        }
+
+        return cache.Identities.Contains(result.ResultIdentity);
     }
 
     private Color GetAvatarColor(string level)
@@ -186,11 +218,13 @@ else
     private void RulesSelectedValuesChanged(IEnumerable<RuleWithCount> rules)
     {
         _selectedRules = rules;
+        InvalidateFilterCache();
     }
 
     private void SeveritySelectionChanged(IReadOnlyCollection<string> selectedValues)
     {
         _selectedSeverity = selectedValues;
+        InvalidateFilterCache();
     }
 
     private IEnumerable<SarifFile> selectedFiles { get; set; } = new List<SarifFile>();
@@ -212,10 +246,22 @@ else
         selectedFiles = SarifFileService.AllFiles;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_findingHandled || string.IsNullOrWhiteSpace(FindingId))
+        {
+            return;
+        }
+
+        _findingHandled = true;
+        await OpenFindingFromQueryAsync(FindingId);
+    }
+
     private void OnTabActivated()
     {
         // reset selected rules
         _selectedRules = null;
+        InvalidateFilterCache();
     }
 
     private Task OpenDetailsAsync(Result result, int  jsDirectoryId)
@@ -232,12 +278,82 @@ else
 
     private async Task AddCodeSnippetsAsync(Run run)
     {
-        var (success, errorMessage) = await CodeSnippetService.AddCodeSnippetsToRunAsync(run, () => InvokeAsync(StateHasChanged));
+        _snippetLoadingCts?.Cancel();
+        _snippetLoadingCts?.Dispose();
+        _snippetLoadingCts = new CancellationTokenSource();
+        _isLoadingSnippets = true;
 
+        try
+        {
+            var (success, errorMessage) = await CodeSnippetService.AddCodeSnippetsToRunAsync(
+                run,
+                onSnippetAdded: () => InvokeAsync(StateHasChanged),
+                batchSize: 25,
+                cancellationToken: _snippetLoadingCts.Token);
+
+            if (!success)
+            {
+                Snackbar.Add(errorMessage, Severity.Error);
+            }
+        }
+        finally
+        {
+            _isLoadingSnippets = false;
+            _snippetLoadingCts?.Dispose();
+            _snippetLoadingCts = null;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void CancelSnippetLoading()
+    {
+        _snippetLoadingCts?.Cancel();
+    }
+
+    private async Task LoadSnippetAsync(Run run, Result result)
+    {
+        var (success, errorMessage) = await CodeSnippetService.EnsureCodeSnippetAsync(run, result);
         if (!success)
         {
-            Snackbar.Add(errorMessage, Severity.Error);
+            Snackbar.Add(errorMessage, Severity.Warning);
         }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OpenFindingFromQueryAsync(string resultIdentity)
+    {
+        var match = SarifFileService.FindResultByIdentity(resultIdentity);
+        if (match == null)
+        {
+            Snackbar.Add("Requested finding is not available in the current analysis session.", Severity.Warning);
+            return;
+        }
+
+        var run = match.Value.Run;
+        var result = match.Value.Result;
+
+        selectedFiles = SarifFileService.AllFiles.Where(file => (file.SarifLog.Runs ?? new List<Run>()).Contains(run)).ToList();
+
+        var (snippetLoaded, errorMessage) = await CodeSnippetService.EnsureCodeSnippetAsync(run, result);
+        if (!snippetLoaded && !string.IsNullOrWhiteSpace(errorMessage))
+        {
+            Snackbar.Add(errorMessage, Severity.Warning);
+        }
+
+        await OpenDetailsAsync(result, run.JSDirectoryId);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void InvalidateFilterCache()
+    {
+        _filterVersion++;
+    }
+
+    public void Dispose()
+    {
+        _snippetLoadingCts?.Cancel();
+        _snippetLoadingCts?.Dispose();
     }
 
 

--- a/Sarifintown/Pages/Home.razor
+++ b/Sarifintown/Pages/Home.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
 @inject LocalFilesService LocalFilesService
+@inject SarifTriageSidecarService SarifTriageSidecarService
 
 <PageTitle>Sarif In Town Start</PageTitle>
 
@@ -116,6 +117,15 @@
                         Name = result.Name,
                         Subdirectories = result.Subdirectories,
                     });
+
+                try
+                {
+                    await SarifTriageSidecarService.PrimeDirectoryAsync(result.DirectoryId);
+                }
+                catch (JSException ex)
+                {
+                    Snackbar.Add($"Could not load suppression sidecar: {ex.Message}", Severity.Warning);
+                }
 
                 Snackbar.Add($"View access granted for: {result.Name}", Severity.Success);
 
@@ -231,6 +241,11 @@
         var logAdded = SarifFileService.AddSarifFile(new SarifFile(filename, size, sarifLog), jsDirectoryId);
         if (logAdded)
         {
+            if (jsDirectoryId > 0)
+            {
+                SarifTriageSidecarService.ApplySuppressions(sarifLog, jsDirectoryId);
+            }
+
             importLog += "Success: File added to the current analysis" + Environment.NewLine;
             return true;
         }

--- a/Sarifintown/Pages/McpDashboard.razor
+++ b/Sarifintown/Pages/McpDashboard.razor
@@ -1,5 +1,6 @@
 @page "/mcp/dashboard"
 @using Sarifintown.Services
+@using System.Text.Json
 @implements IDisposable
 
 @inject McpUiBridgeService Bridge
@@ -39,7 +40,7 @@
         await Bridge.SendAsync("ui.ready", new
         {
             route = "/mcp/dashboard",
-            capabilities = new[] { "state", "navigation", "diagnostics", "toolRequests" }
+            capabilities = new[] { "state", "navigation", "diagnostics", "toolRequests", "openFinding" }
         });
 
         _connectionState = "Connected";
@@ -57,6 +58,17 @@
         if (string.Equals(envelope.Type, "host.getState", StringComparison.OrdinalIgnoreCase))
         {
             await SendStateAsync(envelope.RequestId);
+        }
+
+        if (string.Equals(envelope.Type, "host.openFinding", StringComparison.OrdinalIgnoreCase)
+            && envelope.Payload.ValueKind == JsonValueKind.Object
+            && envelope.Payload.TryGetProperty("resultIdentity", out var resultIdentityElement))
+        {
+            var resultIdentity = resultIdentityElement.GetString();
+            if (!string.IsNullOrWhiteSpace(resultIdentity))
+            {
+                Navigation.NavigateTo($"/analysis?findingId={Uri.EscapeDataString(resultIdentity)}");
+            }
         }
 
         await InvokeAsync(StateHasChanged);

--- a/Sarifintown/Program.cs
+++ b/Sarifintown/Program.cs
@@ -43,6 +43,7 @@ namespace Sarifintown
             builder.Services.AddSingleton<SettingsService>();
             builder.Services.AddScoped<AppModeService>();
             builder.Services.AddScoped<CodeSnippetService>();
+            builder.Services.AddScoped<SarifTriageSidecarService>();
             builder.Services.AddScoped<McpUiBridgeService>();
             builder.Services.AddScoped<McpAgentToolClientService>();
 

--- a/Sarifintown/Services/CodeSnippetService.cs
+++ b/Sarifintown/Services/CodeSnippetService.cs
@@ -20,57 +20,53 @@ namespace Sarifintown.Services
 
         public async Task<(bool Success, string ErrorMessage)> AddCodeSnippetsToRunAsync(Run run, Action onSnippetAdded = null)
         {
-            if (run.JSDirectoryId == 0 && !_localFilesService.AllDirectories.Any())
+            if (!_localFilesService.AllDirectories.Any())
             {
                 return (false, "No Source Code Folder Selected");
             }
 
-            if (run.JSDirectoryId == 0)
+            try
             {
-                try
+                foreach (var result in run.Results ?? new List<Result>())
                 {
-                    foreach (var result in run.Results)
+                    if (result.Locations?.Any() != true)
                     {
-                        if (result.Locations.Any())
-                        {
-                            var normalizedPath = FileHelper.NormalizePath(result.FilenamePath);
-
-                            string error;
-                            string content;
-                            var (adjustedPath, matchedFolder) = FileHelper.AdjustPathToGrantedFolder(normalizedPath, _localFilesService.AllDirectories, out error);
-                            if (adjustedPath == null || matchedFolder == null)
-                            {
-                                return (false, error);
-                            }
-                            else
-                            {
-                                // Assign the matched folder's Id to the run
-                                run.JSDirectoryId = matchedFolder.Id;
-
-                                // save adjusted path for furure references
-                                result.FilenamePath = adjustedPath;
-
-                                content = await _fileReader.ReadFileAsync(adjustedPath);
-                                if (string.IsNullOrEmpty(content))
-                                {
-                                    return (false, $"Unable to read {result.FilenamePath}");
-                                }
-                            }
-
-                            var region = result.Locations[0].PhysicalLocation.Region;
-                            var res = SnippetHelper.ExtractCodeSnippet(content, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
-
-                            result.Locations[0].PhysicalLocation.ExtractedCodeSnippet = res;
-
-                            // Notify UI of changes after each snippet is added
-                            onSnippetAdded?.Invoke();
-                        }
+                        continue;
                     }
+
+                    var fallbackPath = result.Locations[0]?.PhysicalLocation?.ArtifactLocation?.Uri;
+                    var normalizedPath = FileHelper.NormalizePath(string.IsNullOrWhiteSpace(result.FilenamePath) ? fallbackPath : result.FilenamePath);
+
+                    string error;
+                    var (adjustedPath, matchedFolder) = FileHelper.AdjustPathToGrantedFolder(normalizedPath, _localFilesService.AllDirectories, out error);
+                    if (adjustedPath == null || matchedFolder == null)
+                    {
+                        return (false, error);
+                    }
+
+                    if (run.JSDirectoryId == 0)
+                    {
+                        run.JSDirectoryId = matchedFolder.Id;
+                    }
+
+                    result.FilenamePath = adjustedPath;
+
+                    var content = await _fileReader.ReadFileAsync(adjustedPath);
+                    if (string.IsNullOrEmpty(content))
+                    {
+                        return (false, $"Unable to read {result.FilenamePath}");
+                    }
+
+                    var region = result.Locations[0].PhysicalLocation.Region;
+                    var snippet = SnippetHelper.ExtractCodeSnippet(content, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
+                    result.Locations[0].PhysicalLocation.ExtractedCodeSnippet = snippet;
+
+                    onSnippetAdded?.Invoke();
                 }
-                catch (Exception ex)
-                {
-                    return (false, ex.Message);
-                }
+            }
+            catch (Exception ex)
+            {
+                return (false, ex.Message);
             }
 
             return (true, null);

--- a/Sarifintown/Services/CodeSnippetService.cs
+++ b/Sarifintown/Services/CodeSnippetService.cs
@@ -2,7 +2,9 @@ using Sarifintown.Helpers;
 using Sarifintown.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sarifintown.Services
@@ -11,6 +13,8 @@ namespace Sarifintown.Services
     {
         private readonly Sarifintown.Core.IFileReader _fileReader;
         private readonly LocalFilesService _localFilesService;
+        private readonly Dictionary<string, string> _fileContentCache = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ExtractedCodeSnippet> _snippetCache = new(StringComparer.Ordinal);
 
         public CodeSnippetService(Sarifintown.Core.IFileReader fileReader, LocalFilesService localFilesService)
         {
@@ -18,8 +22,17 @@ namespace Sarifintown.Services
             _localFilesService = localFilesService;
         }
 
-        public async Task<(bool Success, string ErrorMessage)> AddCodeSnippetsToRunAsync(Run run, Action onSnippetAdded = null)
+        /// <summary>
+        /// Loads code snippets for all results in a run using batched UI updates and internal file/snippet caching.
+        /// </summary>
+        public async Task<(bool Success, string ErrorMessage)> AddCodeSnippetsToRunAsync(
+            Run run,
+            Action? onSnippetAdded = null,
+            int batchSize = 25,
+            CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(run);
+
             if (!_localFilesService.AllDirectories.Any())
             {
                 return (false, "No Source Code Folder Selected");
@@ -27,49 +40,151 @@ namespace Sarifintown.Services
 
             try
             {
+                var processedInBatch = 0;
+
                 foreach (var result in run.Results ?? new List<Result>())
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     if (result.Locations?.Any() != true)
                     {
                         continue;
                     }
 
-                    var fallbackPath = result.Locations[0]?.PhysicalLocation?.ArtifactLocation?.Uri;
-                    var normalizedPath = FileHelper.NormalizePath(string.IsNullOrWhiteSpace(result.FilenamePath) ? fallbackPath : result.FilenamePath);
-
-                    string error;
-                    var (adjustedPath, matchedFolder) = FileHelper.AdjustPathToGrantedFolder(normalizedPath, _localFilesService.AllDirectories, out error);
-                    if (adjustedPath == null || matchedFolder == null)
+                    if (result.IsSnippetLoaded)
                     {
-                        return (false, error);
+                        continue;
                     }
 
-                    if (run.JSDirectoryId == 0)
+                    var (success, errorMessage) = await EnsureCodeSnippetAsync(run, result, cancellationToken);
+                    if (!success)
                     {
-                        run.JSDirectoryId = matchedFolder.Id;
+                        return (false, errorMessage);
                     }
 
-                    result.FilenamePath = adjustedPath;
-
-                    var content = await _fileReader.ReadFileAsync(adjustedPath);
-                    if (string.IsNullOrEmpty(content))
+                    processedInBatch++;
+                    if (processedInBatch >= Math.Max(1, batchSize))
                     {
-                        return (false, $"Unable to read {result.FilenamePath}");
+                        onSnippetAdded?.Invoke();
+                        processedInBatch = 0;
                     }
-
-                    var region = result.Locations[0].PhysicalLocation.Region;
-                    var snippet = SnippetHelper.ExtractCodeSnippet(content, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
-                    result.Locations[0].PhysicalLocation.ExtractedCodeSnippet = snippet;
-
-                    onSnippetAdded?.Invoke();
                 }
+
+                onSnippetAdded?.Invoke();
             }
-            catch (Exception ex)
+            catch (OperationCanceledException)
+            {
+                return (false, "Code snippet loading was canceled.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                return (false, ex.Message);
+            }
+            catch (IOException ex)
+            {
+                return (false, ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 return (false, ex.Message);
             }
 
             return (true, null);
+        }
+
+        /// <summary>
+        /// Ensures a single result snippet is loaded and cached, enabling lazy and deep-link loading.
+        /// </summary>
+        public async Task<(bool Success, string ErrorMessage)> EnsureCodeSnippetAsync(
+            Run run,
+            Result result,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(run);
+            ArgumentNullException.ThrowIfNull(result);
+
+            if (result.Locations?.Any() != true)
+            {
+                return (false, "Finding does not contain a physical location.");
+            }
+
+            if (result.IsSnippetLoaded)
+            {
+                return (true, null);
+            }
+
+            var location = result.Locations[0];
+            var region = location?.PhysicalLocation?.Region;
+            if (region == null)
+            {
+                return (false, "Finding location does not include region information.");
+            }
+
+            var fallbackPath = location?.PhysicalLocation?.ArtifactLocation?.Uri;
+            var normalizedPath = FileHelper.NormalizePath(string.IsNullOrWhiteSpace(result.FilenamePath) ? fallbackPath : result.FilenamePath);
+
+            string error;
+            var (adjustedPath, matchedFolder) = FileHelper.AdjustPathToGrantedFolder(normalizedPath, _localFilesService.AllDirectories, out error);
+            if (adjustedPath == null || matchedFolder == null)
+            {
+                return (false, error);
+            }
+
+            if (run.JSDirectoryId == 0)
+            {
+                run.JSDirectoryId = matchedFolder.Id;
+            }
+
+            result.FilenamePath = adjustedPath;
+
+            if (string.IsNullOrWhiteSpace(result.ResultIdentity))
+            {
+                result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result);
+            }
+
+            var snippetCacheKey = string.IsNullOrWhiteSpace(result.ResultIdentity)
+                ? $"{result.RuleId}|{result.FilenamePath}|{region.StartLine}:{region.StartColumn}-{region.EndLine}:{region.EndColumn}"
+                : result.ResultIdentity;
+
+            if (_snippetCache.TryGetValue(snippetCacheKey, out var cachedSnippet))
+            {
+                location.PhysicalLocation.ExtractedCodeSnippet = cachedSnippet;
+                result.IsSnippetLoaded = true;
+                return (true, null);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_fileContentCache.TryGetValue(adjustedPath, out var content))
+            {
+                content = await _fileReader.ReadFileAsync(adjustedPath);
+                if (string.IsNullOrEmpty(content))
+                {
+                    return (false, $"Unable to read {result.FilenamePath}");
+                }
+
+                _fileContentCache[adjustedPath] = content;
+            }
+
+            var snippet = SnippetHelper.ExtractCodeSnippet(content, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
+            location.PhysicalLocation.ExtractedCodeSnippet = snippet;
+            result.IsSnippetLoaded = snippet != null;
+
+            if (snippet != null)
+            {
+                _snippetCache[snippetCacheKey] = snippet;
+            }
+
+            return (true, null);
+        }
+
+        /// <summary>
+        /// Clears in-memory file and snippet caches.
+        /// </summary>
+        public void ClearCaches()
+        {
+            _fileContentCache.Clear();
+            _snippetCache.Clear();
         }
     }
 }

--- a/Sarifintown/Services/SarifFileService.cs
+++ b/Sarifintown/Services/SarifFileService.cs
@@ -1,4 +1,5 @@
 ﻿using Sarifintown.Models;
+using Sarifintown.Helpers;
 
 namespace Sarifintown.Services
 {
@@ -11,7 +12,12 @@ namespace Sarifintown.Services
         public bool AddSarifFile(SarifFile sarifFile, int jsDirectoryId = 0)
         {
             if (!_sarifFiles.Contains(sarifFile))
-            {       
+            {
+                foreach (var run in sarifFile.SarifLog.Runs ?? Enumerable.Empty<Run>())
+                {
+                    run.JSDirectoryId = jsDirectoryId;
+                }
+
                 AddFilenamePathAndExt(sarifFile.SarifLog);
                 UseRuleDictionary(sarifFile.SarifLog);
                 CalculateLevelStats(sarifFile.SarifLog);
@@ -48,8 +54,8 @@ namespace Sarifintown.Services
         {
             foreach (var run in sarifLog.Runs)
             {
-                var rules = run.Tool.Driver.Rule;
-                var results = run.Results;
+                var rules = run.Tool?.Driver?.Rule ?? new List<Rule>();
+                var results = run.Results ?? new List<Result>();
 
                 for (int i = 0; i < rules.Count; i++)
                 {
@@ -75,15 +81,21 @@ namespace Sarifintown.Services
 
         private void AddFilenamePathAndExt(SarifLog sarifLog)
         {
-            sarifLog.Runs
-                .SelectMany(run => run.Results)
-                .Where(result => result.Locations.Any())
-                .ToList()
-                .ForEach(result =>
+            foreach (var run in sarifLog.Runs ?? Enumerable.Empty<Run>())
+            {
+                foreach (var result in run.Results?.Where(r => r.Locations?.Any() == true) ?? Enumerable.Empty<Result>())
                 {
-                    result.FilenamePath = result.Locations[0].PhysicalLocation.ArtifactLocation.Uri;
+                    result.ParentRun = run;
+
+                    var firstLocation = result.Locations[0]?.PhysicalLocation?.ArtifactLocation;
+                    var resolvedPath = FileHelper.ResolveArtifactPath(firstLocation, run);
+                    result.FilenamePath = string.IsNullOrWhiteSpace(resolvedPath)
+                        ? firstLocation?.Uri
+                        : resolvedPath;
+
                     result.FilenameExt = Path.GetExtension(result.FilenamePath)?.TrimStart('.');
-                });
+                }
+            }
         }
 
         private void CalculateLevelStats(SarifLog sarifLog)
@@ -96,10 +108,10 @@ namespace Sarifintown.Services
                     int noteCount = 0;
 
                     // Dictionary to look up default level for each rule
-                    var ruleDefaultLevels = run.Tool.Driver.Rule
+                    var ruleDefaultLevels = (run.Tool?.Driver?.Rule ?? new List<Rule>())
                         .ToDictionary(rule => rule.Id, rule => rule.DefaultConfiguration?.Level ?? "warning");
 
-                    run.Results.ForEach(result =>
+                    (run.Results ?? new List<Result>()).ForEach(result =>
                     {
                         if (string.IsNullOrEmpty(result.Level))
                         {

--- a/Sarifintown/Services/SarifFileService.cs
+++ b/Sarifintown/Services/SarifFileService.cs
@@ -22,6 +22,7 @@ namespace Sarifintown.Services
                 UseRuleDictionary(sarifFile.SarifLog);
                 CalculateLevelStats(sarifFile.SarifLog);
                 CalculateUniqueRulesInResults(sarifFile.SarifLog);
+                BuildRunIndexes(sarifFile.SarifLog);
 
                 _sarifFiles.Add(sarifFile);
 
@@ -88,14 +89,135 @@ namespace Sarifintown.Services
                     result.ParentRun = run;
 
                     var firstLocation = result.Locations[0]?.PhysicalLocation?.ArtifactLocation;
+                    result.OriginalFilenamePath = firstLocation?.Uri;
+
                     var resolvedPath = FileHelper.ResolveArtifactPath(firstLocation, run);
                     result.FilenamePath = string.IsNullOrWhiteSpace(resolvedPath)
                         ? firstLocation?.Uri
                         : resolvedPath;
 
+                    result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result);
+                    result.IsSnippetLoaded = result.Locations[0]?.PhysicalLocation?.ExtractedCodeSnippet != null;
+
                     result.FilenameExt = Path.GetExtension(result.FilenamePath)?.TrimStart('.');
                 }
             }
+        }
+
+        /// <summary>
+        /// Finds a result by its stable identity across all loaded SARIF runs.
+        /// </summary>
+        public (Run Run, Result Result)? FindResultByIdentity(string resultIdentity)
+        {
+            if (string.IsNullOrWhiteSpace(resultIdentity))
+            {
+                return null;
+            }
+
+            foreach (var run in _sarifFiles.SelectMany(file => file.SarifLog.Runs ?? Enumerable.Empty<Run>()))
+            {
+                var match = (run.Results ?? new List<Result>())
+                    .FirstOrDefault(result => string.Equals(result.ResultIdentity, resultIdentity, StringComparison.Ordinal));
+
+                if (match != null)
+                {
+                    return (run, match);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a set of result identities matching severity and rule filters using precomputed run indexes.
+        /// </summary>
+        public HashSet<string> GetFilteredResultIdentities(Run run, IReadOnlyCollection<string>? selectedSeverity, IEnumerable<RuleWithCount>? selectedRules)
+        {
+            ArgumentNullException.ThrowIfNull(run);
+
+            var filtered = new HashSet<string>(run.AllResultIdentities, StringComparer.Ordinal);
+
+            if (selectedSeverity != null && selectedSeverity.Count > 0)
+            {
+                var allowedBySeverity = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var severity in selectedSeverity)
+                {
+                    if (!string.IsNullOrWhiteSpace(severity) && run.ResultIdentityBySeverity.TryGetValue(severity, out var identities))
+                    {
+                        allowedBySeverity.UnionWith(identities);
+                    }
+                }
+
+                filtered.IntersectWith(allowedBySeverity);
+            }
+
+            if (selectedRules != null)
+            {
+                var selectedRuleIds = selectedRules
+                    .Where(rule => !string.IsNullOrWhiteSpace(rule?.Rule?.Id))
+                    .Select(rule => rule.Rule.Id)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (selectedRuleIds.Count > 0)
+                {
+                    var allowedByRule = new HashSet<string>(StringComparer.Ordinal);
+                    foreach (var ruleId in selectedRuleIds)
+                    {
+                        if (run.ResultIdentityByRuleId.TryGetValue(ruleId, out var identities))
+                        {
+                            allowedByRule.UnionWith(identities);
+                        }
+                    }
+
+                    filtered.IntersectWith(allowedByRule);
+                }
+            }
+
+            return filtered;
+        }
+
+        private static void BuildRunIndexes(SarifLog sarifLog)
+        {
+            foreach (var run in sarifLog.Runs ?? Enumerable.Empty<Run>())
+            {
+                run.ResultIdentityBySeverity = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+                run.ResultIdentityByRuleId = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+                run.AllResultIdentities = new HashSet<string>(StringComparer.Ordinal);
+
+                foreach (var result in run.Results ?? Enumerable.Empty<Result>())
+                {
+                    if (string.IsNullOrWhiteSpace(result.ResultIdentity))
+                    {
+                        result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result);
+                    }
+
+                    if (string.IsNullOrWhiteSpace(result.ResultIdentity))
+                    {
+                        continue;
+                    }
+
+                    run.AllResultIdentities.Add(result.ResultIdentity);
+                    AddToIndex(run.ResultIdentityBySeverity, result.Level, result.ResultIdentity);
+                    AddToIndex(run.ResultIdentityByRuleId, result.RuleId, result.ResultIdentity);
+                }
+            }
+        }
+
+        private static void AddToIndex(Dictionary<string, HashSet<string>> index, string? key, string resultIdentity)
+        {
+            if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(resultIdentity))
+            {
+                return;
+            }
+
+            if (!index.TryGetValue(key, out var set))
+            {
+                set = new HashSet<string>(StringComparer.Ordinal);
+                index[key] = set;
+            }
+
+            set.Add(resultIdentity);
         }
 
         private void CalculateLevelStats(SarifLog sarifLog)

--- a/Sarifintown/Services/SarifTriageSidecarService.cs
+++ b/Sarifintown/Services/SarifTriageSidecarService.cs
@@ -1,0 +1,161 @@
+using Microsoft.JSInterop;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+using System.Text.Json;
+
+namespace Sarifintown.Services
+{
+    public sealed class SarifTriageSidecarService
+    {
+        private const string SidecarRelativePath = ".sarif/suppressions.sidecar.json";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true
+        };
+
+        private readonly IJSRuntime _jsRuntime;
+        private readonly Dictionary<int, SarifTriageSidecar> _sidecarsByDirectoryId = new();
+
+        public SarifTriageSidecarService(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        /// <summary>
+        /// Loads the sidecar suppression file for the selected directory into memory.
+        /// </summary>
+        public async Task PrimeDirectoryAsync(int directoryId, CancellationToken cancellationToken = default)
+        {
+            if (directoryId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(directoryId));
+            }
+
+            await _jsRuntime.InvokeVoidAsync("scriptLoader.ensure", cancellationToken, "/js/fileReader.js");
+            var sidecarJson = await _jsRuntime.InvokeAsync<string>("fileSystemHelpers.readTextFile", cancellationToken, directoryId, SidecarRelativePath);
+
+            if (string.IsNullOrWhiteSpace(sidecarJson))
+            {
+                _sidecarsByDirectoryId[directoryId] = new SarifTriageSidecar();
+                return;
+            }
+
+            var parsed = JsonSerializer.Deserialize<SarifTriageSidecar>(sidecarJson, JsonOptions);
+            _sidecarsByDirectoryId[directoryId] = parsed ?? new SarifTriageSidecar();
+        }
+
+        /// <summary>
+        /// Applies loaded sidecar suppressions to SARIF results by stable identity matching.
+        /// </summary>
+        public void ApplySuppressions(SarifLog sarifLog, int directoryId)
+        {
+            ArgumentNullException.ThrowIfNull(sarifLog);
+
+            if (!_sidecarsByDirectoryId.TryGetValue(directoryId, out var sidecar) || sidecar.Suppressions.Count == 0)
+            {
+                return;
+            }
+
+            var byIdentity = sidecar.Suppressions
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Identity) && entry.Suppression != null)
+                .GroupBy(entry => entry.Identity, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+
+            foreach (var result in (sarifLog.Runs ?? new List<Run>()).SelectMany(run => run.Results ?? Enumerable.Empty<Result>()))
+            {
+                var identity = SarifTriageIdentityHelper.BuildIdentity(result);
+                if (!byIdentity.TryGetValue(identity, out var entries))
+                {
+                    continue;
+                }
+
+                result.Suppressions ??= new List<Suppression>();
+                foreach (var entry in entries)
+                {
+                    if (!result.Suppressions.Any(existing =>
+                        string.Equals(existing.Kind, entry.Suppression.Kind, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(existing.Status, entry.Suppression.Status, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(existing.Justification, entry.Suppression.Justification, StringComparison.Ordinal)))
+                    {
+                        result.Suppressions.Add(entry.Suppression);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds or updates suppression metadata in the sidecar file without changing the original SARIF file.
+        /// </summary>
+        public async Task UpsertSuppressionAsync(
+            int directoryId,
+            Result result,
+            string justification,
+            string status = "accepted",
+            string kind = "external",
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+
+            if (string.IsNullOrWhiteSpace(justification))
+            {
+                throw new ArgumentException("Suppression justification is required.", nameof(justification));
+            }
+
+            if (!_sidecarsByDirectoryId.ContainsKey(directoryId))
+            {
+                await PrimeDirectoryAsync(directoryId, cancellationToken);
+            }
+
+            var sidecar = _sidecarsByDirectoryId[directoryId];
+            var identity = SarifTriageIdentityHelper.BuildIdentity(result);
+
+            var firstLocation = result.Locations?.FirstOrDefault()?.PhysicalLocation;
+            var existingIndex = sidecar.Suppressions.FindIndex(entry => string.Equals(entry.Identity, identity, StringComparison.Ordinal));
+
+            var suppression = new Suppression
+            {
+                Kind = kind,
+                Status = status,
+                Justification = justification,
+                Location = new Suppression.SuppressionLocation
+                {
+                    Uri = result.FilenamePath,
+                    Region = firstLocation?.Region
+                }
+            };
+
+            var updatedEntry = new SarifTriageSuppressionEntry
+            {
+                Identity = identity,
+                RuleId = result.RuleId ?? string.Empty,
+                Path = result.FilenamePath ?? firstLocation?.ArtifactLocation?.Uri ?? string.Empty,
+                StartLine = firstLocation?.Region?.StartLine,
+                UpdatedUtc = DateTime.UtcNow,
+                Suppression = suppression
+            };
+
+            if (existingIndex >= 0)
+            {
+                sidecar.Suppressions[existingIndex] = updatedEntry;
+            }
+            else
+            {
+                sidecar.Suppressions.Add(updatedEntry);
+            }
+
+            result.Suppressions ??= new List<Suppression>();
+            if (!result.Suppressions.Any(existing =>
+                string.Equals(existing.Kind, suppression.Kind, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Status, suppression.Status, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(existing.Justification, suppression.Justification, StringComparison.Ordinal)))
+            {
+                result.Suppressions.Add(suppression);
+            }
+
+            var serialized = JsonSerializer.Serialize(sidecar, JsonOptions);
+            await _jsRuntime.InvokeVoidAsync("fileSystemHelpers.writeTextFile", cancellationToken, directoryId, SidecarRelativePath, serialized);
+        }
+    }
+}

--- a/Sarifintown/wwwroot/js/fileReader.js
+++ b/Sarifintown/wwwroot/js/fileReader.js
@@ -196,6 +196,73 @@ window.fileSystemHelpers = {
         return sarifFiles;
     },
 
+    async readTextFile(directoryId, relativePath) {
+        const directoryHandle = this.directoryHandles[directoryId];
+        if (!directoryHandle)
+            throw new Error('Invalid directory handle.');
+
+        const normalizedPath = (relativePath || '').replace(/\\/g, '/').replace(/^\/+/, '');
+        if (!normalizedPath)
+            throw new Error('relativePath is required.');
+
+        const segments = normalizedPath.split('/');
+        let currentHandle = directoryHandle;
+
+        for (let i = 0; i < segments.length; i++) {
+            const isLastSegment = i === segments.length - 1;
+            const segmentName = segments[i];
+
+            if (isLastSegment) {
+                try {
+                    const fileHandle = await currentHandle.getFileHandle(segmentName, { create: false });
+                    const file = await fileHandle.getFile();
+                    return await file.text();
+                } catch {
+                    return null;
+                }
+            }
+
+            try {
+                currentHandle = await currentHandle.getDirectoryHandle(segmentName, { create: false });
+            } catch {
+                return null;
+            }
+        }
+
+        return null;
+    },
+
+    async writeTextFile(directoryId, relativePath, content) {
+        const directoryHandle = this.directoryHandles[directoryId];
+        if (!directoryHandle)
+            throw new Error('Invalid directory handle.');
+
+        const normalizedPath = (relativePath || '').replace(/\\/g, '/').replace(/^\/+/, '');
+        if (!normalizedPath)
+            throw new Error('relativePath is required.');
+
+        const directoryPermission = await directoryHandle.queryPermission({ mode: 'readwrite' });
+        if (directoryPermission === 'denied') {
+            const requestResult = await directoryHandle.requestPermission({ mode: 'readwrite' });
+            if (requestResult !== 'granted') {
+                throw new Error('Write permission was denied.');
+            }
+        }
+
+        const segments = normalizedPath.split('/');
+        let currentHandle = directoryHandle;
+
+        for (let i = 0; i < segments.length - 1; i++) {
+            currentHandle = await currentHandle.getDirectoryHandle(segments[i], { create: true });
+        }
+
+        const fileName = segments[segments.length - 1];
+        const fileHandle = await currentHandle.getFileHandle(fileName, { create: true });
+        const writable = await fileHandle.createWritable();
+        await writable.write(content ?? '');
+        await writable.close();
+    },
+
     
     async canAccessSubfolder(directoryId, subfolderName) {
         try {


### PR DESCRIPTION
Introduce support for external suppression sidecars and stable result identities. Adds SarifTriageSidecar model, SarifTriageSidecarService (load, apply, upsert suppressions) and SarifTriageIdentityHelper (stable SHA256 identity from fingerprints or fallback). Enhance FileHelper with ResolveArtifactPath and RebaseToWorkspaceRelativePath to resolve URIs, artifact indices and originalUriBaseIds, and a helper to combine base ids. Update SarifLog model to include OriginalUriBaseIds, Artifacts, fingerprints, and Result.ParentRun and index fields. Wire up UI and DI: Home.razor primes/applies sidecars, Program registers the service, and SarifFileService/CodeSnippetService/SarifTools updated to use the new helpers and safer null handling. Add JS fileReader readTextFile/writeTextFile for sidecar I/O and multiple unit tests covering file path resolution, identity building, and sidecar application.