### PR TITLE
Add triage workflow, CLI commands, and tests

### DIFF
--- a/.sarif/sarifintown-prompts/base/core-directive.md
+++ b/.sarif/sarifintown-prompts/base/core-directive.md
@@ -1,0 +1,3 @@
+# Core Directive
+
+<!-- TODO: Add global triage directives for the LLM system prompt. -->

--- a/.sarif/sarifintown-prompts/base/output-format.md
+++ b/.sarif/sarifintown-prompts/base/output-format.md
@@ -1,0 +1,3 @@
+# Output Format
+
+<!-- TODO: Define the required output schema/markdown format for triage responses. -->

--- a/.sarif/sarifintown-prompts/categories/default-sast.md
+++ b/.sarif/sarifintown-prompts/categories/default-sast.md
@@ -1,0 +1,3 @@
+# Default SAST
+
+<!-- TODO: Add fallback SAST analysis guidance for uncategorized rules. -->

--- a/.sarif/sarifintown-prompts/categories/sast-sqli.md
+++ b/.sarif/sarifintown-prompts/categories/sast-sqli.md
@@ -1,0 +1,3 @@
+# SAST SQL Injection
+
+<!-- TODO: Add SQLi-specific analysis guidance and remediation expectations. -->

--- a/.sarif/sarifintown-prompts/categories/sast-xss.md
+++ b/.sarif/sarifintown-prompts/categories/sast-xss.md
@@ -1,0 +1,3 @@
+# SAST XSS
+
+<!-- TODO: Add XSS-specific analysis guidance and remediation expectations. -->

--- a/.sarif/sarifintown-prompts/categories/secret-exposure.md
+++ b/.sarif/sarifintown-prompts/categories/secret-exposure.md
@@ -1,0 +1,3 @@
+# Secret Exposure
+
+<!-- TODO: Add secret/token/key exposure analysis guidance and remediation expectations. -->

--- a/.sarif/sarifintown-prompts/org-overrides/.gitkeep
+++ b/.sarif/sarifintown-prompts/org-overrides/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep org-overrides directory in source control.

--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -48,12 +48,6 @@ sarifintown
 dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 ```
 
-## Option C: run with alternate tool command (if present in your environment)
-
-```bash
-sarifintown-agent
-```
-
 ---
 
 ## Generic MCP stdio configuration (works with most AI IDEs)
@@ -224,7 +218,7 @@ dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 - `transport`: must be `stdio` for this server mode.
 - `command` + `args`: starts the MCP server process.
 - `cwd`: optional but useful for predictable relative paths.
-- `env.PROJECT_ROOT`: **required** for correct SARIF discovery from `.sarif/`.
+- `env.PROJECT_ROOT`: recommended for deterministic `.sarif` discovery in multi-root or custom launch environments.
 - `DOTNET_ENVIRONMENT`: optional; this project does not require it for MCP behavior.
 
 ### Path guidance
@@ -245,6 +239,36 @@ dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 6. Call `LoadAndFilterSarif` using either:
    - full SARIF path, or
    - filename discovered at startup (for example: `scan1.sarif`).
+7. Call `TriageStatus` to confirm triage state aggregation from `.sarif/triage.json`.
+8. Call `TriageList` and `TriageInspect` for finding prioritization and evidence retrieval.
+
+---
+
+## MCP tools currently exposed by `Sarifintown.Engine`
+
+### Discovery and routing
+
+- `ListWorkspaceSarifFiles`
+- `ResolveInteractiveSurface`
+
+### Analysis and extraction
+
+- `LoadAndFilterSarif`
+- `ExtractCodeFlow`
+- `GenerateAnalysisReport`
+
+### Triage workflow
+
+- `TriageStatus`
+- `TriageList`
+- `TriageQuery` (alias of `TriageList`)
+- `TriageInspect`
+- `Triage`
+- `TriageBulk`
+
+Triage decisions are persisted to `<workspace>/.sarif/triage.json`.
+
+Note: Tool responses are JSON serialized from .NET types and therefore use `PascalCase` property names unless otherwise noted.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Sarifintown
 
-Sarifintown is a Blazor WebAssembly solution for analyzing SARIF (Static Analysis Results Interchange Format) files and extracting code snippets from source code. 
+Sarifintown is a Blazor WebAssembly solution for analyzing SARIF (Static Analysis Results Interchange Format) files and extracting code snippets from source code.
 
 MCP server support is available via `Sarifintown.Engine`; see the concise setup guide in [`MCP_SETUP.md`](MCP_SETUP.md).
 
 ## Projects
 
-- **Sarifintown.UI**: Blazor WebAssembly app for SARIF analysis and code snippet extraction.
-- **Sarifintown.Core**: Core library containing models, helpers, and shared logic.
-- **Sarifintown.UI.Tests**: Test project using NUnit, bUnit, and Playwright for automated testing.
+- **Sarifintown.UI**: Blazor WebAssembly app for SARIF analysis, triage, and code snippet extraction.
+- **Sarifintown.Core**: Shared models, helpers, and SARIF processing logic.
+- **Sarifintown.Engine**: MCP server and CLI/TUI entrypoint for agent and terminal workflows.
+- **Sarifintown.Tests**, **Sarifintown.Core.Tests**, **Sarifintown.Engine.Tests**: NUnit test projects.
 
 ## Features
 
@@ -20,6 +21,8 @@ MCP server support is available via `Sarifintown.Engine`; see the concise setup 
 - Extract whole methods with Tree-sitter WASM grammars to improve code flow analysis.
 - Responsive UI built with MudBlazor.
 - Group and filter results by severity, rule and file path.
+- MCP tools for SARIF discovery, filtering, flow extraction, analysis report generation, and triage workflows.
+- Shared triage state persisted in `.sarif/triage.json` for MCP/CLI triage commands.
 
 ## Prerequisites
 
@@ -40,6 +43,18 @@ MCP server support is available via `Sarifintown.Engine`; see the concise setup 
 
 4. **Full Details Analysis**  
    If a SARIF file contains the code flow, you can view code threads and highlights using Tree-sitter grammars.
+
+## MCP triage workflow commands
+
+`Sarifintown.Engine` exposes a shared triage workflow through MCP tools:
+
+- `TriageStatus`
+- `TriageList` (and alias `TriageQuery`)
+- `TriageInspect`
+- `Triage`
+- `TriageBulk`
+
+These commands use loaded SARIF findings and persist decision state to `.sarif/triage.json`.
 
 ## License
 

--- a/Sarifintown.AgentEngine.Tests/PromptAssemblyServiceTests.cs
+++ b/Sarifintown.AgentEngine.Tests/PromptAssemblyServiceTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Microsoft.Extensions.Options;
 
 namespace Sarifintown.AgentEngine.Tests;
 
@@ -22,6 +23,84 @@ public class PromptAssemblyServiceTests
             var prompt = await service.BuildTriagePromptAsync("CA3001", "Possible SQL injection");
 
             Assert.That(prompt.Contains("# sql module", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [Test]
+    public async Task BuildTriagePromptAsync_WhenTemplateStyleCompact_UsesCompactTemplate()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var options = Options.Create(new PromptAssemblyOptions
+            {
+                RootDirectoryPath = promptRoot,
+                TemplateStyle = PromptTemplateStyle.Compact
+            });
+
+            var service = new PromptAssemblyService(options);
+            var prompt = await service.BuildTriagePromptAsync("RULE-2", "message");
+
+            Assert.That(prompt.Contains("Vulnerability Report Template (Compact)", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [Test]
+    public async Task BuildTriagePromptAsync_WhenTemplateStyleVerbose_UsesVerboseTemplate()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var options = Options.Create(new PromptAssemblyOptions
+            {
+                RootDirectoryPath = promptRoot,
+                TemplateStyle = PromptTemplateStyle.Verbose
+            });
+
+            var service = new PromptAssemblyService(options);
+            var prompt = await service.BuildTriagePromptAsync("RULE-3", "message");
+
+            Assert.That(prompt.Contains("Vulnerability Report Template (Verbose)", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [Test]
+    public async Task BuildTriagePromptAsync_IncludesOption2EvidenceRenderingGuidance()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var service = new PromptAssemblyService(promptRoot);
+
+            var prompt = await service.BuildTriagePromptAsync("RULE-1", "message");
+
+            Assert.That(prompt.Contains("### [Metadata]", StringComparison.Ordinal), Is.True);
+            Assert.That(prompt.Contains("### [Description]", StringComparison.Ordinal), Is.True);
+            Assert.That(prompt.Contains("### [Data Flow Evidence]", StringComparison.Ordinal), Is.True);
+            Assert.That(prompt.Contains("Option 2.2 (`line ±3 concatenated blocks`)", StringComparison.Ordinal), Is.True);
+            Assert.That(prompt.Contains("if adjacent steps differ by <= 6 lines", StringComparison.Ordinal), Is.True);
+            Assert.That(prompt.Contains("Option 2.3 (`tree-sitter method extraction`)", StringComparison.Ordinal), Is.True);
         }
         finally
         {

--- a/Sarifintown.AgentEngine.Tests/PromptAssemblyServiceTests.cs
+++ b/Sarifintown.AgentEngine.Tests/PromptAssemblyServiceTests.cs
@@ -1,0 +1,124 @@
+using NUnit.Framework;
+
+namespace Sarifintown.AgentEngine.Tests;
+
+[TestFixture]
+public class PromptAssemblyServiceTests
+{
+    [Test]
+    public async Task BuildTriagePromptAsync_WhenSqlSignalPresent_UsesSqlCategoryModule()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "sast-sqli.md", "# sql module");
+            WriteCategoryFile(promptRoot, "sast-xss.md", "# xss module");
+            WriteCategoryFile(promptRoot, "secret-exposure.md", "# secret module");
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var service = new PromptAssemblyService(promptRoot);
+
+            var prompt = await service.BuildTriagePromptAsync("CA3001", "Possible SQL injection");
+
+            Assert.That(prompt.Contains("# sql module", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [Test]
+    public async Task BuildTriagePromptAsync_WhenRequiredFilesMissing_IncludesMarkdownMissingComments()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            var service = new PromptAssemblyService(promptRoot);
+
+            var prompt = await service.BuildTriagePromptAsync("UnknownRule", "Unknown message");
+
+            Assert.That(prompt.Contains("<!-- missing-prompt-module: base/core-directive.md -->", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [Test]
+    public async Task BuildTriagePromptAsync_WhenOverridesExist_IncludesOverridesHeader()
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var overridesPath = Path.Combine(promptRoot, "org-overrides");
+            Directory.CreateDirectory(overridesPath);
+            File.WriteAllText(Path.Combine(overridesPath, "aaa.md"), "override-a");
+            File.WriteAllText(Path.Combine(overridesPath, "bbb.md"), "override-b");
+
+            var service = new PromptAssemblyService(promptRoot);
+
+            var prompt = await service.BuildTriagePromptAsync("Rule", "message");
+
+            Assert.That(prompt.Contains("### Organizational Policies & Accepted Risks", StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    [TestCase("rule-xss", "", "# xss module")]
+    [TestCase("", "cross site scripting", "# xss module")]
+    [TestCase("", "secret leaked key", "# secret module")]
+    [TestCase("", "generic rule", "# default module")]
+    public async Task BuildTriagePromptAsync_RoutesToExpectedCategory(string ruleId, string message, string expectedCategoryMarker)
+    {
+        var promptRoot = CreatePromptRoot();
+        try
+        {
+            WriteCoreFiles(promptRoot);
+            WriteCategoryFile(promptRoot, "sast-sqli.md", "# sql module");
+            WriteCategoryFile(promptRoot, "sast-xss.md", "# xss module");
+            WriteCategoryFile(promptRoot, "secret-exposure.md", "# secret module");
+            WriteCategoryFile(promptRoot, "default-sast.md", "# default module");
+
+            var service = new PromptAssemblyService(promptRoot);
+
+            var prompt = await service.BuildTriagePromptAsync(ruleId, message);
+
+            Assert.That(prompt.Contains(expectedCategoryMarker, StringComparison.Ordinal), Is.True);
+        }
+        finally
+        {
+            Directory.Delete(promptRoot, true);
+        }
+    }
+
+    private static string CreatePromptRoot()
+    {
+        var promptRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(promptRoot);
+        return promptRoot;
+    }
+
+    private static void WriteCoreFiles(string promptRoot)
+    {
+        var basePath = Path.Combine(promptRoot, "base");
+        Directory.CreateDirectory(basePath);
+        File.WriteAllText(Path.Combine(basePath, "core-directive.md"), "# core");
+        File.WriteAllText(Path.Combine(basePath, "output-format.md"), "# output");
+    }
+
+    private static void WriteCategoryFile(string promptRoot, string fileName, string content)
+    {
+        var categoriesPath = Path.Combine(promptRoot, "categories");
+        Directory.CreateDirectory(categoriesPath);
+        File.WriteAllText(Path.Combine(categoriesPath, fileName), content);
+    }
+}

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -99,7 +99,7 @@ namespace Sarifintown.AgentEngine.Tests
             {
                 var findingsJson = await SarifTools.TriageList(limit: 5);
                 var findings = JsonSerializer.Deserialize<List<JsonElement>>(findingsJson);
-                var findingId = findings![0].GetProperty("findingId").GetString();
+                var findingId = findings![0].GetProperty("FindingId").GetString();
 
                 var triagePath = Path.Combine(sarifDirectory, "triage.json");
                 File.WriteAllText(triagePath, JsonSerializer.Serialize(new
@@ -121,9 +121,9 @@ namespace Sarifintown.AgentEngine.Tests
                 var responseJson = await SarifTools.TriageStatus();
                 var payload = JsonSerializer.Deserialize<JsonElement>(responseJson);
 
-                Assert.That(payload.GetProperty("totalFindings").GetInt32(), Is.EqualTo(2));
-                Assert.That(payload.GetProperty("triagedCount").GetInt32(), Is.EqualTo(1));
-                Assert.That(payload.GetProperty("openCount").GetInt32(), Is.EqualTo(1));
+                Assert.That(payload.GetProperty("TotalFindings").GetInt32(), Is.EqualTo(2));
+                Assert.That(payload.GetProperty("TriagedCount").GetInt32(), Is.EqualTo(1));
+                Assert.That(payload.GetProperty("OpenCount").GetInt32(), Is.EqualTo(1));
             }
             finally
             {
@@ -198,7 +198,7 @@ namespace Sarifintown.AgentEngine.Tests
 
                 Assert.That(payload, Is.Not.Null);
                 Assert.That(payload!.Count, Is.EqualTo(1));
-                Assert.That(payload[0].GetProperty("ruleName").GetString(), Is.EqualTo("SQLInjection"));
+                Assert.That(payload[0].GetProperty("RuleName").GetString(), Is.EqualTo("SQLInjection"));
             }
             finally
             {
@@ -258,19 +258,19 @@ namespace Sarifintown.AgentEngine.Tests
             {
                 var listJson = await SarifTools.TriageList(limit: 1);
                 var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("findingId").GetString();
+                var findingId = listPayload![0].GetProperty("FindingId").GetString();
 
                 var triageJson = await SarifTools.Triage(findingId!, "TP", "validated", "User");
                 var triagePayload = JsonSerializer.Deserialize<JsonElement>(triageJson);
-                Assert.That(triagePayload.GetProperty("success").GetBoolean(), Is.True);
+                Assert.That(triagePayload.GetProperty("Success").GetBoolean(), Is.True);
 
                 var triageFileJson = File.ReadAllText(Path.Combine(sarifDirectory, "triage.json"));
                 Assert.That(triageFileJson, Does.Contain("validated"));
 
                 var dryRunJson = await SarifTools.TriageBulk("FP", "noise", severity: "Medium", dryRun: true);
                 var dryRunPayload = JsonSerializer.Deserialize<JsonElement>(dryRunJson);
-                Assert.That(dryRunPayload.GetProperty("dryRun").GetBoolean(), Is.True);
-                Assert.That(dryRunPayload.GetProperty("affectedCount").GetInt32(), Is.EqualTo(1));
+                Assert.That(dryRunPayload.GetProperty("DryRun").GetBoolean(), Is.True);
+                Assert.That(dryRunPayload.GetProperty("AffectedCount").GetInt32(), Is.EqualTo(1));
             }
             finally
             {

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Sarifintown.AgentEngine;
 using Sarifintown.Core;
+using System.Linq;
 using System.Text.Json;
 
 namespace Sarifintown.AgentEngine.Tests
@@ -10,7 +11,7 @@ namespace Sarifintown.AgentEngine.Tests
     {
         private class FakeFileReader : IFileReader
         {
-            public Dictionary<string, string> Files { get; } = new();
+            public Dictionary<string, string> Files { get; } = new(StringComparer.OrdinalIgnoreCase);
 
             public Task<string> ReadFileAsync(string relativePath)
             {
@@ -18,12 +19,152 @@ namespace Sarifintown.AgentEngine.Tests
                 {
                     return Task.FromResult(content);
                 }
+
                 // Fallback to actual file read if not in dictionary
                 if (File.Exists(relativePath))
                 {
                     return File.ReadAllTextAsync(relativePath);
                 }
                 throw new FileNotFoundException($"File not found: {relativePath}");
+            }
+        }
+
+        [Test]
+        public async Task TriageInspect_WithLineWindowConcatenated_MergesNearbySteps()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            var sourceDirectory = Path.Combine(workspace, "src");
+            Directory.CreateDirectory(sarifDirectory);
+            Directory.CreateDirectory(sourceDirectory);
+
+            var sourcePath = Path.Combine(sourceDirectory, "Flow.cs");
+            File.WriteAllText(sourcePath, string.Join("\n", Enumerable.Range(1, 40).Select(index => $"line {index}")));
+
+            var sarifPath = Path.Combine(sarifDirectory, "inspect.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-FLOW",
+                      "message": { "text": "flow" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Flow.cs" },
+                            "region": { "startLine": 10 }
+                          }
+                        }
+                      ],
+                      "codeFlows": [
+                        {
+                          "threadFlows": [
+                            {
+                              "locations": [
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 10 } } } },
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 14 } } } },
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 30 } } } }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 1);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingId = listPayload![0].GetProperty("FindingId").GetString();
+
+                var inspectJson = await SarifTools.TriageInspect(findingId!, "line-window-concatenated");
+                var inspectPayload = JsonSerializer.Deserialize<JsonElement>(inspectJson);
+
+                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceMode").GetString(), Is.EqualTo("line-window-concatenated"));
+                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceBlocks").GetArrayLength(), Is.EqualTo(2));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task TriageInspect_WithLineWindowStrict_UsesPerStepBlocks()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            var sourceDirectory = Path.Combine(workspace, "src");
+            Directory.CreateDirectory(sarifDirectory);
+            Directory.CreateDirectory(sourceDirectory);
+
+            var sourcePath = Path.Combine(sourceDirectory, "Strict.cs");
+            File.WriteAllText(sourcePath, string.Join("\n", Enumerable.Range(1, 20).Select(index => $"line {index}")));
+
+            var sarifPath = Path.Combine(sarifDirectory, "strict-inspect.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-STRICT",
+                      "message": { "text": "flow" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Strict.cs" },
+                            "region": { "startLine": 4 }
+                          }
+                        }
+                      ],
+                      "codeFlows": [
+                        {
+                          "threadFlows": [
+                            {
+                              "locations": [
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Strict.cs" }, "region": { "startLine": 4 } } } },
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Strict.cs" }, "region": { "startLine": 9 } } } }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 1);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingId = listPayload![0].GetProperty("FindingId").GetString();
+
+                var inspectJson = await SarifTools.TriageInspect(findingId!, "line-window-strict");
+                var inspectPayload = JsonSerializer.Deserialize<JsonElement>(inspectJson);
+
+                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceMode").GetString(), Is.EqualTo("line-window-strict"));
+                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceBlocks").GetArrayLength(), Is.EqualTo(2));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
             }
         }
 

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -44,6 +44,238 @@ namespace Sarifintown.AgentEngine.Tests
             SarifTools.TreeSitterEngine = new FakeTreeSitterEngine();
             SarifTools.SetDiscoveredSarifFiles(Array.Empty<string>());
             SarifTools.SetLocalUiBaseUrl(string.Empty);
+            SarifTools.SetWorkspaceRoot(Directory.GetCurrentDirectory());
+        }
+
+        [Test]
+        public async Task TriageStatus_WithTriageState_ReturnsAggregatedCounts()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "status.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-HIGH",
+                      "level": "error",
+                      "message": { "text": "High issue" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/one.cs" },
+                            "region": { "startLine": 10 }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "ruleId": "RULE-MED",
+                      "level": "warning",
+                      "message": { "text": "Medium issue" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/two.cs" },
+                            "region": { "startLine": 20 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var findingsJson = await SarifTools.TriageList(limit: 5);
+                var findings = JsonSerializer.Deserialize<List<JsonElement>>(findingsJson);
+                var findingId = findings![0].GetProperty("findingId").GetString();
+
+                var triagePath = Path.Combine(sarifDirectory, "triage.json");
+                File.WriteAllText(triagePath, JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    entries = new[]
+                    {
+                        new
+                        {
+                            findingId,
+                            state = "FP",
+                            reason = "known noise",
+                            author = "AI",
+                            updatedUtc = "2025-01-01T00:00:00Z"
+                        }
+                    }
+                }));
+
+                var responseJson = await SarifTools.TriageStatus();
+                var payload = JsonSerializer.Deserialize<JsonElement>(responseJson);
+
+                Assert.That(payload.GetProperty("totalFindings").GetInt32(), Is.EqualTo(2));
+                Assert.That(payload.GetProperty("triagedCount").GetInt32(), Is.EqualTo(1));
+                Assert.That(payload.GetProperty("openCount").GetInt32(), Is.EqualTo(1));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task TriageList_WithFilters_ReturnsPrioritizedItems()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "list.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "SQLInjection",
+                      "level": "error",
+                      "message": { "text": "Critical path" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/UserController.cs" },
+                            "region": { "startLine": 15 }
+                          }
+                        }
+                      ],
+                      "codeFlows": [
+                        {
+                          "threadFlows": [
+                            {
+                              "locations": [
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/UserController.cs" }, "region": { "startLine": 15 } } } },
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/UserController.cs" }, "region": { "startLine": 32 } } } }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "ruleId": "CA1031",
+                      "level": "warning",
+                      "message": { "text": "Lower priority" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "tests/Ignore.cs" },
+                            "region": { "startLine": 8 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var responseJson = await SarifTools.TriageList(severity: "High", file: "*UserController.cs", limit: 5);
+                var payload = JsonSerializer.Deserialize<List<JsonElement>>(responseJson);
+
+                Assert.That(payload, Is.Not.Null);
+                Assert.That(payload!.Count, Is.EqualTo(1));
+                Assert.That(payload[0].GetProperty("ruleName").GetString(), Is.EqualTo("SQLInjection"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task Triage_And_TriageBulkDryRun_UpdateAndPreviewState()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "triage.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-ONE",
+                      "level": "error",
+                      "message": { "text": "One" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/a.cs" },
+                            "region": { "startLine": 7 }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "ruleId": "RULE-TWO",
+                      "level": "warning",
+                      "message": { "text": "Two" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/b.cs" },
+                            "region": { "startLine": 9 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 1);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingId = listPayload![0].GetProperty("findingId").GetString();
+
+                var triageJson = await SarifTools.Triage(findingId!, "TP", "validated", "User");
+                var triagePayload = JsonSerializer.Deserialize<JsonElement>(triageJson);
+                Assert.That(triagePayload.GetProperty("success").GetBoolean(), Is.True);
+
+                var triageFileJson = File.ReadAllText(Path.Combine(sarifDirectory, "triage.json"));
+                Assert.That(triageFileJson, Does.Contain("validated"));
+
+                var dryRunJson = await SarifTools.TriageBulk("FP", "noise", severity: "Medium", dryRun: true);
+                var dryRunPayload = JsonSerializer.Deserialize<JsonElement>(dryRunJson);
+                Assert.That(dryRunPayload.GetProperty("dryRun").GetBoolean(), Is.True);
+                Assert.That(dryRunPayload.GetProperty("affectedCount").GetInt32(), Is.EqualTo(1));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
         }
 
         [Test]

--- a/Sarifintown.AgentEngine.Tests/V8TreeSitterEngineTests.cs
+++ b/Sarifintown.AgentEngine.Tests/V8TreeSitterEngineTests.cs
@@ -22,7 +22,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task ExtractMethodAsync_WithValidCSharpCode_ReturnsAstString()
+        public async Task ExtractMethodAsync_WithValidCSharpCode_ReturnsMethodBody()
         {
             // Arrange
             var sourceCode = @"
@@ -33,19 +33,19 @@ namespace Sarifintown.AgentEngine.Tests
                     int x = 1;
                 }
             }";
-            var language = "c_sharp"; // Note: the wasm file is tree-sitter-c_sharp.wasm
+            var language = "csharp";
 
             // Act
-            var result = await _engine.ExtractMethodAsync(sourceCode, language, 0, 0);
+            var result = await _engine.ExtractMethodAsync(sourceCode, language, 2, 4);
 
             // Assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result, Contains.Substring("class_declaration"));
-            Assert.That(result, Contains.Substring("method_declaration"));
+            Assert.That(result, Contains.Substring("public void TestMethod()"));
+            Assert.That(result, Contains.Substring("int x = 1;"));
         }
 
         [Test]
-        public async Task ExtractMethodAsync_WithValidJavascriptCode_ReturnsAstString()
+        public async Task ExtractMethodAsync_WithValidJavascriptCode_ReturnsFunctionBody()
         {
             // Arrange
             var sourceCode = @"
@@ -55,11 +55,21 @@ namespace Sarifintown.AgentEngine.Tests
             var language = "javascript";
 
             // Act
-            var result = await _engine.ExtractMethodAsync(sourceCode, language, 0, 0);
+            var result = await _engine.ExtractMethodAsync(sourceCode, language, 1, 1);
 
             // Assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result, Contains.Substring("function_declaration"));
+            Assert.That(result, Contains.Substring("function testMethod()"));
+        }
+
+        [Test]
+        public async Task ExtractMethodAsync_WithUnknownLanguage_ReturnsEmptyForFallback()
+        {
+            var sourceCode = "line1\nline2";
+
+            var result = await _engine.ExtractMethodAsync(sourceCode, "unknownlang", 0, 0);
+
+            Assert.That(result, Is.EqualTo(string.Empty));
         }
     }
 }

--- a/Sarifintown.AgentEngine/IPromptAssemblyService.cs
+++ b/Sarifintown.AgentEngine/IPromptAssemblyService.cs
@@ -1,0 +1,9 @@
+namespace Sarifintown.AgentEngine;
+
+public interface IPromptAssemblyService
+{
+    /// <summary>
+    /// Builds a triage-ready LLM system prompt from modular markdown templates and finding context.
+    /// </summary>
+    Task<string> BuildTriagePromptAsync(string ruleId, string message, CancellationToken cancellationToken = default);
+}

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -33,6 +33,7 @@ SarifTools.FileReader = app.Services.GetRequiredService<IFileReader>();
 SarifTools.TreeSitterEngine = treeSitter;
 SarifTools.SetDiscoveredSarifFiles(discovery.SarifFiles);
 SarifTools.SetLocalUiBaseUrl(string.Empty);
+SarifTools.SetWorkspaceRoot(discovery.WorkspaceRoot);
 
 await app.StartAsync();
 

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -12,6 +12,7 @@ var discovery = WorkspaceSarifDiscovery.Discover();
 // Register Headless Implementations
 builder.Services.AddSingleton<IFileReader>(new NativeFileReader(discovery.WorkspaceRoot));
 builder.Services.AddSingleton<ITreeSitterEngine, V8TreeSitterEngine>();
+builder.Services.AddSingleton<IPromptAssemblyService, PromptAssemblyService>();
 
 // Register MCP Server (if using the prerelease SDK)
 builder.Services.AddMcpServer()

--- a/Sarifintown.AgentEngine/PromptAssemblyOptions.cs
+++ b/Sarifintown.AgentEngine/PromptAssemblyOptions.cs
@@ -1,0 +1,8 @@
+namespace Sarifintown.AgentEngine;
+
+public sealed class PromptAssemblyOptions
+{
+    public const string SectionName = "PromptAssembly";
+
+    public string? RootDirectoryPath { get; init; }
+}

--- a/Sarifintown.AgentEngine/PromptAssemblyOptions.cs
+++ b/Sarifintown.AgentEngine/PromptAssemblyOptions.cs
@@ -1,8 +1,17 @@
 namespace Sarifintown.AgentEngine;
 
+public enum PromptTemplateStyle
+{
+    Structured = 0,
+    Compact = 1,
+    Verbose = 2
+}
+
 public sealed class PromptAssemblyOptions
 {
     public const string SectionName = "PromptAssembly";
 
     public string? RootDirectoryPath { get; init; }
+
+    public PromptTemplateStyle TemplateStyle { get; init; } = PromptTemplateStyle.Structured;
 }

--- a/Sarifintown.AgentEngine/PromptAssemblyService.cs
+++ b/Sarifintown.AgentEngine/PromptAssemblyService.cs
@@ -1,0 +1,201 @@
+using Microsoft.Extensions.Options;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Sarifintown.AgentEngine;
+
+public sealed class PromptAssemblyService : IPromptAssemblyService
+{
+    private const string PromptsRootRelativePath = ".sarif/sarifintown-prompts";
+    private const string BaseDirectoryName = "base";
+    private const string CategoriesDirectoryName = "categories";
+    private const string OverridesDirectoryName = "org-overrides";
+
+    private const string CoreDirectiveFileName = "core-directive.md";
+    private const string OutputFormatFileName = "output-format.md";
+    private const string SqlCategoryFileName = "sast-sqli.md";
+    private const string XssCategoryFileName = "sast-xss.md";
+    private const string SecretCategoryFileName = "secret-exposure.md";
+    private const string DefaultCategoryFileName = "default-sast.md";
+
+    private readonly string _promptRootDirectory;
+
+    public PromptAssemblyService(string? rootDirectoryPath = null)
+    {
+        _promptRootDirectory = ResolveRootDirectory(rootDirectoryPath);
+    }
+
+    public PromptAssemblyService(IOptions<PromptAssemblyOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _promptRootDirectory = ResolveRootDirectory(options.Value.RootDirectoryPath);
+    }
+
+    /// <summary>
+    /// Builds a triage-ready LLM system prompt from modular markdown templates and finding context.
+    /// </summary>
+    public async Task<string> BuildTriagePromptAsync(string ruleId, string message, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var resolvedRuleId = ruleId?.Trim() ?? string.Empty;
+        var resolvedMessage = message?.Trim() ?? string.Empty;
+
+        var coreDirectivePath = Path.Combine(_promptRootDirectory, BaseDirectoryName, CoreDirectiveFileName);
+        var categoryModulePath = Path.Combine(
+            _promptRootDirectory,
+            CategoriesDirectoryName,
+            DetermineCategoryModule(resolvedRuleId, resolvedMessage));
+        var outputFormatPath = Path.Combine(_promptRootDirectory, BaseDirectoryName, OutputFormatFileName);
+
+        var sections = new List<string>
+        {
+            await ReadModuleOrMissingCommentAsync(coreDirectivePath, cancellationToken).ConfigureAwait(false),
+            await ReadModuleOrMissingCommentAsync(categoryModulePath, cancellationToken).ConfigureAwait(false),
+            BuildFindingContextSection(resolvedRuleId, resolvedMessage)
+        };
+
+        var overrideSection = await BuildOverrideSectionAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(overrideSection))
+        {
+            sections.Add(overrideSection);
+        }
+
+        sections.Add(await ReadModuleOrMissingCommentAsync(outputFormatPath, cancellationToken).ConfigureAwait(false));
+
+        return string.Join(Environment.NewLine, sections.Where(section => !string.IsNullOrWhiteSpace(section)));
+    }
+
+    private async Task<string> BuildOverrideSectionAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var overridesDirectoryPath = Path.Combine(_promptRootDirectory, OverridesDirectoryName);
+        if (!Directory.Exists(overridesDirectoryPath))
+        {
+            return string.Empty;
+        }
+
+        var overrideFiles = Directory
+            .EnumerateFiles(overridesDirectoryPath, "*.md", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (overrideFiles.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("### Organizational Policies & Accepted Risks");
+
+        for (var index = 0; index < overrideFiles.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var content = await ReadModuleOrMissingCommentAsync(overrideFiles[index], cancellationToken).ConfigureAwait(false);
+            builder.AppendLine(content);
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string BuildFindingContextSection(string ruleId, string message)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("### Finding Context");
+        builder.AppendLine($"- rule-id: `{(string.IsNullOrWhiteSpace(ruleId) ? "unknown" : ruleId)}`");
+        builder.AppendLine("- source: `sarif-finding`");
+        builder.AppendLine();
+        builder.AppendLine("#### Finding Message");
+        builder.AppendLine(string.IsNullOrWhiteSpace(message) ? "- n/a" : message);
+        builder.AppendLine();
+        builder.AppendLine("#### Evidence Template");
+        builder.AppendLine("- file: `<relative-file-path>`");
+        builder.AppendLine("- location: `<start-line[:start-column]-end-line[:end-column]>`");
+        builder.AppendLine("- language: `<programming-language>`");
+        builder.AppendLine("- data-flow: `source -> propagation -> sink` (markdown bullet list)");
+        builder.AppendLine();
+        builder.AppendLine("```text");
+        builder.AppendLine("<code-snippet-from-sarif-or-source>");
+        builder.AppendLine("```");
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string DetermineCategoryModule(string ruleId, string message)
+    {
+        var normalized = NormalizeForMatching($"{ruleId} {message}");
+
+        if (normalized.Contains("sqli", StringComparison.Ordinal) || normalized.Contains("sql", StringComparison.Ordinal))
+        {
+            return SqlCategoryFileName;
+        }
+
+        if (normalized.Contains("xss", StringComparison.Ordinal) || normalized.Contains("crosssitescripting", StringComparison.Ordinal))
+        {
+            return XssCategoryFileName;
+        }
+
+        if (normalized.Contains("secret", StringComparison.Ordinal)
+            || normalized.Contains("token", StringComparison.Ordinal)
+            || normalized.Contains("key", StringComparison.Ordinal))
+        {
+            return SecretCategoryFileName;
+        }
+
+        return DefaultCategoryFileName;
+    }
+
+    private async Task<string> ReadModuleOrMissingCommentAsync(string modulePath, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!File.Exists(modulePath))
+        {
+            return CreateMissingFileComment(modulePath);
+        }
+
+        try
+        {
+            return await File.ReadAllTextAsync(modulePath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (IOException)
+        {
+            return CreateMissingFileComment(modulePath);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return CreateMissingFileComment(modulePath);
+        }
+    }
+
+    private static string ResolveRootDirectory(string? configuredRootDirectoryPath)
+    {
+        var workspaceRoot = WorkspaceSarifDiscovery.Discover().WorkspaceRoot;
+        if (string.IsNullOrWhiteSpace(configuredRootDirectoryPath))
+        {
+            return Path.GetFullPath(Path.Combine(workspaceRoot, PromptsRootRelativePath));
+        }
+
+        return Path.IsPathRooted(configuredRootDirectoryPath)
+            ? Path.GetFullPath(configuredRootDirectoryPath)
+            : Path.GetFullPath(Path.Combine(workspaceRoot, configuredRootDirectoryPath));
+    }
+
+    private string CreateMissingFileComment(string path)
+    {
+        var relativePath = Path.GetRelativePath(_promptRootDirectory, path).Replace('\\', '/');
+        return $"<!-- missing-prompt-module: {relativePath} -->";
+    }
+
+    private static string NormalizeForMatching(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return string.Empty;
+        }
+
+        var lowered = input.ToLowerInvariant();
+        return Regex.Replace(lowered, "[^a-z0-9]", string.Empty, RegexOptions.CultureInvariant);
+    }
+}

--- a/Sarifintown.AgentEngine/PromptAssemblyService.cs
+++ b/Sarifintown.AgentEngine/PromptAssemblyService.cs
@@ -19,16 +19,19 @@ public sealed class PromptAssemblyService : IPromptAssemblyService
     private const string DefaultCategoryFileName = "default-sast.md";
 
     private readonly string _promptRootDirectory;
+    private readonly PromptTemplateStyle _templateStyle;
 
     public PromptAssemblyService(string? rootDirectoryPath = null)
     {
         _promptRootDirectory = ResolveRootDirectory(rootDirectoryPath);
+        _templateStyle = PromptTemplateStyle.Structured;
     }
 
     public PromptAssemblyService(IOptions<PromptAssemblyOptions> options)
     {
         ArgumentNullException.ThrowIfNull(options);
         _promptRootDirectory = ResolveRootDirectory(options.Value.RootDirectoryPath);
+        _templateStyle = options.Value.TemplateStyle;
     }
 
     /// <summary>
@@ -52,7 +55,7 @@ public sealed class PromptAssemblyService : IPromptAssemblyService
         {
             await ReadModuleOrMissingCommentAsync(coreDirectivePath, cancellationToken).ConfigureAwait(false),
             await ReadModuleOrMissingCommentAsync(categoryModulePath, cancellationToken).ConfigureAwait(false),
-            BuildFindingContextSection(resolvedRuleId, resolvedMessage)
+            BuildFindingContextSection(resolvedRuleId, resolvedMessage, _templateStyle)
         };
 
         var overrideSection = await BuildOverrideSectionAsync(cancellationToken).ConfigureAwait(false);
@@ -99,28 +102,107 @@ public sealed class PromptAssemblyService : IPromptAssemblyService
         return builder.ToString().TrimEnd();
     }
 
-    private static string BuildFindingContextSection(string ruleId, string message)
+    private static string BuildFindingContextSection(string ruleId, string message, PromptTemplateStyle templateStyle)
     {
-        var builder = new StringBuilder();
-        builder.AppendLine("### Finding Context");
-        builder.AppendLine($"- rule-id: `{(string.IsNullOrWhiteSpace(ruleId) ? "unknown" : ruleId)}`");
-        builder.AppendLine("- source: `sarif-finding`");
-        builder.AppendLine();
-        builder.AppendLine("#### Finding Message");
-        builder.AppendLine(string.IsNullOrWhiteSpace(message) ? "- n/a" : message);
-        builder.AppendLine();
-        builder.AppendLine("#### Evidence Template");
-        builder.AppendLine("- file: `<relative-file-path>`");
-        builder.AppendLine("- location: `<start-line[:start-column]-end-line[:end-column]>`");
-        builder.AppendLine("- language: `<programming-language>`");
-        builder.AppendLine("- data-flow: `source -> propagation -> sink` (markdown bullet list)");
-        builder.AppendLine();
-        builder.AppendLine("```text");
-        builder.AppendLine("<code-snippet-from-sarif-or-source>");
-        builder.AppendLine("```");
+        var resolvedRule = string.IsNullOrWhiteSpace(ruleId) ? "unknown" : ruleId;
+        var resolvedMessage = string.IsNullOrWhiteSpace(message) ? "- n/a" : message;
 
-        return builder.ToString().TrimEnd();
+        var template = templateStyle switch
+        {
+            PromptTemplateStyle.Compact => CompactFindingContextTemplate,
+            PromptTemplateStyle.Verbose => VerboseFindingContextTemplate,
+            _ => StructuredFindingContextTemplate
+        };
+
+        return template
+            .Replace("{{RULE_ID}}", resolvedRule, StringComparison.Ordinal)
+            .Replace("{{MESSAGE}}", resolvedMessage, StringComparison.Ordinal)
+            .TrimEnd();
     }
+
+    private const string StructuredFindingContextTemplate = """
+### Finding Context
+- rule-id: `{{RULE_ID}}`
+- source: `sarif-finding`
+
+#### Finding Message
+{{MESSAGE}}
+
+#### Vulnerability Report Template
+Keep `[Metadata]` and `[Description]` consistent across all extraction strategies. Change only `[Data Flow Evidence]` rendering.
+
+```markdown
+# Vulnerability Report
+
+### [Metadata]
+* **Rule ID:** `<rule-id>`
+* **Category:** `<security-category>`
+* **Primary File:** `<relative-file-path>`
+* **Sink Node:** `<sink-api-or-call>`
+
+### [Description]
+<clear summary of why untrusted input reaches a dangerous sink>
+
+### [Data Flow Evidence]
+**[Step 1: Source]** `<file-path:line>`
+```csharp
+<source snippet>
+```
+**[Step 2: Propagator]** `<file-path:line>`
+```csharp
+<propagation snippet(s)>
+```
+**[Step N: Sink]** `<file-path:line>`
+```csharp
+<sink snippet>
+```
+```
+
+#### Data Flow Rendering Rules
+- Option 2.1 (`line ±3 strict separation`): output one step header plus one code block per step.
+- Option 2.2 (`line ±3 concatenated blocks`): group by `file_path`, sort by `line_number`, and if adjacent steps differ by <= 6 lines emit sequential step headers followed by one shared code block.
+- Option 2.3 (`tree-sitter method extraction`): if steps resolve to the same method node, emit sequential step headers followed by one shared full-method code block.
+- Use `Source`, `Propagator`, and `Sink` labels in each step header.
+""";
+
+    private const string CompactFindingContextTemplate = """
+### Finding Context
+- rule-id: `{{RULE_ID}}`
+- source: `sarif-finding`
+
+#### Finding Message
+{{MESSAGE}}
+
+#### Vulnerability Report Template (Compact)
+Use sections in this order: `[Metadata]`, `[Description]`, `[Data Flow Evidence]`.
+
+#### Data Flow Rendering Rules
+- Option 2.1: one code block per step (`line ±3`).
+- Option 2.2: same file + line distance <= 6 => one shared code block.
+- Option 2.3: same tree-sitter method => one shared full-method code block.
+""";
+
+    private const string VerboseFindingContextTemplate = """
+### Finding Context
+- rule-id: `{{RULE_ID}}`
+- source: `sarif-finding`
+
+#### Finding Message
+{{MESSAGE}}
+
+#### Vulnerability Report Template (Verbose)
+Always render `# Vulnerability Report`.
+Always keep `### [Metadata]` and `### [Description]` unchanged across extraction modes.
+Only alter `### [Data Flow Evidence]` according to the selected extraction strategy.
+
+#### Data Flow Rendering Rules
+1. Group steps by `file_path`.
+2. Sort steps by `line_number`.
+3. Option 2.1 (`line ±3 strict separation`): emit one step header + one code block for each step.
+4. Option 2.2 (`line ±3 concatenated blocks`): if `Step[N+1].Line_Number - Step[N].Line_Number <= 6`, emit sequential step headers then one code block.
+5. Option 2.3 (`tree-sitter method extraction`): if steps are inside the same method AST node, emit sequential step headers then one shared method block.
+6. Use labels `Source`, `Propagator`, `Sink` for each step header.
+""";
 
     private static string DetermineCategoryModule(string ruleId, string message)
     {

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -17,6 +17,7 @@ namespace Sarifintown.AgentEngine
         private static readonly object SyncRoot = new();
         private static List<string> _discoveredSarifFiles = new();
         private static string _localUiBaseUrl = string.Empty;
+        private static string _workspaceRoot = Directory.GetCurrentDirectory();
         private static readonly string[] IdeHostTokens =
         [
             "vscode",
@@ -97,6 +98,19 @@ namespace Sarifintown.AgentEngine
             }
         }
 
+        public static void SetWorkspaceRoot(string workspaceRoot)
+        {
+            if (string.IsNullOrWhiteSpace(workspaceRoot))
+            {
+                throw new ArgumentException("Workspace root is required.", nameof(workspaceRoot));
+            }
+
+            lock (SyncRoot)
+            {
+                _workspaceRoot = Path.GetFullPath(workspaceRoot);
+            }
+        }
+
         [McpServerTool]
         [Description("Returns all SARIF files discovered in the current workspace .sarif folder at server startup.")]
         public static string ListWorkspaceSarifFiles()
@@ -114,6 +128,95 @@ namespace Sarifintown.AgentEngine
             });
 
             return JsonSerializer.Serialize(payload);
+        }
+
+        [McpServerTool]
+        [Description("Provides a 10,000-foot security posture summary from loaded SARIF findings and local .sarif/triage.json state.")]
+        public static async Task<string> TriageStatus()
+        {
+            var workflow = CreateTriageWorkflowService();
+            var status = await workflow.GetStatusAsync();
+            return JsonSerializer.Serialize(status);
+        }
+
+        [McpServerTool]
+        [Description("Returns prioritized findings with optional filters: severity, rule, file, state, and limit.")]
+        public static async Task<string> TriageList(
+            string severity = "",
+            string rule = "",
+            string file = "",
+            string state = "",
+            int limit = 10)
+        {
+            var workflow = CreateTriageWorkflowService();
+            var findings = await workflow.ListAsync(new TriageQueryOptions(severity, rule, file, state, limit));
+            return JsonSerializer.Serialize(findings);
+        }
+
+        [McpServerTool]
+        [Description("Alias of TriageList for query-oriented clients.")]
+        public static Task<string> TriageQuery(
+            string severity = "",
+            string rule = "",
+            string file = "",
+            string state = "",
+            int limit = 10)
+        {
+            return TriageList(severity, rule, file, state, limit);
+        }
+
+        [McpServerTool]
+        [Description("Returns dense technical evidence for a single finding including ordered data flow steps and method snippets.")]
+        public static async Task<string> TriageInspect(string findingId)
+        {
+            var workflow = CreateTriageWorkflowService();
+            var inspect = await workflow.InspectAsync(findingId);
+
+            if (inspect == null)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    message = $"Finding not found: {findingId}"
+                });
+            }
+
+            return JsonSerializer.Serialize(inspect);
+        }
+
+        [McpServerTool]
+        [Description("Records a TP/FP triage decision for one finding in .sarif/triage.json.")]
+        public static async Task<string> Triage(
+            string findingId,
+            string state,
+            string reason,
+            string author = "AI")
+        {
+            var workflow = CreateTriageWorkflowService();
+            var result = await workflow.TriageAsync(findingId, state, reason, author);
+            return JsonSerializer.Serialize(result);
+        }
+
+        [McpServerTool]
+        [Description("Applies TP/FP triage to multiple findings using list filters. At least one of severity/rule/file is required.")]
+        public static async Task<string> TriageBulk(
+            string state,
+            string reason,
+            string severity = "",
+            string rule = "",
+            string file = "",
+            bool dryRun = false,
+            string author = "AI")
+        {
+            var workflow = CreateTriageWorkflowService();
+            var result = await workflow.TriageBulkAsync(
+                state,
+                reason,
+                new TriageQueryOptions(severity, rule, file, string.Empty, int.MaxValue),
+                dryRun,
+                author);
+
+            return JsonSerializer.Serialize(result);
         }
 
         [McpServerTool]
@@ -151,9 +254,17 @@ namespace Sarifintown.AgentEngine
             }
 
             string selectedAction = string.Empty;
+            string commandResult = string.Empty;
             if (startCliMenu)
             {
                 selectedAction = SpectreCliMenu.Start();
+                if (selectedAction.StartsWith("Triage ", StringComparison.Ordinal))
+                {
+                    commandResult = SpectreCliMenu
+                        .ExecuteTriageActionAsync(CreateTriageWorkflowService(), selectedAction)
+                        .GetAwaiter()
+                        .GetResult();
+                }
             }
 
             return JsonSerializer.Serialize(new
@@ -167,6 +278,7 @@ namespace Sarifintown.AgentEngine
                 {
                     library = "Spectre.Console",
                     action = selectedAction,
+                    action_result = commandResult,
                     menu = "interactive"
                 }
             });
@@ -379,6 +491,25 @@ namespace Sarifintown.AgentEngine
             }
 
             return sarifPath;
+        }
+
+        private static TriageWorkflowService CreateTriageWorkflowService()
+        {
+            if (FileReader == null || TreeSitterEngine == null)
+            {
+                throw new InvalidOperationException("Core engines are not initialized.");
+            }
+
+            List<string> discoveredFiles;
+            string workspaceRoot;
+
+            lock (SyncRoot)
+            {
+                discoveredFiles = _discoveredSarifFiles.ToList();
+                workspaceRoot = _workspaceRoot;
+            }
+
+            return new TriageWorkflowService(FileReader, TreeSitterEngine, workspaceRoot, discoveredFiles);
         }
 
         private static string DetectHost(McpServer thisServer, string hostHint)

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -167,10 +167,10 @@ namespace Sarifintown.AgentEngine
 
         [McpServerTool]
         [Description("Returns dense technical evidence for a single finding including ordered data flow steps and method snippets.")]
-        public static async Task<string> TriageInspect(string findingId)
+        public static async Task<string> TriageInspect(string findingId, string evidenceMode = "")
         {
             var workflow = CreateTriageWorkflowService();
-            var inspect = await workflow.InspectAsync(findingId);
+            var inspect = await workflow.InspectAsync(findingId, evidenceMode);
 
             if (inspect == null)
             {
@@ -384,32 +384,55 @@ namespace Sarifintown.AgentEngine
                         if (string.IsNullOrEmpty(relativePath)) continue;
 
                         var resolvedPath = FileHelper.ResolveArtifactPath(physLoc.ArtifactLocation, targetRun);
-                        var fullPath = Path.IsPathRooted(resolvedPath)
-                            ? resolvedPath
-                            : Path.Combine(sourceCodeRoot, (resolvedPath ?? relativePath).Replace("file://", "").TrimStart('/'));
+                        var candidatePath = string.IsNullOrWhiteSpace(resolvedPath) ? relativePath : resolvedPath;
+                        var fullPath = Path.IsPathRooted(candidatePath)
+                            ? candidatePath
+                            : Path.Combine(sourceCodeRoot, candidatePath.Replace("file://", "").TrimStart('/'));
+
+                        if (!File.Exists(fullPath))
+                        {
+                            var fallbackByFileName = Path.Combine(sourceCodeRoot, Path.GetFileName(candidatePath));
+                            if (File.Exists(fallbackByFileName))
+                            {
+                                fullPath = fallbackByFileName;
+                            }
+                        }
 
                         string snippetCode = "Source file unavailable";
 
-                        if (File.Exists(fullPath))
+                        string? sourceCode = null;
+                        try
                         {
-                            var sourceCode = await FileReader.ReadFileAsync(fullPath);
-
-                            // Leverage TreeSitter for accurate code parsing
+                            sourceCode = await FileReader.ReadFileAsync(fullPath);
+                        }
+                        catch (IOException)
+                        {
+                            sourceCode = null;
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            sourceCode = null;
+                        }
+                        if (!string.IsNullOrWhiteSpace(sourceCode))
+                        {
                             var language = GetLanguageFromExtension(Path.GetExtension(fullPath));
 
-                            int startLine = (physLoc.Region?.StartLine ?? 1) - 1;
-                            int endLine = (physLoc.Region?.EndLine ?? startLine + 1) - 1;
+                            var windowStartLine = physLoc.Region?.StartLine ?? 1;
+                            var windowEndLine = physLoc.Region?.EndLine > 0
+                                ? physLoc.Region.EndLine
+                                : windowStartLine;
 
-                            snippetCode = await TreeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine);
-
-                            if (string.IsNullOrEmpty(snippetCode))
+                            if (!string.IsNullOrWhiteSpace(language))
                             {
-                                // Basic snippet extraction (expandable with TreeSitter nodes)
-                                var lines = sourceCode.Split('\n');
-                                startLine = Math.Max(0, startLine);
-                                endLine = Math.Min(lines.Length - 1, endLine);
+                                var startLine = Math.Max(0, windowStartLine - 1);
+                                var endLine = Math.Max(startLine, windowEndLine - 1);
+                                snippetCode = await TreeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine);
+                            }
 
-                                snippetCode = string.Join("\n", lines.Skip(startLine).Take(endLine - startLine + 1));
+                            if (string.IsNullOrWhiteSpace(snippetCode)
+                                || snippetCode.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
+                            {
+                                snippetCode = SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
                             }
                         }
 
@@ -460,7 +483,7 @@ namespace Sarifintown.AgentEngine
                 ".sh" => "bash",
                 ".ps1" => "powershell",
                 ".sql" => "sql",
-                _ => "csharp" // default
+            _ => string.Empty
             };
         }
 

--- a/Sarifintown.AgentEngine/SpectreCliMenu.cs
+++ b/Sarifintown.AgentEngine/SpectreCliMenu.cs
@@ -1,9 +1,24 @@
 using Spectre.Console;
+using System.Text.Json;
 
 namespace Sarifintown.AgentEngine;
 
 internal static class SpectreCliMenu
 {
+    private static readonly string[] Actions =
+    [
+        "Triage status",
+        "Triage list",
+        "Triage inspect",
+        "Triage decision",
+        "Triage bulk",
+        "List SARIF files",
+        "Load and filter SARIF",
+        "Extract code flow",
+        "Generate analysis report",
+        "Exit"
+    ];
+
     public static string Start()
     {
         try
@@ -12,14 +27,7 @@ internal static class SpectreCliMenu
                 new SelectionPrompt<string>()
                     .Title("[green]Sarifintown CLI Menu[/]")
                     .PageSize(10)
-                    .AddChoices(
-                    [
-                        "List SARIF files",
-                        "Load and filter SARIF",
-                        "Extract code flow",
-                        "Generate analysis report",
-                        "Exit"
-                    ]));
+                    .AddChoices(Actions));
 
             return action;
         }
@@ -27,5 +35,132 @@ internal static class SpectreCliMenu
         {
             return "non-interactive-terminal";
         }
+    }
+
+    public static async Task<string> ExecuteTriageActionAsync(
+        TriageWorkflowService workflow,
+        string action,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(workflow);
+
+        return action switch
+        {
+            "Triage status" => await RenderStatusAsync(workflow, cancellationToken),
+            "Triage list" => await RenderListAsync(workflow, cancellationToken),
+            "Triage inspect" => await RenderInspectAsync(workflow, cancellationToken),
+            "Triage decision" => await RenderTriageAsync(workflow, cancellationToken),
+            "Triage bulk" => await RenderTriageBulkAsync(workflow, cancellationToken),
+            _ => JsonSerializer.Serialize(new { success = false, message = $"Unsupported action: {action}" })
+        };
+    }
+
+    private static async Task<string> RenderStatusAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    {
+        var status = await workflow.GetStatusAsync(cancellationToken);
+
+        AnsiConsole.MarkupLine($"[green]Total findings:[/] {status.TotalFindings}");
+        AnsiConsole.MarkupLine($"[yellow]Open:[/] {status.OpenCount}  [blue]Triaged:[/] {status.TriagedCount}  [green]TP:[/] {status.TruePositiveCount}  [red]FP:[/] {status.FalsePositiveCount}");
+
+        return JsonSerializer.Serialize(status);
+    }
+
+    private static async Task<string> RenderListAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    {
+        var severity = AnsiConsole.Ask<string>("Severity filter (optional, CSV):", string.Empty);
+        var rule = AnsiConsole.Ask<string>("Rule filter (optional, CSV):", string.Empty);
+        var file = AnsiConsole.Ask<string>("File filter (optional, wildcard supported):", string.Empty);
+        var state = AnsiConsole.Ask<string>("State filter (optional: Open/TP/FP):", string.Empty);
+        var limit = AnsiConsole.Ask<int>("Limit:", 10);
+
+        var results = await workflow.ListAsync(new TriageQueryOptions(severity, rule, file, state, limit), cancellationToken);
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("FindingId");
+        table.AddColumn("Rule");
+        table.AddColumn("File");
+        table.AddColumn("Line");
+        table.AddColumn("Severity");
+        table.AddColumn("State");
+        table.AddColumn("TPS");
+
+        foreach (var item in results)
+        {
+            table.AddRow(
+                item.FindingId,
+                item.RuleName,
+                item.FilePath,
+                item.LineNumber?.ToString() ?? "",
+                item.Severity,
+                item.State,
+                item.PriorityScore.ToString("0.##"));
+        }
+
+        AnsiConsole.Write(table);
+        return JsonSerializer.Serialize(results);
+    }
+
+    private static async Task<string> RenderInspectAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    {
+        var findingId = AnsiConsole.Ask<string>("Finding ID:");
+        var result = await workflow.InspectAsync(findingId, cancellationToken);
+
+        if (result == null)
+        {
+            var errorPayload = new { success = false, message = $"Finding not found: {findingId}" };
+            AnsiConsole.MarkupLine($"[red]{errorPayload.message}[/]");
+            return JsonSerializer.Serialize(errorPayload);
+        }
+
+        AnsiConsole.MarkupLine($"[green]Rule:[/] {result.RuleId} ({result.RuleName})");
+        AnsiConsole.MarkupLine($"[green]Severity:[/] {result.Severity}  [green]State:[/] {result.State}");
+        AnsiConsole.MarkupLine($"[green]Flow steps:[/] {result.DataFlowSteps.Count}");
+
+        return JsonSerializer.Serialize(result);
+    }
+
+    private static async Task<string> RenderTriageAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    {
+        var findingId = AnsiConsole.Ask<string>("Finding ID:");
+        var state = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Triage state")
+                .AddChoices("TP", "FP"));
+        var reason = AnsiConsole.Ask<string>("Reason:");
+        var author = AnsiConsole.Ask<string>("Author:", "User");
+
+        var result = await workflow.TriageAsync(findingId, state, reason, author, cancellationToken);
+        AnsiConsole.MarkupLine(result.Success
+            ? $"[green]{result.Message}[/]"
+            : $"[red]{result.Message}[/]");
+
+        return JsonSerializer.Serialize(result);
+    }
+
+    private static async Task<string> RenderTriageBulkAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    {
+        var state = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Triage state")
+                .AddChoices("TP", "FP"));
+        var reason = AnsiConsole.Ask<string>("Reason:");
+        var severity = AnsiConsole.Ask<string>("Severity filter (optional, CSV):", string.Empty);
+        var rule = AnsiConsole.Ask<string>("Rule filter (optional, CSV):", string.Empty);
+        var file = AnsiConsole.Ask<string>("File filter (optional, wildcard supported):", string.Empty);
+        var dryRun = AnsiConsole.Confirm("Dry run only?", true);
+        var author = AnsiConsole.Ask<string>("Author:", "User");
+
+        var result = await workflow.TriageBulkAsync(
+            state,
+            reason,
+            new TriageQueryOptions(severity, rule, file, string.Empty, int.MaxValue),
+            dryRun,
+            author,
+            cancellationToken);
+
+        AnsiConsole.MarkupLine(result.Success
+            ? $"[green]{result.Message}[/]"
+            : $"[red]{result.Message}[/]");
+
+        return JsonSerializer.Serialize(result);
     }
 }

--- a/Sarifintown.AgentEngine/TriageWorkflowModels.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowModels.cs
@@ -7,6 +7,13 @@ internal enum TriageFindingState
     FP = 2
 }
 
+internal enum TriageEvidenceMode
+{
+    TreeSitterMethod = 0,
+    LineWindowStrict = 1,
+    LineWindowConcatenated = 2
+}
+
 internal sealed record TriageQueryOptions(
     string Severity = "",
     string Rule = "",
@@ -39,6 +46,16 @@ internal sealed record TriageInspectStep(
     string Message,
     string CodeSnippet);
 
+internal sealed record TriageEvidenceBlock(
+    int StartStepIndex,
+    int EndStepIndex,
+    string FilePath,
+    int? StartLine,
+    int? EndLine,
+    string Mode,
+    IReadOnlyList<int> StepIndexes,
+    string CodeSnippet);
+
 internal sealed record TriageInspectResult(
     string FindingId,
     string RuleId,
@@ -48,7 +65,9 @@ internal sealed record TriageInspectResult(
     string Message,
     string RuleDescription,
     string Remediation,
-    IReadOnlyList<TriageInspectStep> DataFlowSteps);
+    IReadOnlyList<TriageInspectStep> DataFlowSteps,
+    string DataFlowEvidenceMode,
+    IReadOnlyList<TriageEvidenceBlock> DataFlowEvidenceBlocks);
 
 internal sealed record TriageOperationResult(
     bool Success,

--- a/Sarifintown.AgentEngine/TriageWorkflowModels.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowModels.cs
@@ -1,0 +1,82 @@
+namespace Sarifintown.AgentEngine;
+
+internal enum TriageFindingState
+{
+    Open = 0,
+    TP = 1,
+    FP = 2
+}
+
+internal sealed record TriageQueryOptions(
+    string Severity = "",
+    string Rule = "",
+    string File = "",
+    string State = "",
+    int Limit = 10);
+
+internal sealed record TriageStatusResult(
+    int TotalFindings,
+    IReadOnlyDictionary<string, int> SeverityCounts,
+    IReadOnlyDictionary<string, int> RuleCounts,
+    int OpenCount,
+    int TriagedCount,
+    int TruePositiveCount,
+    int FalsePositiveCount);
+
+internal sealed record TriageListItem(
+    string FindingId,
+    string RuleName,
+    string FilePath,
+    int? LineNumber,
+    string Severity,
+    double PriorityScore,
+    string State);
+
+internal sealed record TriageInspectStep(
+    int Index,
+    string FilePath,
+    int? StartLine,
+    string Message,
+    string CodeSnippet);
+
+internal sealed record TriageInspectResult(
+    string FindingId,
+    string RuleId,
+    string RuleName,
+    string Severity,
+    string State,
+    string Message,
+    string RuleDescription,
+    string Remediation,
+    IReadOnlyList<TriageInspectStep> DataFlowSteps);
+
+internal sealed record TriageOperationResult(
+    bool Success,
+    string Message,
+    string FindingId,
+    string State,
+    string Reason,
+    string Author,
+    DateTime UpdatedUtc);
+
+internal sealed record TriageBulkResult(
+    bool Success,
+    string Message,
+    int AffectedCount,
+    IReadOnlyList<string> ModifiedFindingIds,
+    bool DryRun);
+
+internal sealed record TriageStateDocument
+{
+    public int SchemaVersion { get; init; } = 1;
+    public List<TriageStateEntry> Entries { get; init; } = new();
+}
+
+internal sealed record TriageStateEntry
+{
+    public string FindingId { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public string Reason { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public DateTime UpdatedUtc { get; init; } = DateTime.UtcNow;
+}

--- a/Sarifintown.AgentEngine/TriageWorkflowService.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowService.cs
@@ -1,0 +1,912 @@
+using Sarifintown.Core;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Text.Json;
+
+namespace Sarifintown.AgentEngine;
+
+internal sealed class TriageWorkflowService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly IFileReader _fileReader;
+    private readonly ITreeSitterEngine _treeSitterEngine;
+    private readonly string _workspaceRoot;
+    private readonly IReadOnlyList<string> _sarifFiles;
+
+    public TriageWorkflowService(
+        IFileReader fileReader,
+        ITreeSitterEngine treeSitterEngine,
+        string workspaceRoot,
+        IEnumerable<string> sarifFiles)
+    {
+        ArgumentNullException.ThrowIfNull(fileReader);
+        ArgumentNullException.ThrowIfNull(treeSitterEngine);
+        ArgumentNullException.ThrowIfNull(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(sarifFiles);
+
+        _fileReader = fileReader;
+        _treeSitterEngine = treeSitterEngine;
+        _workspaceRoot = workspaceRoot;
+        _sarifFiles = sarifFiles
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<TriageStatusResult> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var findings = await LoadFindingsAsync(cancellationToken);
+
+        var severityCounts = findings
+            .GroupBy(finding => finding.Severity, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+        EnsureSeverityBuckets(severityCounts);
+
+        var ruleCounts = findings
+            .GroupBy(finding => finding.RuleCategory, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+        var truePositiveCount = findings.Count(finding => finding.State == TriageFindingState.TP);
+        var falsePositiveCount = findings.Count(finding => finding.State == TriageFindingState.FP);
+        var triagedCount = truePositiveCount + falsePositiveCount;
+        var openCount = findings.Count - triagedCount;
+
+        return new TriageStatusResult(
+            findings.Count,
+            severityCounts,
+            ruleCounts,
+            openCount,
+            triagedCount,
+            truePositiveCount,
+            falsePositiveCount);
+    }
+
+    public async Task<IReadOnlyList<TriageListItem>> ListAsync(TriageQueryOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var findings = await LoadFindingsAsync(cancellationToken);
+        var filtered = ApplyFilters(findings, options);
+
+        var ordered = filtered
+            .OrderByDescending(finding => finding.PriorityScore)
+            .ThenBy(finding => finding.FindingId, StringComparer.Ordinal)
+            .Take(options.Limit <= 0 ? 10 : options.Limit)
+            .Select(finding => new TriageListItem(
+                finding.FindingId,
+                finding.RuleName,
+                finding.FilePath,
+                finding.LineNumber,
+                finding.Severity,
+                finding.PriorityScore,
+                finding.State.ToString()))
+            .ToList();
+
+        return ordered;
+    }
+
+    public async Task<TriageInspectResult?> InspectAsync(string findingId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(findingId))
+        {
+            throw new ArgumentException("Finding identifier is required.", nameof(findingId));
+        }
+
+        var findings = await LoadFindingsAsync(cancellationToken);
+        var finding = findings.FirstOrDefault(item => string.Equals(item.FindingId, findingId, StringComparison.Ordinal));
+
+        if (finding == null)
+        {
+            return null;
+        }
+
+        var steps = new List<TriageInspectStep>();
+        var flowLocations = finding.Result.CodeFlows?
+            .SelectMany(flow => flow.ThreadFlows ?? new List<ThreadFlow>())
+            .SelectMany(threadFlow => threadFlow.Locations ?? new List<ThreadFlowLocation>())
+            .ToList() ?? new List<ThreadFlowLocation>();
+
+        for (var index = 0; index < flowLocations.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var flowLocation = flowLocations[index];
+            var physicalLocation = flowLocation.Location?.PhysicalLocation;
+            if (physicalLocation == null)
+            {
+                continue;
+            }
+
+            var resolvedPath = ResolveFindingPath(finding, physicalLocation.ArtifactLocation);
+            var snippet = await ExtractSnippetAsync(resolvedPath, physicalLocation.Region, cancellationToken);
+
+            steps.Add(new TriageInspectStep(
+                index + 1,
+                physicalLocation.ArtifactLocation?.Uri ?? string.Empty,
+                physicalLocation.Region?.StartLine,
+                flowLocation.Location?.Message?.Text ?? string.Empty,
+                snippet));
+        }
+
+        return new TriageInspectResult(
+            finding.FindingId,
+            finding.Result.RuleId ?? string.Empty,
+            finding.RuleName,
+            finding.Severity,
+            finding.State.ToString(),
+            finding.Result.Message?.Text ?? string.Empty,
+            finding.RuleDescription,
+            finding.Remediation,
+            steps);
+    }
+
+    public async Task<TriageOperationResult> TriageAsync(
+        string findingId,
+        string state,
+        string reason,
+        string author,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(findingId))
+        {
+            throw new ArgumentException("Finding identifier is required.", nameof(findingId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Triage reason is required.", nameof(reason));
+        }
+
+        if (string.IsNullOrWhiteSpace(author))
+        {
+            throw new ArgumentException("Triage author is required.", nameof(author));
+        }
+
+        if (!TryParseDecisionState(state, out var parsedState))
+        {
+            throw new ArgumentException("State must be TP or FP.", nameof(state));
+        }
+
+        var findings = await LoadFindingsAsync(cancellationToken);
+        var findingExists = findings.Any(item => string.Equals(item.FindingId, findingId, StringComparison.Ordinal));
+
+        if (!findingExists)
+        {
+            return new TriageOperationResult(
+                false,
+                $"Finding not found: {findingId}",
+                findingId,
+                parsedState.ToString(),
+                reason,
+                author,
+                DateTime.UtcNow);
+        }
+
+        var document = await LoadTriageStateDocumentAsync(cancellationToken);
+        var now = DateTime.UtcNow;
+        var existingIndex = document.Entries.FindIndex(entry =>
+            string.Equals(entry.FindingId, findingId, StringComparison.Ordinal));
+
+        var entry = new TriageStateEntry
+        {
+            FindingId = findingId,
+            State = parsedState.ToString(),
+            Reason = reason,
+            Author = author,
+            UpdatedUtc = now
+        };
+
+        if (existingIndex >= 0)
+        {
+            document.Entries[existingIndex] = entry;
+        }
+        else
+        {
+            document.Entries.Add(entry);
+        }
+
+        await SaveTriageStateDocumentAsync(document, cancellationToken);
+
+        return new TriageOperationResult(
+            true,
+            "Triage decision saved.",
+            findingId,
+            parsedState.ToString(),
+            reason,
+            author,
+            now);
+    }
+
+    public async Task<TriageBulkResult> TriageBulkAsync(
+        string state,
+        string reason,
+        TriageQueryOptions options,
+        bool dryRun,
+        string author,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Triage reason is required.", nameof(reason));
+        }
+
+        if (string.IsNullOrWhiteSpace(author))
+        {
+            throw new ArgumentException("Triage author is required.", nameof(author));
+        }
+
+        if (!TryParseDecisionState(state, out var parsedState))
+        {
+            throw new ArgumentException("State must be TP or FP.", nameof(state));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Severity)
+            && string.IsNullOrWhiteSpace(options.Rule)
+            && string.IsNullOrWhiteSpace(options.File))
+        {
+            return new TriageBulkResult(
+                false,
+                "At least one filter is required for bulk triage.",
+                0,
+                Array.Empty<string>(),
+                dryRun);
+        }
+
+        var findings = await LoadFindingsAsync(cancellationToken);
+        var filtered = ApplyFilters(findings, options)
+            .Select(finding => finding.FindingId)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (dryRun)
+        {
+            return new TriageBulkResult(
+                true,
+                $"Dry run complete. {filtered.Count} findings would be triaged.",
+                filtered.Count,
+                filtered,
+                true);
+        }
+
+        var document = await LoadTriageStateDocumentAsync(cancellationToken);
+        var now = DateTime.UtcNow;
+
+        foreach (var findingId in filtered)
+        {
+            var entry = new TriageStateEntry
+            {
+                FindingId = findingId,
+                State = parsedState.ToString(),
+                Reason = reason,
+                Author = author,
+                UpdatedUtc = now
+            };
+
+            var existingIndex = document.Entries.FindIndex(existing =>
+                string.Equals(existing.FindingId, findingId, StringComparison.Ordinal));
+
+            if (existingIndex >= 0)
+            {
+                document.Entries[existingIndex] = entry;
+            }
+            else
+            {
+                document.Entries.Add(entry);
+            }
+        }
+
+        await SaveTriageStateDocumentAsync(document, cancellationToken);
+
+        return new TriageBulkResult(
+            true,
+            $"Bulk triage updated {filtered.Count} findings.",
+            filtered.Count,
+            filtered,
+            false);
+    }
+
+    private async Task<List<TriageFindingEnvelope>> LoadFindingsAsync(CancellationToken cancellationToken)
+    {
+        var triageState = await LoadTriageStateDocumentAsync(cancellationToken);
+        var triageMap = triageState.Entries
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.FindingId))
+            .GroupBy(entry => entry.FindingId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.OrderByDescending(item => item.UpdatedUtc).First(), StringComparer.Ordinal);
+
+        var findings = new List<TriageFindingEnvelope>();
+
+        foreach (var sarifFile in _sarifFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(sarifFile))
+            {
+                continue;
+            }
+
+            var content = await _fileReader.ReadFileAsync(sarifFile);
+            var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, JsonOptions);
+            if (sarifLog?.Runs == null)
+            {
+                continue;
+            }
+
+            foreach (var run in sarifLog.Runs)
+            {
+                var rules = (run.Tool?.Driver?.Rule ?? new List<Rule>())
+                    .Where(rule => !string.IsNullOrWhiteSpace(rule.Id))
+                    .GroupBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+                foreach (var result in run.Results ?? new List<Result>())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (string.IsNullOrWhiteSpace(result.ResultIdentity))
+                    {
+                        result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result);
+                    }
+
+                    var findingId = result.ResultIdentity;
+                    if (string.IsNullOrWhiteSpace(findingId))
+                    {
+                        continue;
+                    }
+
+                    var rule = ResolveRule(rules, run, result);
+                    var severity = ResolveSeverity(result, rule);
+                    var state = ResolveState(triageMap, findingId);
+                    var filePath = ResolveResultFilePath(run, result);
+                    var lineNumber = result.Locations?.FirstOrDefault()?.PhysicalLocation?.Region?.StartLine;
+                    var priority = CalculatePriorityScore(severity, result);
+                    var ruleName = !string.IsNullOrWhiteSpace(rule?.Name)
+                        ? rule!.Name
+                        : result.RuleId ?? "UnknownRule";
+                    var ruleCategory = ResolveRuleCategory(rule, result);
+                    var ruleDescription = rule?.ShortDescription?.Text ?? string.Empty;
+                    var remediation = ResolveRemediation(rule, result);
+
+                    findings.Add(new TriageFindingEnvelope(
+                        findingId,
+                        result,
+                        run,
+                        sarifFile,
+                        severity,
+                        state,
+                        ruleName,
+                        filePath,
+                        lineNumber,
+                        priority,
+                        ruleCategory,
+                        ruleDescription,
+                        remediation));
+                }
+            }
+        }
+
+        return findings;
+    }
+
+    private static IEnumerable<TriageFindingEnvelope> ApplyFilters(IEnumerable<TriageFindingEnvelope> findings, TriageQueryOptions options)
+    {
+        var filtered = findings;
+
+        if (!string.IsNullOrWhiteSpace(options.Severity))
+        {
+            var severities = SplitCsv(options.Severity)
+                .Select(NormalizeSeverity)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            filtered = filtered.Where(finding => severities.Contains(finding.Severity));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Rule))
+        {
+            var ruleFilters = SplitCsv(options.Rule).ToArray();
+            filtered = filtered.Where(finding => ruleFilters.Any(rule =>
+                string.Equals(finding.Result.RuleId, rule, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(finding.RuleName, rule, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.File))
+        {
+            var fileFilters = SplitCsv(options.File).ToArray();
+            filtered = filtered.Where(finding => fileFilters.Any(filter => MatchesFileFilter(finding.FilePath, filter)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.State)
+            && Enum.TryParse<TriageFindingState>(options.State, true, out var requiredState))
+        {
+            filtered = filtered.Where(finding => finding.State == requiredState);
+        }
+
+        return filtered;
+    }
+
+    private static bool MatchesFileFilter(string filePath, string filter)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || string.IsNullOrWhiteSpace(filter))
+        {
+            return false;
+        }
+
+        var normalizedPath = filePath.Replace('\\', '/');
+        var normalizedFilter = filter.Replace('\\', '/');
+
+        if (normalizedFilter.Contains('*') || normalizedFilter.Contains('?'))
+        {
+            var pattern = "^" + Regex.Escape(normalizedFilter)
+                .Replace("\\*", ".*")
+                .Replace("\\?", ".") + "$";
+
+            return Regex.IsMatch(normalizedPath, pattern, RegexOptions.IgnoreCase)
+                || Regex.IsMatch(Path.GetFileName(normalizedPath), pattern, RegexOptions.IgnoreCase);
+        }
+
+        return normalizedPath.Contains(normalizedFilter, StringComparison.OrdinalIgnoreCase)
+            || Path.GetFileName(normalizedPath).Contains(normalizedFilter, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> SplitCsv(string value)
+    {
+        return value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(item => !string.IsNullOrWhiteSpace(item));
+    }
+
+    private static Rule? ResolveRule(
+        IReadOnlyDictionary<string, Rule> rules,
+        Run run,
+        Result result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.RuleId)
+            && rules.TryGetValue(result.RuleId, out var byRuleId))
+        {
+            return byRuleId;
+        }
+
+        if (result.RuleIndex >= 0
+            && run.Tool?.Driver?.Rule != null
+            && result.RuleIndex < run.Tool.Driver.Rule.Count)
+        {
+            return run.Tool.Driver.Rule[result.RuleIndex];
+        }
+
+        return result.Rule;
+    }
+
+    private static string ResolveSeverity(Result result, Rule? rule)
+    {
+        if (TryResolveSecuritySeverity(result.Properties, out var fromResultProperties))
+        {
+            return fromResultProperties;
+        }
+
+        if (TryResolveSecuritySeverity(rule?.Properties, out var fromRuleProperties))
+        {
+            return fromRuleProperties;
+        }
+
+        var level = result.Level;
+        if (string.IsNullOrWhiteSpace(level))
+        {
+            level = rule?.DefaultConfiguration?.Level;
+        }
+
+        return NormalizeSeverity(level);
+    }
+
+    private static bool TryResolveSecuritySeverity(Dictionary<string, object>? properties, out string severity)
+    {
+        severity = string.Empty;
+
+        if (properties == null || properties.Count == 0)
+        {
+            return false;
+        }
+
+        if (!properties.TryGetValue("security-severity", out var rawValue) || rawValue == null)
+        {
+            return false;
+        }
+
+        if (!TryConvertToDouble(rawValue, out var score))
+        {
+            return false;
+        }
+
+        severity = score switch
+        {
+            >= 9.0 => "Critical",
+            >= 7.0 => "High",
+            >= 4.0 => "Medium",
+            _ => "Low"
+        };
+
+        return true;
+    }
+
+    private static bool TryResolveSecuritySeverity(Dictionary<string, JsonElement>? properties, out string severity)
+    {
+        severity = string.Empty;
+
+        if (properties == null || properties.Count == 0)
+        {
+            return false;
+        }
+
+        if (!properties.TryGetValue("security-severity", out var rawValue))
+        {
+            return false;
+        }
+
+        if (!TryConvertToDouble(rawValue, out var score))
+        {
+            return false;
+        }
+
+        severity = score switch
+        {
+            >= 9.0 => "Critical",
+            >= 7.0 => "High",
+            >= 4.0 => "Medium",
+            _ => "Low"
+        };
+
+        return true;
+    }
+
+    private static bool TryConvertToDouble(object value, out double parsed)
+    {
+        parsed = 0;
+
+        return value switch
+        {
+            double doubleValue => (parsed = doubleValue) >= 0,
+            float floatValue => (parsed = floatValue) >= 0,
+            decimal decimalValue => (parsed = (double)decimalValue) >= 0,
+            int intValue => (parsed = intValue) >= 0,
+            long longValue => (parsed = longValue) >= 0,
+            JsonElement element => TryConvertToDouble(element, out parsed),
+            string text => double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
+            _ => false
+        };
+    }
+
+    private static bool TryConvertToDouble(JsonElement element, out double parsed)
+    {
+        parsed = 0;
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetDouble(out parsed),
+            JsonValueKind.String => double.TryParse(element.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
+            _ => false
+        };
+    }
+
+    private static string NormalizeSeverity(string? rawSeverity)
+    {
+        if (string.IsNullOrWhiteSpace(rawSeverity))
+        {
+            return "Medium";
+        }
+
+        var normalized = rawSeverity.Trim().ToLowerInvariant();
+
+        return normalized switch
+        {
+            "critical" => "Critical",
+            "error" => "High",
+            "high" => "High",
+            "warning" => "Medium",
+            "medium" => "Medium",
+            "note" => "Low",
+            "low" => "Low",
+            _ => "Medium"
+        };
+    }
+
+    private static string ResolveRuleCategory(Rule? rule, Result result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.RuleId))
+        {
+            return result.RuleId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(rule?.Id))
+        {
+            return rule.Id;
+        }
+
+        return "UnknownRule";
+    }
+
+    private static string ResolveRemediation(Rule? rule, Result result)
+    {
+        if (TryResolvePropertyText(result.Properties, "remediation", out var remediationFromResult))
+        {
+            return remediationFromResult;
+        }
+
+        if (TryResolvePropertyText(rule?.Properties, "help", out var remediationFromRuleHelp))
+        {
+            return remediationFromRuleHelp;
+        }
+
+        if (TryResolvePropertyText(rule?.Properties, "recommendation", out var recommendationFromRule))
+        {
+            return recommendationFromRule;
+        }
+
+        return string.Empty;
+    }
+
+    private static bool TryResolvePropertyText(Dictionary<string, object>? properties, string key, out string text)
+    {
+        text = string.Empty;
+
+        if (properties == null || !properties.TryGetValue(key, out var rawValue) || rawValue == null)
+        {
+            return false;
+        }
+
+        text = rawValue switch
+        {
+            JsonElement element when element.ValueKind == JsonValueKind.String => element.GetString() ?? string.Empty,
+            JsonElement element => element.ToString(),
+            _ => rawValue.ToString() ?? string.Empty
+        };
+
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
+    private static bool TryResolvePropertyText(Dictionary<string, JsonElement>? properties, string key, out string text)
+    {
+        text = string.Empty;
+
+        if (properties == null || !properties.TryGetValue(key, out var element))
+        {
+            return false;
+        }
+
+        text = element.ValueKind == JsonValueKind.String
+            ? element.GetString() ?? string.Empty
+            : element.ToString();
+
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
+    private static TriageFindingState ResolveState(
+        IReadOnlyDictionary<string, TriageStateEntry> triageMap,
+        string findingId)
+    {
+        if (!triageMap.TryGetValue(findingId, out var triageEntry)
+            || string.IsNullOrWhiteSpace(triageEntry.State))
+        {
+            return TriageFindingState.Open;
+        }
+
+        if (Enum.TryParse<TriageFindingState>(triageEntry.State, true, out var parsedState))
+        {
+            return parsedState;
+        }
+
+        return TriageFindingState.Open;
+    }
+
+    private static string ResolveResultFilePath(Run run, Result result)
+    {
+        var firstLocation = result.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation;
+        var resolved = FileHelper.ResolveArtifactPath(firstLocation, run);
+
+        if (!string.IsNullOrWhiteSpace(resolved))
+        {
+            return resolved;
+        }
+
+        return firstLocation?.Uri ?? string.Empty;
+    }
+
+    private static double CalculatePriorityScore(string severity, Result result)
+    {
+        var severityWeight = severity switch
+        {
+            "Critical" => 100,
+            "High" => 80,
+            "Medium" => 50,
+            "Low" => 20,
+            _ => 40
+        };
+
+        var flowComplexity = result.CodeFlows?
+            .SelectMany(codeFlow => codeFlow.ThreadFlows ?? new List<ThreadFlow>())
+            .Sum(threadFlow => threadFlow.Locations?.Count ?? 0) ?? 0;
+
+        return severityWeight + (flowComplexity * 5);
+    }
+
+    private static void EnsureSeverityBuckets(IDictionary<string, int> severityCounts)
+    {
+        var buckets = new[] { "Critical", "High", "Medium", "Low" };
+        foreach (var bucket in buckets)
+        {
+            if (!severityCounts.ContainsKey(bucket))
+            {
+                severityCounts[bucket] = 0;
+            }
+        }
+    }
+
+    private bool TryParseDecisionState(string state, out TriageFindingState parsed)
+    {
+        if (Enum.TryParse<TriageFindingState>(state, true, out parsed)
+            && parsed is TriageFindingState.TP or TriageFindingState.FP)
+        {
+            return true;
+        }
+
+        parsed = TriageFindingState.Open;
+        return false;
+    }
+
+    private async Task<TriageStateDocument> LoadTriageStateDocumentAsync(CancellationToken cancellationToken)
+    {
+        var triagePath = GetTriageFilePath();
+
+        if (!File.Exists(triagePath))
+        {
+            return new TriageStateDocument();
+        }
+
+        var json = await File.ReadAllTextAsync(triagePath, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new TriageStateDocument();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TriageStateDocument>(json, JsonOptions) ?? new TriageStateDocument();
+        }
+        catch (JsonException jsonException)
+        {
+            throw new InvalidOperationException($"Invalid triage state file format at {triagePath}.", jsonException);
+        }
+    }
+
+    private async Task SaveTriageStateDocumentAsync(TriageStateDocument document, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var triagePath = GetTriageFilePath();
+        var triageDirectory = Path.GetDirectoryName(triagePath);
+
+        if (string.IsNullOrWhiteSpace(triageDirectory))
+        {
+            throw new InvalidOperationException("Unable to resolve triage state directory.");
+        }
+
+        Directory.CreateDirectory(triageDirectory);
+        var json = JsonSerializer.Serialize(document, JsonOptions);
+        await File.WriteAllTextAsync(triagePath, json, cancellationToken);
+    }
+
+    private string GetTriageFilePath()
+    {
+        return Path.Combine(_workspaceRoot, ".sarif", "triage.json");
+    }
+
+    private string ResolveFindingPath(TriageFindingEnvelope finding, PhysicalLocation.PhysicalLocationArtifactLocation? artifactLocation)
+    {
+        var resolved = FileHelper.ResolveArtifactPath(artifactLocation, finding.Run);
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            resolved = artifactLocation?.Uri ?? string.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            return string.Empty;
+        }
+
+        if (Path.IsPathRooted(resolved))
+        {
+            return resolved;
+        }
+
+        return Path.Combine(_workspaceRoot, resolved.Replace('/', Path.DirectorySeparatorChar));
+    }
+
+    private async Task<string> ExtractSnippetAsync(string sourcePath, Region? region, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+        {
+            return "Source file unavailable";
+        }
+
+        var sourceCode = await _fileReader.ReadFileAsync(sourcePath);
+        if (string.IsNullOrWhiteSpace(sourceCode))
+        {
+            return string.Empty;
+        }
+
+        var startLine = Math.Max(0, (region?.StartLine ?? 1) - 1);
+        var endLine = Math.Max(startLine, (region?.EndLine ?? startLine + 1) - 1);
+        var language = GetLanguageFromExtension(Path.GetExtension(sourcePath));
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var extractedMethod = await _treeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine);
+        if (!string.IsNullOrWhiteSpace(extractedMethod) && !extractedMethod.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
+        {
+            return extractedMethod.Trim();
+        }
+
+        var lines = sourceCode.Split('\n');
+        if (lines.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var safeStart = Math.Min(startLine, lines.Length - 1);
+        var safeEnd = Math.Min(endLine, lines.Length - 1);
+        return string.Join("\n", lines.Skip(safeStart).Take((safeEnd - safeStart) + 1)).Trim();
+    }
+
+    private static string GetLanguageFromExtension(string extension)
+    {
+        return extension.ToLowerInvariant() switch
+        {
+            ".cs" => "csharp",
+            ".js" => "javascript",
+            ".ts" => "typescript",
+            ".py" => "python",
+            ".java" => "java",
+            ".cpp" => "cpp",
+            ".c" => "c",
+            ".go" => "go",
+            ".rs" => "rust",
+            ".rb" => "ruby",
+            ".php" => "php",
+            ".html" => "html",
+            ".css" => "css",
+            ".json" => "json",
+            ".xml" => "xml",
+            ".yaml" => "yaml",
+            ".yml" => "yaml",
+            ".md" => "markdown",
+            ".sh" => "bash",
+            ".ps1" => "powershell",
+            ".sql" => "sql",
+            _ => "csharp"
+        };
+    }
+
+    private sealed record TriageFindingEnvelope(
+        string FindingId,
+        Result Result,
+        Run Run,
+        string SarifPath,
+        string Severity,
+        TriageFindingState State,
+        string RuleName,
+        string FilePath,
+        int? LineNumber,
+        double PriorityScore,
+        string RuleCategory,
+        string RuleDescription,
+        string Remediation);
+}

--- a/Sarifintown.AgentEngine/TriageWorkflowService.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowService.cs
@@ -96,12 +96,17 @@ internal sealed class TriageWorkflowService
         return ordered;
     }
 
-    public async Task<TriageInspectResult?> InspectAsync(string findingId, CancellationToken cancellationToken = default)
+    public async Task<TriageInspectResult?> InspectAsync(
+        string findingId,
+        string evidenceMode = "",
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(findingId))
         {
             throw new ArgumentException("Finding identifier is required.", nameof(findingId));
         }
+
+        var resolvedEvidenceMode = ParseEvidenceMode(evidenceMode);
 
         var findings = await LoadFindingsAsync(cancellationToken);
         var finding = findings.FirstOrDefault(item => string.Equals(item.FindingId, findingId, StringComparison.Ordinal));
@@ -128,7 +133,7 @@ internal sealed class TriageWorkflowService
             }
 
             var resolvedPath = ResolveFindingPath(finding, physicalLocation.ArtifactLocation);
-            var snippet = await ExtractSnippetAsync(resolvedPath, physicalLocation.Region, cancellationToken);
+            var snippet = await ExtractSnippetAsync(resolvedPath, physicalLocation.Region, resolvedEvidenceMode, cancellationToken);
 
             steps.Add(new TriageInspectStep(
                 index + 1,
@@ -137,6 +142,8 @@ internal sealed class TriageWorkflowService
                 flowLocation.Location?.Message?.Text ?? string.Empty,
                 snippet));
         }
+
+        var evidenceBlocks = await BuildEvidenceBlocksAsync(finding, steps, resolvedEvidenceMode, cancellationToken);
 
         return new TriageInspectResult(
             finding.FindingId,
@@ -147,7 +154,193 @@ internal sealed class TriageWorkflowService
             finding.Result.Message?.Text ?? string.Empty,
             finding.RuleDescription,
             finding.Remediation,
-            steps);
+            steps,
+            ToEvidenceModeValue(resolvedEvidenceMode),
+            evidenceBlocks);
+    }
+
+    public Task<TriageInspectResult?> InspectAsync(string findingId, CancellationToken cancellationToken = default)
+    {
+        return InspectAsync(findingId, string.Empty, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<TriageEvidenceBlock>> BuildEvidenceBlocksAsync(
+        TriageFindingEnvelope finding,
+        IReadOnlyList<TriageInspectStep> steps,
+        TriageEvidenceMode mode,
+        CancellationToken cancellationToken)
+    {
+        if (steps.Count == 0)
+        {
+            return Array.Empty<TriageEvidenceBlock>();
+        }
+
+        if (mode == TriageEvidenceMode.LineWindowStrict)
+        {
+            return steps
+                .Select(step => new TriageEvidenceBlock(
+                    step.Index,
+                    step.Index,
+                    step.FilePath,
+                    step.StartLine,
+                    step.StartLine,
+                    ToEvidenceModeValue(mode),
+                    new[] { step.Index },
+                    step.CodeSnippet))
+                .ToList();
+        }
+
+        var groupedBlocks = new List<TriageEvidenceBlock>();
+
+        for (var index = 0; index < steps.Count;)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var blockSteps = new List<TriageInspectStep> { steps[index] };
+            var nextIndex = index + 1;
+
+            while (nextIndex < steps.Count && ShouldMergeSteps(steps[nextIndex - 1], steps[nextIndex], mode))
+            {
+                blockSteps.Add(steps[nextIndex]);
+                nextIndex++;
+            }
+
+            var first = blockSteps[0];
+            var last = blockSteps[^1];
+            var snippet = await ResolveBlockSnippetAsync(finding, blockSteps, mode, cancellationToken);
+
+            groupedBlocks.Add(new TriageEvidenceBlock(
+                first.Index,
+                last.Index,
+                first.FilePath,
+                first.StartLine,
+                last.StartLine,
+                ToEvidenceModeValue(mode),
+                blockSteps.Select(step => step.Index).ToArray(),
+                snippet));
+
+            index = nextIndex;
+        }
+
+        return groupedBlocks;
+    }
+
+    private async Task<string> ResolveBlockSnippetAsync(
+        TriageFindingEnvelope finding,
+        IReadOnlyList<TriageInspectStep> blockSteps,
+        TriageEvidenceMode mode,
+        CancellationToken cancellationToken)
+    {
+        if (blockSteps.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        if (mode == TriageEvidenceMode.TreeSitterMethod)
+        {
+            return blockSteps[0].CodeSnippet;
+        }
+
+        var firstPath = blockSteps[0].FilePath;
+        if (string.IsNullOrWhiteSpace(firstPath))
+        {
+            return blockSteps[0].CodeSnippet;
+        }
+
+        var resolvedPath = ResolveFindingPath(
+            finding,
+            new PhysicalLocation.PhysicalLocationArtifactLocation { Uri = firstPath });
+
+        if (string.IsNullOrWhiteSpace(resolvedPath) || !File.Exists(resolvedPath))
+        {
+            return blockSteps[0].CodeSnippet;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var sourceCode = await _fileReader.ReadFileAsync(resolvedPath);
+        if (string.IsNullOrWhiteSpace(sourceCode))
+        {
+            return blockSteps[0].CodeSnippet;
+        }
+
+        var minLine = blockSteps
+            .Where(step => step.StartLine.HasValue)
+            .Select(step => step.StartLine!.Value)
+            .DefaultIfEmpty(1)
+            .Min();
+
+        var maxLine = blockSteps
+            .Where(step => step.StartLine.HasValue)
+            .Select(step => step.StartLine!.Value)
+            .DefaultIfEmpty(minLine)
+            .Max();
+
+        return SnippetHelper.ExtractLineWindow(sourceCode, minLine, maxLine);
+    }
+
+    private static bool ShouldMergeSteps(TriageInspectStep previous, TriageInspectStep current, TriageEvidenceMode mode)
+    {
+        if (!string.Equals(previous.FilePath, current.FilePath, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return mode switch
+        {
+            TriageEvidenceMode.LineWindowConcatenated => CanMergeByLineDistance(previous.StartLine, current.StartLine),
+            TriageEvidenceMode.TreeSitterMethod => CanMergeByMethodSnippet(previous.CodeSnippet, current.CodeSnippet),
+            _ => false
+        };
+    }
+
+    private static bool CanMergeByLineDistance(int? previousLine, int? currentLine)
+    {
+        if (!previousLine.HasValue || !currentLine.HasValue)
+        {
+            return false;
+        }
+
+        return currentLine.Value - previousLine.Value <= 6;
+    }
+
+    private static bool CanMergeByMethodSnippet(string previousSnippet, string currentSnippet)
+    {
+        if (string.IsNullOrWhiteSpace(previousSnippet)
+            || string.IsNullOrWhiteSpace(currentSnippet)
+            || previousSnippet.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase)
+            || currentSnippet.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return string.Equals(previousSnippet, currentSnippet, StringComparison.Ordinal);
+    }
+
+    private static TriageEvidenceMode ParseEvidenceMode(string? mode)
+    {
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            return TriageEvidenceMode.TreeSitterMethod;
+        }
+
+        var normalized = mode.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "line-window-strict" or "strict" or "option2.1" => TriageEvidenceMode.LineWindowStrict,
+            "line-window-concatenated" or "concatenated" or "option2.2" => TriageEvidenceMode.LineWindowConcatenated,
+            "tree-sitter-method" or "tree-sitter" or "option2.3" => TriageEvidenceMode.TreeSitterMethod,
+            _ => TriageEvidenceMode.TreeSitterMethod
+        };
+    }
+
+    private static string ToEvidenceModeValue(TriageEvidenceMode mode)
+    {
+        return mode switch
+        {
+            TriageEvidenceMode.LineWindowStrict => "line-window-strict",
+            TriageEvidenceMode.LineWindowConcatenated => "line-window-concatenated",
+            _ => "tree-sitter-method"
+        };
     }
 
     public async Task<TriageOperationResult> TriageAsync(
@@ -830,7 +1023,11 @@ internal sealed class TriageWorkflowService
         return Path.Combine(_workspaceRoot, resolved.Replace('/', Path.DirectorySeparatorChar));
     }
 
-    private async Task<string> ExtractSnippetAsync(string sourcePath, Region? region, CancellationToken cancellationToken)
+    private async Task<string> ExtractSnippetAsync(
+        string sourcePath,
+        Region? region,
+        TriageEvidenceMode evidenceMode,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
         {
@@ -843,9 +1040,23 @@ internal sealed class TriageWorkflowService
             return string.Empty;
         }
 
-        var startLine = Math.Max(0, (region?.StartLine ?? 1) - 1);
-        var endLine = Math.Max(startLine, (region?.EndLine ?? startLine + 1) - 1);
+        if (evidenceMode is TriageEvidenceMode.LineWindowStrict or TriageEvidenceMode.LineWindowConcatenated)
+        {
+            var windowStart = region?.StartLine ?? 1;
+            var windowEnd = region?.EndLine > 0 ? region.EndLine : windowStart;
+            return SnippetHelper.ExtractLineWindow(sourceCode, windowStart, windowEnd);
+        }
+
+        var windowStartLine = region?.StartLine ?? 1;
+        var windowEndLine = region?.EndLine > 0 ? region.EndLine : windowStartLine;
+        var startLine = Math.Max(0, windowStartLine - 1);
+        var endLine = Math.Max(startLine, windowEndLine - 1);
         var language = GetLanguageFromExtension(Path.GetExtension(sourcePath));
+
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+        }
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -855,15 +1066,7 @@ internal sealed class TriageWorkflowService
             return extractedMethod.Trim();
         }
 
-        var lines = sourceCode.Split('\n');
-        if (lines.Length == 0)
-        {
-            return string.Empty;
-        }
-
-        var safeStart = Math.Min(startLine, lines.Length - 1);
-        var safeEnd = Math.Min(endLine, lines.Length - 1);
-        return string.Join("\n", lines.Skip(safeStart).Take((safeEnd - safeStart) + 1)).Trim();
+        return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
     }
 
     private static string GetLanguageFromExtension(string extension)
@@ -891,7 +1094,7 @@ internal sealed class TriageWorkflowService
             ".sh" => "bash",
             ".ps1" => "powershell",
             ".sql" => "sql",
-            _ => "csharp"
+            _ => string.Empty
         };
     }
 

--- a/Sarifintown.AgentEngine/V8TreeSitterEngine.cs
+++ b/Sarifintown.AgentEngine/V8TreeSitterEngine.cs
@@ -6,6 +6,7 @@ using Sarifintown.Core;
 public class V8TreeSitterEngine : ITreeSitterEngine, IDisposable
 {
     private readonly V8ScriptEngine _engine;
+    private readonly Dictionary<string, byte[]> _languageWasmCache = new(StringComparer.OrdinalIgnoreCase);
 
     public V8TreeSitterEngine()
     {
@@ -56,13 +57,33 @@ public class V8TreeSitterEngine : ITreeSitterEngine, IDisposable
 
     public async Task<string> ExtractMethodAsync(string sourceCode, string language, int startLine, int endLine)
     {
-        var baseDir = AppContext.BaseDirectory;
-        var wasmPath = Path.Combine(baseDir, "tree-sitter", $"tree-sitter-{language.ToLower()}.wasm");
+        if (string.IsNullOrWhiteSpace(sourceCode))
+        {
+            return string.Empty;
+        }
 
-        var wasmBytes = await File.ReadAllBytesAsync(wasmPath);
+        var normalizedLanguage = NormalizeLanguage(language);
+        var baseDir = AppContext.BaseDirectory;
+        var wasmPath = Path.Combine(baseDir, "tree-sitter", $"tree-sitter-{normalizedLanguage}.wasm");
+
+        if (!File.Exists(wasmPath))
+        {
+            return string.Empty;
+        }
+
+        if (!_languageWasmCache.TryGetValue(normalizedLanguage, out var wasmBytes))
+        {
+            wasmBytes = await File.ReadAllBytesAsync(wasmPath);
+            _languageWasmCache[normalizedLanguage] = wasmBytes;
+        }
+
+        var targetStartLine = Math.Max(0, startLine);
+        var targetEndLine = Math.Max(targetStartLine, endLine);
 
         _engine.Script.sourceCode = sourceCode;
         _engine.Script.wasmBytes = wasmBytes;
+        _engine.Script.targetStartLine = targetStartLine;
+        _engine.Script.targetEndLine = targetEndLine;
 
         var promise = _engine.Evaluate(@"
             (async () => {
@@ -77,7 +98,65 @@ public class V8TreeSitterEngine : ITreeSitterEngine, IDisposable
 
                     const tree = parser.parse(sourceCode);
 
-                    return tree.rootNode.toString();
+                    const methodNodeTypes = new Set([
+                        'method_declaration',
+                        'function_declaration',
+                        'method_definition',
+                        'function_definition',
+                        'constructor_declaration',
+                        'arrow_function',
+                        'lambda_expression',
+                        'function_item',
+                        'function_expression',
+                        'function_signature_item',
+                        'function',
+                        'local_function_statement'
+                    ]);
+
+                    const findMethodForLine = (node, targetLine) => {
+                        if (!node) {
+                            return null;
+                        }
+
+                        if (methodNodeTypes.has(node.type)
+                            && node.startPosition.row <= targetLine
+                            && node.endPosition.row >= targetLine) {
+                            return node;
+                        }
+
+                        for (let i = 0; i < node.namedChildCount; i++) {
+                            const child = node.namedChild(i);
+                            if (!child) {
+                                continue;
+                            }
+
+                            if (targetLine < child.startPosition.row || targetLine > child.endPosition.row) {
+                                continue;
+                            }
+
+                            const found = findMethodForLine(child, targetLine);
+                            if (found) {
+                                return found;
+                            }
+                        }
+
+                        return null;
+                    };
+
+                    let node = findMethodForLine(tree.rootNode, targetStartLine);
+                    if (!node && targetEndLine !== targetStartLine) {
+                        node = findMethodForLine(tree.rootNode, targetEndLine);
+                    }
+
+                    while (node && !methodNodeTypes.has(node.type)) {
+                        node = node.parent;
+                    }
+
+                    if (!node) {
+                        return '';
+                    }
+
+                    return sourceCode.substring(node.startIndex, node.endIndex);
                 } catch (e) {
                     return 'ERROR: ' + e.toString();
                 }
@@ -87,6 +166,20 @@ public class V8TreeSitterEngine : ITreeSitterEngine, IDisposable
         // Properly cast and await the result
         string result = (string)await ((ScriptObject)promise).ToTask();
         return result;
+    }
+
+    private static string NormalizeLanguage(string language)
+    {
+        var normalized = (language ?? string.Empty).Trim().ToLowerInvariant();
+
+        return normalized switch
+        {
+            "csharp" => "c_sharp",
+            "cs" => "c_sharp",
+            "typescriptreact" => "tsx",
+            "javascriptreact" => "javascript",
+            _ => normalized
+        };
     }
 
     public void Dispose() => _engine.Dispose();

--- a/Sarifintown.Core.Tests/SnippetHelperTests.cs
+++ b/Sarifintown.Core.Tests/SnippetHelperTests.cs
@@ -80,4 +80,20 @@ public class SnippetHelperTests
 
         Assert.That(result, Does.Contain("<mark>line2\nline3\nline</mark>4"));
     }
+
+    [Test]
+    public void ExtractLineWindow_WithRadius_ReturnsBoundedContext()
+    {
+        var result = SnippetHelper.ExtractLineWindow(SampleCode, 5, 5, 2);
+
+        Assert.That(result, Is.EqualTo(string.Join(Environment.NewLine, "line3", "line4", "line5", "line6", "line7")));
+    }
+
+    [Test]
+    public void ExtractLineRange_WithRange_ReturnsInclusiveLines()
+    {
+        var result = SnippetHelper.ExtractLineRange(SampleCode, 2, 4);
+
+        Assert.That(result, Is.EqualTo(string.Join(Environment.NewLine, "line2", "line3", "line4")));
+    }
 }

--- a/Sarifintown.Core/Helpers/SnippetHelper.cs
+++ b/Sarifintown.Core/Helpers/SnippetHelper.cs
@@ -4,12 +4,64 @@ namespace Sarifintown.Helpers
 {
     public class SnippetHelper
     {
-        public static ExtractedCodeSnippet ExtractCodeSnippet(string fileContent, Region region)
+        private const int DefaultContextRadius = 3;
+
+        public static ExtractedCodeSnippet ExtractCodeSnippet(string fileContent, Region region, int surroundingLines = DefaultContextRadius)
         {
-            return ExtractCodeSnippet(fileContent, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
+            return ExtractCodeSnippet(fileContent, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn, surroundingLines);
         }
 
-        public static ExtractedCodeSnippet ExtractCodeSnippet(string fileContent, int startLine, int startColumn, int endLine, int endColumn)
+        public static string ExtractLineWindow(string fileContent, int startLine, int endLine, int radius = DefaultContextRadius)
+        {
+            if (string.IsNullOrEmpty(fileContent))
+            {
+                return string.Empty;
+            }
+
+            var allLines = fileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            if (allLines.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var normalizedStart = Math.Max(1, startLine);
+            var normalizedEnd = Math.Max(normalizedStart, endLine);
+
+            var visibleStartLine = Math.Max(1, normalizedStart - Math.Max(0, radius));
+            var visibleEndLine = Math.Min(allLines.Length, normalizedEnd + Math.Max(0, radius));
+
+            return string.Join(Environment.NewLine, allLines.Skip(visibleStartLine - 1).Take((visibleEndLine - visibleStartLine) + 1)).TrimEnd();
+        }
+
+        public static string ExtractLineRange(string fileContent, int startLine, int endLine)
+        {
+            if (string.IsNullOrEmpty(fileContent))
+            {
+                return string.Empty;
+            }
+
+            var allLines = fileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            if (allLines.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var normalizedStart = Math.Max(1, startLine);
+            var normalizedEnd = Math.Max(normalizedStart, endLine);
+
+            var safeStart = Math.Min(normalizedStart, allLines.Length);
+            var safeEnd = Math.Min(normalizedEnd, allLines.Length);
+
+            return string.Join(Environment.NewLine, allLines.Skip(safeStart - 1).Take((safeEnd - safeStart) + 1)).TrimEnd();
+        }
+
+        public static ExtractedCodeSnippet ExtractCodeSnippet(
+            string fileContent,
+            int startLine,
+            int startColumn,
+            int endLine,
+            int endColumn,
+            int surroundingLines = DefaultContextRadius)
         {
             // Split the file content into lines
             var allLines = fileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
@@ -24,8 +76,9 @@ namespace Sarifintown.Helpers
             }
 
             // Calculate the visible range of lines to include (with boundary checks)
-            int visibleStartLine = Math.Max(1, startLine - 3);
-            int visibleEndLine = Math.Min(totalLines, endLine + 3);
+            var contextRadius = Math.Max(1, surroundingLines);
+            int visibleStartLine = Math.Max(1, startLine - contextRadius);
+            int visibleEndLine = Math.Min(totalLines, endLine + contextRadius);
 
             // Extract ContextSnippet: the lines from visibleStartLine to visibleEndLine
             var contextLines = new List<string>();

--- a/Sarifintown.Tests/CodeSnippetServiceTests.cs
+++ b/Sarifintown.Tests/CodeSnippetServiceTests.cs
@@ -15,8 +15,9 @@ namespace Sarifintown.Tests
 
             var localFilesService = new LocalFilesService();
             localFilesService.AddDirectory(new DirectoryPicker { Id = 1, Name = "src" });
+            var settingsService = new SettingsService();
 
-            var service = new CodeSnippetService(fileReader, localFilesService);
+            var service = new CodeSnippetService(fileReader, localFilesService, settingsService);
             var run = new Run { Results = new List<Result>() };
             var result = CreateResult();
             run.Results.Add(result);
@@ -40,8 +41,9 @@ namespace Sarifintown.Tests
 
             var localFilesService = new LocalFilesService();
             localFilesService.AddDirectory(new DirectoryPicker { Id = 2, Name = "src" });
+            var settingsService = new SettingsService();
 
-            var service = new CodeSnippetService(fileReader, localFilesService);
+            var service = new CodeSnippetService(fileReader, localFilesService, settingsService);
             var run = new Run
             {
                 Results =
@@ -60,6 +62,29 @@ namespace Sarifintown.Tests
             Assert.That(response.Success, Is.True);
             Assert.That(run.Results.All(result => result.IsSnippetLoaded), Is.True);
             Assert.That(callbackCount, Is.GreaterThanOrEqualTo(2));
+        }
+
+        [Test]
+        public async Task EnsureCodeSnippetAsync_WhenSurroundingLinesChanged_UsesConfiguredWindow()
+        {
+            var fileReader = new CountingFileReader();
+            fileReader.Files["src/file.cs"] = "line1\nline2\nline3\nline4\nline5\nline6";
+
+            var localFilesService = new LocalFilesService();
+            localFilesService.AddDirectory(new DirectoryPicker { Id = 3, Name = "src" });
+
+            var settingsService = new SettingsService { SurroundingLines = 1 };
+            var service = new CodeSnippetService(fileReader, localFilesService, settingsService);
+
+            var run = new Run { Results = new List<Result>() };
+            var result = CreateResult("src/file.cs");
+            run.Results.Add(result);
+
+            var response = await service.EnsureCodeSnippetAsync(run, result);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(result.Locations[0].PhysicalLocation.ExtractedCodeSnippet!.VisibleStartLine, Is.EqualTo(1));
+            Assert.That(result.Locations[0].PhysicalLocation.ExtractedCodeSnippet!.VisibleEndLine, Is.EqualTo(3));
         }
 
         private static Result CreateResult(string path = "src/file.cs")

--- a/Sarifintown.Tests/SettingsServiceTests.cs
+++ b/Sarifintown.Tests/SettingsServiceTests.cs
@@ -1,0 +1,35 @@
+using Sarifintown.Services;
+
+namespace Sarifintown.Tests;
+
+[TestFixture]
+public class SettingsServiceTests
+{
+    [Test]
+    public void SurroundingLines_Default_IsThree()
+    {
+        var service = new SettingsService();
+
+        Assert.That(service.SurroundingLines, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void SurroundingLines_WhenSetBelowMin_ClampsToMin()
+    {
+        var service = new SettingsService();
+
+        service.SurroundingLines = 0;
+
+        Assert.That(service.SurroundingLines, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void SurroundingLines_WhenSetAboveMax_ClampsToMax()
+    {
+        var service = new SettingsService();
+
+        service.SurroundingLines = 42;
+
+        Assert.That(service.SurroundingLines, Is.EqualTo(10));
+    }
+}

--- a/Sarifintown.sln
+++ b/Sarifintown.sln
@@ -1,15 +1,15 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.3.11512.155
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarifintown.UI", "Sarifintown\\Sarifintown.UI.csproj", "{69ECCA96-E434-49D3-989E-CD6B7773715C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarifintown.UI", "Sarifintown\Sarifintown.UI.csproj", "{69ECCA96-E434-49D3-989E-CD6B7773715C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.UI.Tests", "Sarifintown.Tests\\Sarifintown.UI.Tests.csproj", "{75CECCCA-4789-4555-975B-5E772FD99208}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.UI.Tests", "Sarifintown.Tests\Sarifintown.UI.Tests.csproj", "{75CECCCA-4789-4555-975B-5E772FD99208}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		LICENSE = LICENSE
+		MCP_SETUP.md = MCP_SETUP.md
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -26,11 +26,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Core", "Sarifintown.Core\Sarifintown.Core.csproj", "{B2B08E1B-2B6F-4B1C-A3E1-87FB057F2A1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine", "Sarifintown.AgentEngine\\Sarifintown.Engine.csproj", "{92D84CDA-6203-9FCF-A448-4BEAB5E92476}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine", "Sarifintown.AgentEngine\Sarifintown.Engine.csproj", "{92D84CDA-6203-9FCF-A448-4BEAB5E92476}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Core.Tests", "Sarifintown.Core.Tests\Sarifintown.Core.Tests.csproj", "{5539053E-9CDC-4385-8D1B-67F67C5AD5EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine.Tests", "Sarifintown.AgentEngine.Tests\\Sarifintown.Engine.Tests.csproj", "{4765B0F9-9B5F-46D0-BCCD-F1AB026C4B77}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarifintown.Engine.Tests", "Sarifintown.AgentEngine.Tests\Sarifintown.Engine.Tests.csproj", "{4765B0F9-9B5F-46D0-BCCD-F1AB026C4B77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Sarifintown/Pages/FullDetailsDialog.razor
+++ b/Sarifintown/Pages/FullDetailsDialog.razor
@@ -223,7 +223,10 @@
         {
             foreach (var codeFlowItem in _codeFlowDataList)
             {
-                codeFlowItem.ExtractedSnippet = SnippetHelper.ExtractCodeSnippet(_usedFiles[codeFlowItem.Filename], codeFlowItem.Region);
+                codeFlowItem.ExtractedSnippet = SnippetHelper.ExtractCodeSnippet(
+                    _usedFiles[codeFlowItem.Filename],
+                    codeFlowItem.Region,
+                    SettingsService.SurroundingLines);
             }
         }
         else if (SettingsService.ResultViewMode == ResultViewMode.SingleWindow)
@@ -231,7 +234,10 @@
 
             foreach (var codeFlowItem in _codeFlowDataList)
             {                
-                codeFlowItem.ExtractedSnippet = SnippetHelper.ExtractCodeSnippet(_usedFiles[codeFlowItem.Filename], codeFlowItem.Region);
+                codeFlowItem.ExtractedSnippet = SnippetHelper.ExtractCodeSnippet(
+                    _usedFiles[codeFlowItem.Filename],
+                    codeFlowItem.Region,
+                    SettingsService.SurroundingLines);
 
             }
 

--- a/Sarifintown/Pages/Settings.razor
+++ b/Sarifintown/Pages/Settings.razor
@@ -14,6 +14,14 @@
     }
 </MudSelect>
 
+<MudNumericField T="int"
+                 @bind-Value="SettingsService.SurroundingLines"
+                 Label="Surrounding lines"
+                 Min="@SettingsService.MinSurroundingLines"
+                 Max="@SettingsService.MaxSurroundingLines"
+                 Immediate="true"
+                 HelperText="Used for snippet context windows. Range: 1..10." />
+
 <MudText Color="Color.Warning"> SingleWindow mode: Work in Progress.</MudText>
 
 

--- a/Sarifintown/Services/CodeSnippetService.cs
+++ b/Sarifintown/Services/CodeSnippetService.cs
@@ -13,13 +13,18 @@ namespace Sarifintown.Services
     {
         private readonly Sarifintown.Core.IFileReader _fileReader;
         private readonly LocalFilesService _localFilesService;
+        private readonly SettingsService _settingsService;
         private readonly Dictionary<string, string> _fileContentCache = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, ExtractedCodeSnippet> _snippetCache = new(StringComparer.Ordinal);
 
-        public CodeSnippetService(Sarifintown.Core.IFileReader fileReader, LocalFilesService localFilesService)
+        public CodeSnippetService(
+            Sarifintown.Core.IFileReader fileReader,
+            LocalFilesService localFilesService,
+            SettingsService settingsService)
         {
             _fileReader = fileReader;
             _localFilesService = localFilesService;
+            _settingsService = settingsService;
         }
 
         /// <summary>
@@ -166,7 +171,13 @@ namespace Sarifintown.Services
                 _fileContentCache[adjustedPath] = content;
             }
 
-            var snippet = SnippetHelper.ExtractCodeSnippet(content, region.StartLine, region.StartColumn, region.EndLine, region.EndColumn);
+            var snippet = SnippetHelper.ExtractCodeSnippet(
+                content,
+                region.StartLine,
+                region.StartColumn,
+                region.EndLine,
+                region.EndColumn,
+                _settingsService.SurroundingLines);
             location.PhysicalLocation.ExtractedCodeSnippet = snippet;
             result.IsSnippetLoaded = snippet != null;
 

--- a/Sarifintown/Services/SettingsService.cs
+++ b/Sarifintown/Services/SettingsService.cs
@@ -2,7 +2,19 @@
 {
     public class SettingsService
     {
+        public const int MinSurroundingLines = 1;
+        public const int MaxSurroundingLines = 10;
+        public const int DefaultSurroundingLines = 3;
+
+        private int _surroundingLines = DefaultSurroundingLines;
+
         public ResultViewMode ResultViewMode { get; set; } = ResultViewMode.SplitMode;
+
+        public int SurroundingLines
+        {
+            get => _surroundingLines;
+            set => _surroundingLines = Math.Clamp(value, MinSurroundingLines, MaxSurroundingLines);
+        }
     }
 
     public enum ResultViewMode


### PR DESCRIPTION
Introduce a Triage workflow to support listing, inspecting and triaging SARIF findings. Added TriageWorkflowService and TriageWorkflowModels to load findings, maintain .sarif/triage.json state, compute status/priority, apply filters, and perform single/bulk triage operations. Exposed new SarifTools server tools (TriageStatus, TriageList, TriageQuery, TriageInspect, Triage, TriageBulk), added workspace root management and wiring in Program to initialize the service. Enhanced SpectreCliMenu to present triage actions and execute interactive triage flows. Extended SarifTools unit tests to cover status, listing, inspect/triage and bulk dry-run scenarios. Files added: TriageWorkflowService.cs, TriageWorkflowModels.cs; modified: SarifTools.cs, Program.cs, SpectreCliMenu.cs, and SarifToolsTests.cs.