### PR TITLE
Introduce manage_triage and analyze_sarif facades

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,3 +11,5 @@
 - Do not guess repository state, scan results, triage state, or code-flow evidence. Retrieve data through MCP tools first.
 - If a required domain action has an MCP tool, call the tool before proposing conclusions.
 - Keep responses aligned with tool outputs; do not invent findings, IDs, or file paths.
+- Universal SARIF workflow restriction: for triage actions use only `manage_triage`; for SARIF analysis actions use only `analyze_sarif`. Always enforce MCP-only execution: do not use generic scripts, terminal commands, or external summarization when MCP actions exist.
+- Never use generic tools (custom scripts, terminal commands, or external summarization) to process SARIF triage or SARIF analysis data when MCP actions are available.

--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -310,6 +310,35 @@ Use the same server body for both schema styles:
 - macOS/Linux paths: `/...`.
 - Prefer absolute paths for `cwd` and `PROJECT_ROOT`.
 
+### Optional preload and warmup tuning
+
+You can tune SARIF preload behavior and startup snippet warmup directly from MCP client env vars:
+
+- `SARIFINTOWN_Preload__Strategy`: `None`, `LatestPerTool`, or `All`
+- `SARIFINTOWN_Preload__EnableSnippetPreload`: `true`/`false`
+- `SARIFINTOWN_Preload__MaxPreloadedSnippets`: integer
+
+Example (global tool invocation preserved):
+
+```json
+{
+  "servers": {
+    "sarifintown": {
+      "transport": "stdio",
+      "command": "sarifintown",
+      "args": [],
+      "cwd": "C:/dev/sarifintown",
+      "env": {
+        "PROJECT_ROOT": "C:/dev/my-app",
+        "SARIFINTOWN_Preload__Strategy": "LatestPerTool",
+        "SARIFINTOWN_Preload__EnableSnippetPreload": "true",
+        "SARIFINTOWN_Preload__MaxPreloadedSnippets": "50"
+      }
+    }
+  }
+}
+```
+
 ---
 
 ## Quick validation checklist
@@ -447,3 +476,23 @@ Recommended host response:
 - Test the command manually in terminal.
 - Verify .NET SDK is installed.
 - Verify project path is correct.
+
+## Server starts but MCP `initialize` appears stuck
+
+`Sarifintown.Engine` now emits startup diagnostics to **stderr** (MCP console output) so stdio protocol messages on stdout are not polluted.
+
+Typical startup sequence:
+
+1. Workspace discovery (`PROJECT_ROOT` and fallbacks)
+2. Tree-sitter initialization
+3. SARIF state initialization
+4. Optional snippet preload
+5. Web host start + local UI URL resolution
+6. Wait for MCP traffic
+
+If `initialize` stalls, inspect MCP console logs for lines prefixed with `sarifintown-mcp` and look for a `failed after ... ms` message to identify the blocking stage.
+
+If the process crashes before your MCP client can render console output, run the same command directly in a terminal to capture stderr:
+
+- Global tool: `sarifintown`
+- Fallback: `dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj`

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ MCP server support is available via `Sarifintown.Engine`; see the concise setup 
 - Group and filter results by severity, rule and file path.
 - MCP tools for SARIF discovery, filtering, flow extraction, analysis report generation, and triage workflows.
 - Shared triage state persisted in `.sarif/triage.json` for MCP/CLI triage commands.
+- In-memory SARIF findings cache with configurable preload strategy for low-latency triage commands.
+- JIT snippet warmup queue that anticipates `TriageInspect` after `TriageList`/`TriageListGuided` responses.
 
 ## Prerequisites
 
@@ -68,6 +70,28 @@ MCP prompt primitives are also exposed:
 - `SarifintownInspectFinding`
 
 These commands use loaded SARIF findings and persist decision state to `.sarif/triage.json`.
+
+## Engine preload and warmup configuration
+
+`Sarifintown.Engine` supports preload and snippet warmup tuning via `.sarif/engine.json` and environment variables.
+
+Example `.sarif/engine.json`:
+
+```json
+{
+  "Preload": {
+    "Strategy": "LatestPerTool",
+    "EnableSnippetPreload": true,
+    "MaxPreloadedSnippets": 50
+  }
+}
+```
+
+Equivalent environment variables:
+
+- `SARIFINTOWN_Preload__Strategy` = `None` | `LatestPerTool` | `All`
+- `SARIFINTOWN_Preload__EnableSnippetPreload` = `true` | `false`
+- `SARIFINTOWN_Preload__MaxPreloadedSnippets` = integer
 
 ## License
 

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -140,6 +140,67 @@ namespace Sarifintown.AgentEngine.Tests
             }
         }
 
+        [Test]
+        public async Task ManageTriage_WithDecideAndBulkActions_ReturnsMarkdownSummaries()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "facade-decide-bulk.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-FACADE-DECIDE",
+                      "level": "error",
+                      "message": { "text": "triage me" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Facade.cs" },
+                            "region": { "startLine": 9 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 1);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingId = listPayload![0].GetProperty("FindingId").GetString();
+
+                var decideResult = await SarifTools.manage_triage("decide", findingId!, state: "TP", reason: "validated");
+                var decideText = decideResult.Content[0] as TextContentBlock;
+
+                Assert.That(decideText, Is.Not.Null);
+                Assert.That(decideText!.Text, Contains.Substring("## Triage Decision Result"));
+                Assert.That(decideText.Text, Does.Not.Contain("```json"));
+
+                var bulkResult = await SarifTools.manage_triage("bulk_decide", state: "FP", reason: "bulk-noise", filters: "{\"rule\":\"RULE-FACADE-DECIDE\",\"dryRun\":true}");
+                var bulkText = bulkResult.Content[0] as TextContentBlock;
+
+                Assert.That(bulkText, Is.Not.Null);
+                Assert.That(bulkText!.Text, Contains.Substring("## Bulk Triage Result"));
+                Assert.That(bulkText.Text, Does.Not.Contain("```json"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
         [TestCase("true positive", "TP")]
         [TestCase("false positive", "FP")]
         public async Task Triage_WithNaturalLanguageState_MapsToExpectedState(string inputState, string expectedState)
@@ -1024,7 +1085,8 @@ namespace Sarifintown.AgentEngine.Tests
 
                 Assert.That(textBlock, Is.Not.Null);
                 Assert.That(textBlock!.Text, Does.Not.Contain("Dummy payload"));
-                Assert.That(textBlock.Text, Contains.Substring("TotalFindings"));
+                Assert.That(textBlock.Text, Contains.Substring("## SARIF Triage Status"));
+                Assert.That(textBlock.Text, Does.Not.Contain("```json"));
             }
             finally
             {

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -4,7 +4,9 @@ using NUnit.Framework;
 using Sarifintown.AgentEngine;
 using Sarifintown.Core;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
+using System.Threading;
 
 namespace Sarifintown.AgentEngine.Tests
 {
@@ -28,6 +30,113 @@ namespace Sarifintown.AgentEngine.Tests
                     return File.ReadAllTextAsync(relativePath);
                 }
                 throw new FileNotFoundException($"File not found: {relativePath}");
+            }
+        }
+
+        [Test]
+        public async Task TriageList_WithLatestPerToolPreload_IncludesOnlyNewestFilePerTool()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var olderToolAPath = Path.Combine(sarifDirectory, "tool-a-older.sarif");
+            File.WriteAllText(olderToolAPath, """
+            {
+              "runs": [
+                {
+                  "tool": { "driver": { "name": "ToolA" } },
+                  "results": [
+                    {
+                      "ruleId": "RULE-OLD",
+                      "level": "warning",
+                      "message": { "text": "old" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/old.cs" },
+                            "region": { "startLine": 1 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            var latestToolAPath = Path.Combine(sarifDirectory, "tool-a-latest.sarif");
+            File.WriteAllText(latestToolAPath, """
+            {
+              "runs": [
+                {
+                  "tool": { "driver": { "name": "ToolA" } },
+                  "results": [
+                    {
+                      "ruleId": "RULE-NEW",
+                      "level": "error",
+                      "message": { "text": "new" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/new.cs" },
+                            "region": { "startLine": 2 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            var toolBPath = Path.Combine(sarifDirectory, "tool-b.sarif");
+            File.WriteAllText(toolBPath, """
+            {
+              "runs": [
+                {
+                  "tool": { "driver": { "name": "ToolB" } },
+                  "results": [
+                    {
+                      "ruleId": "RULE-B",
+                      "level": "warning",
+                      "message": { "text": "b" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/b.cs" },
+                            "region": { "startLine": 3 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            var baseline = DateTime.UtcNow;
+            File.SetLastWriteTimeUtc(olderToolAPath, baseline.AddMinutes(-5));
+            File.SetLastWriteTimeUtc(latestToolAPath, baseline.AddMinutes(-1));
+            File.SetLastWriteTimeUtc(toolBPath, baseline.AddMinutes(-2));
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { olderToolAPath, latestToolAPath, toolBPath });
+
+            try
+            {
+                var responseJson = await SarifTools.TriageList(limit: 10);
+                var payload = JsonSerializer.Deserialize<List<JsonElement>>(responseJson);
+                var ruleNames = payload!.Select(item => item.GetProperty("RuleName").GetString()).ToList();
+
+                Assert.That(ruleNames, Is.EqualTo(new[] { "RULE-NEW", "RULE-B" }));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
             }
         }
 
@@ -78,74 +187,6 @@ namespace Sarifintown.AgentEngine.Tests
                 var triagePayload = JsonSerializer.Deserialize<JsonElement>(triageJson);
 
                 Assert.That(triagePayload.GetProperty("State").GetString(), Is.EqualTo(expectedState));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task ExtractCodeFlow_WhenSourceRootIsOneLevelAboveProject_ResolvesSnippet()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            var projectRoot = Path.Combine(workspace, "SharpSaster");
-            var controllerDirectory = Path.Combine(projectRoot, "Controllers");
-
-            Directory.CreateDirectory(sarifDirectory);
-            Directory.CreateDirectory(controllerDirectory);
-
-            var sourcePath = Path.Combine(controllerDirectory, "SqlAdvancedController.cs");
-            File.WriteAllText(sourcePath, "class SqlAdvancedController { void Run() { } }");
-
-            var sarifPath = Path.Combine(sarifDirectory, "results.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "csharp/Sqli",
-                      "codeFlows": [
-                        {
-                          "threadFlows": [
-                            {
-                              "locations": [
-                                {
-                                  "location": {
-                                    "physicalLocation": {
-                                      "artifactLocation": {
-                                        "uri": "Controllers/SqlAdvancedController.cs"
-                                      },
-                                      "region": {
-                                        "startLine": 1,
-                                        "endLine": 1
-                                      }
-                                    },
-                                    "message": {
-                                      "text": "Step 1"
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            try
-            {
-                var result = await SarifTools.ExtractCodeFlow(sarifPath, "0", workspace);
-
-                Assert.That(result, Contains.Substring("SqlAdvancedController.cs"));
-                Assert.That(result, Contains.Substring("extracted_code_snippet"));
             }
             finally
             {
@@ -294,10 +335,20 @@ namespace Sarifintown.AgentEngine.Tests
 
         private class FakeTreeSitterEngine : ITreeSitterEngine
         {
+            private static int _extractMethodCallCount;
+
+            public static int ExtractMethodCallCount => Volatile.Read(ref _extractMethodCallCount);
+
+            public static void Reset()
+            {
+                Interlocked.Exchange(ref _extractMethodCallCount, 0);
+            }
+
             public Task InitializeAsync() => Task.CompletedTask;
 
             public Task<string> ExtractMethodAsync(string sourceCode, string language, int startLine, int endLine)
             {
+                Interlocked.Increment(ref _extractMethodCallCount);
                 return Task.FromResult("extracted_code_snippet");
             }
         }
@@ -307,9 +358,84 @@ namespace Sarifintown.AgentEngine.Tests
         {
             SarifTools.FileReader = new FakeFileReader();
             SarifTools.TreeSitterEngine = new FakeTreeSitterEngine();
+            FakeTreeSitterEngine.Reset();
+            SetInternalSarifToolsProperty("StateService", null);
+            SetInternalSarifToolsProperty("SnippetCache", null);
+            SetInternalSarifToolsProperty("SnippetWarmupService", null);
             SarifTools.SetDiscoveredSarifFiles(Array.Empty<string>());
             SarifTools.SetLocalUiBaseUrl(string.Empty);
             SarifTools.SetWorkspaceRoot(Directory.GetCurrentDirectory());
+        }
+
+        [Test]
+        public async Task TriageInspect_WithSharedSnippetCache_ReusesExtractedMethodAcrossCalls()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            var sourceDirectory = Path.Combine(workspace, "src");
+            Directory.CreateDirectory(sarifDirectory);
+            Directory.CreateDirectory(sourceDirectory);
+
+            var sourcePath = Path.Combine(sourceDirectory, "Cached.cs");
+            File.WriteAllText(sourcePath, "class Cached { void Run() { } }");
+
+            var sarifPath = Path.Combine(sarifDirectory, "cached-inspect.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-CACHED",
+                      "message": { "text": "flow" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Cached.cs" },
+                            "region": { "startLine": 1 }
+                          }
+                        }
+                      ],
+                      "codeFlows": [
+                        {
+                          "threadFlows": [
+                            {
+                              "locations": [
+                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Cached.cs" }, "region": { "startLine": 1, "endLine": 1 } } } }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+            SetInternalSarifToolsProperty("SnippetCache", CreateInternalTypeInstance("Sarifintown.AgentEngine.SnippetCacheService"));
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 1);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingId = listPayload![0].GetProperty("FindingId").GetString();
+
+                var firstInspect = await SarifTools.TriageInspect(findingId!);
+                var secondInspect = await SarifTools.TriageInspect(findingId!);
+
+                Assert.That(firstInspect, Contains.Substring("extracted_code_snippet"));
+                Assert.That(secondInspect, Contains.Substring("extracted_code_snippet"));
+                Assert.That(FakeTreeSitterEngine.ExtractMethodCallCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                SetInternalSarifToolsProperty("SnippetCache", null);
+                Directory.Delete(workspace, true);
+            }
         }
 
         [Test]
@@ -540,195 +666,6 @@ namespace Sarifintown.AgentEngine.Tests
             finally
             {
                 Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task LoadAndFilterSarif_WithDiscoveredFileName_ResolvesAndParsesFile()
-        {
-            // Arrange
-            var sarifContent = @"
-            {
-                ""runs"": [
-                    {
-                        ""results"": [
-                            {
-                                ""ruleId"": ""RULE-DISCOVERED"",
-                                ""level"": ""warning"",
-                                ""message"": { ""text"": ""From discovered file"" }
-                            }
-                        ]
-                    }
-                ]
-            }";
-
-            var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempDirectory);
-            var tempFile = Path.Combine(tempDirectory, "scan.sarif");
-            File.WriteAllText(tempFile, sarifContent);
-            SarifTools.SetDiscoveredSarifFiles(new[] { tempFile });
-
-            try
-            {
-                // Act
-                var result = await SarifTools.LoadAndFilterSarif("scan.sarif");
-
-                // Assert
-                Assert.That(result, Contains.Substring("RULE-DISCOVERED"));
-            }
-            finally
-            {
-                Directory.Delete(tempDirectory, true);
-            }
-        }
-
-        [Test]
-        public void ListWorkspaceSarifFiles_WithDiscoveredFiles_ReturnsSerializedList()
-        {
-            // Arrange
-            var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempDirectory);
-            var fileOne = Path.Combine(tempDirectory, "a.sarif");
-            var fileTwo = Path.Combine(tempDirectory, "b.sarif");
-            File.WriteAllText(fileOne, "{}");
-            File.WriteAllText(fileTwo, "{}");
-            SarifTools.SetDiscoveredSarifFiles(new[] { fileOne, fileTwo });
-
-            try
-            {
-                // Act
-                var json = SarifTools.ListWorkspaceSarifFiles();
-                var parsed = JsonSerializer.Deserialize<List<JsonElement>>(json);
-
-                // Assert
-                Assert.That(parsed, Is.Not.Null);
-                Assert.That(parsed!.Count, Is.EqualTo(2));
-            }
-            finally
-            {
-                Directory.Delete(tempDirectory, true);
-            }
-        }
-
-        [Test]
-        public async Task LoadAndFilterSarif_WhenFileDoesNotExist_ReturnsError()
-        {
-            // Arrange
-            var path = "nonexistent.sarif";
-
-            // Act
-            var result = await SarifTools.LoadAndFilterSarif(path);
-
-            // Assert
-            Assert.That(result, Contains.Substring("File not found"));
-        }
-
-        [Test]
-        public async Task LoadAndFilterSarif_WithValidSarif_ReturnsFilteredResults()
-        {
-            // Arrange
-            var sarifContent = @"
-            {
-                ""runs"": [
-                    {
-                        ""results"": [
-                            {
-                                ""ruleId"": ""RULE001"",
-                                ""level"": ""error"",
-                                ""message"": { ""text"": ""Test error"" }
-                            },
-                            {
-                                ""ruleId"": ""RULE002"",
-                                ""level"": ""warning"",
-                                ""message"": { ""text"": ""Test warning"" }
-                            }
-                        ]
-                    }
-                ]
-            }";
-
-            var tempFile = Path.GetTempFileName();
-            File.WriteAllText(tempFile, sarifContent);
-
-            try
-            {
-                // Act
-                var result = await SarifTools.LoadAndFilterSarif(tempFile, severity: "error");
-
-                // Assert
-                Assert.That(result, Contains.Substring("RULE001"));
-                Assert.That(result, Does.Not.Contain("RULE002"));
-            }
-            finally
-            {
-                File.Delete(tempFile);
-            }
-        }
-
-        [Test]
-        public async Task ExtractCodeFlow_WithValidData_ReturnsFlowSteps()
-        {
-            // Arrange
-            var sarifContent = @"
-            {
-                ""runs"": [
-                    {
-                        ""results"": [
-                            {
-                                ""ruleId"": ""RULE001"",
-                                ""codeFlows"": [
-                                    {
-                                        ""threadFlows"": [
-                                            {
-                                                ""locations"": [
-                                                    {
-                                                        ""location"": {
-                                                            ""physicalLocation"": {
-                                                                ""artifactLocation"": {
-                                                                    ""uri"": ""test.cs""
-                                                                },
-                                                                ""region"": {
-                                                                    ""startLine"": 10
-                                                                }
-                                                            },
-                                                            ""message"": {
-                                                                ""text"": ""Step 1""
-                                                            }
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }";
-
-            var tempSarifFile = Path.GetTempFileName();
-            File.WriteAllText(tempSarifFile, sarifContent);
-
-            var tempSourceDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempSourceDir);
-            var tempSourceFile = Path.Combine(tempSourceDir, "test.cs");
-            File.WriteAllText(tempSourceFile, "var x = 1;\nvar y = 2;\nvar z = 3;");
-
-            try
-            {
-                // Act
-                var result = await SarifTools.ExtractCodeFlow(tempSarifFile, "0", tempSourceDir);
-
-                // Assert
-                Assert.That(result, Contains.Substring("RULE001"));
-                Assert.That(result, Contains.Substring("test.cs"));
-                Assert.That(result, Contains.Substring("extracted_code_snippet"));
-            }
-            finally
-            {
-                File.Delete(tempSarifFile);
-                Directory.Delete(tempSourceDir, true);
             }
         }
 
@@ -1054,6 +991,111 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
+        public async Task ManageTriage_WithStatusAction_ReturnsRealPayloadWithoutDummyContent()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "status-facade.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-STATUS",
+                      "level": "warning",
+                      "message": { "text": "status" }
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var result = await SarifTools.manage_triage("status");
+                var textBlock = result.Content[0] as TextContentBlock;
+
+                Assert.That(textBlock, Is.Not.Null);
+                Assert.That(textBlock!.Text, Does.Not.Contain("Dummy payload"));
+                Assert.That(textBlock.Text, Contains.Substring("TotalFindings"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task ManageTriage_WithSqlIssuesAction_FiltersToSqlRelatedRules()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "sql-issues.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "csharp/Sqli",
+                      "level": "error",
+                      "message": { "text": "SQL injection" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Api.cs" },
+                            "region": { "startLine": 12 }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "ruleId": "CA1031",
+                      "level": "warning",
+                      "message": { "text": "catch all" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Api.cs" },
+                            "region": { "startLine": 20 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var result = await SarifTools.manage_triage("sql_issues", filters: "{\"limit\":10}");
+                var textBlock = result.Content[0] as TextContentBlock;
+
+                Assert.That(textBlock, Is.Not.Null);
+                Assert.That(textBlock!.Text, Contains.Substring("csharp/Sqli"));
+                Assert.That(textBlock.Text, Does.Not.Contain("CA1031"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
         public void BuildUiResourceUri_WithDynamicLocalUiBaseUrl_UsesAssignedPort()
         {
             SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
@@ -1067,29 +1109,6 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task AnalyzeSarif_WithListFilesAction_ReturnsDiscoveredFiles()
-        {
-            var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempDirectory);
-            var fileOne = Path.Combine(tempDirectory, "x.sarif");
-            File.WriteAllText(fileOne, "{}");
-            SarifTools.SetDiscoveredSarifFiles(new[] { fileOne });
-
-            try
-            {
-                var result = await SarifTools.analyze_sarif("list_files");
-                var textBlock = result.Content[0] as TextContentBlock;
-
-                Assert.That(textBlock, Is.Not.Null);
-                Assert.That(textBlock!.Text, Contains.Substring("x.sarif"));
-            }
-            finally
-            {
-                Directory.Delete(tempDirectory, true);
-            }
-        }
-
-        [Test]
         public void McpToolExposure_IsLimitedToFacadeTools()
         {
             var toolMethods = typeof(SarifTools)
@@ -1099,7 +1118,19 @@ namespace Sarifintown.AgentEngine.Tests
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToList();
 
-            Assert.That(toolMethods, Is.EqualTo(new[] { "analyze_sarif", "manage_triage" }));
+            Assert.That(toolMethods, Is.EqualTo(new[] { "manage_triage" }));
+        }
+
+        private static object CreateInternalTypeInstance(string typeName)
+        {
+            var type = typeof(SarifTools).Assembly.GetType(typeName, throwOnError: true)!;
+            return Activator.CreateInstance(type)!;
+        }
+
+        private static void SetInternalSarifToolsProperty(string propertyName, object? value)
+        {
+            var property = typeof(SarifTools).GetProperty(propertyName, BindingFlags.Static | BindingFlags.NonPublic);
+            property!.SetValue(null, value);
         }
     }
 }

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -33,6 +33,60 @@ namespace Sarifintown.AgentEngine.Tests
             }
         }
 
+        [Test]
+        public async Task SarifTriage_WithDisplayAliasTarget_ResolvesToUnderlyingFindingId()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "alias-target.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-ALIAS",
+                      "level": "error",
+                      "message": { "text": "alias target" }
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var getResult = await SarifTools.SarifGet(scope: "set", filter: "severity:high", limit: 10);
+                var stateContext = JsonSerializer.SerializeToElement(getResult.Meta);
+                var alias = stateContext
+                    .GetProperty("context")
+                    .GetProperty("aliases")[0]
+                    .GetProperty("displayid")
+                    .GetString();
+
+                Assert.That(alias, Is.Not.Null.And.Not.Empty);
+
+                var triageResult = await SarifTools.SarifTriage(
+                    state: "confirmed",
+                    reason: "alias-validated",
+                    target: alias!);
+
+                var triageText = triageResult.Content[0] as TextContentBlock;
+                Assert.That(triageText, Is.Not.Null);
+                Assert.That(triageText!.Text, Contains.Substring("Affected findings: **1**"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
         private class FakeTreeSitterEngine : ITreeSitterEngine
         {
             private static int _extractMethodCallCount;
@@ -185,7 +239,7 @@ namespace Sarifintown.AgentEngine.Tests
                 await SarifTools.SarifGet(scope: "set", filter: "severity:high");
 
                 var triageResult = await SarifTools.SarifTriage(
-                    state: "TP",
+                    state: "confirmed",
                     reason: "validated",
                     target: "scope");
 
@@ -197,6 +251,13 @@ namespace Sarifintown.AgentEngine.Tests
             {
                 Directory.Delete(workspace, true);
             }
+        }
+
+        [Test]
+        public void SarifTriage_WithInvalidState_ThrowsArgumentException()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await SarifTools.SarifTriage(state: "tp", reason: "invalid", target: "scope"));
         }
 
         [Test]

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -1,5 +1,5 @@
-using ModelContextProtocol.Server;
 using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 using NUnit.Framework;
 using Sarifintown.AgentEngine;
 using Sarifintown.Core;
@@ -24,494 +24,12 @@ namespace Sarifintown.AgentEngine.Tests
                     return Task.FromResult(content);
                 }
 
-                // Fallback to actual file read if not in dictionary
                 if (File.Exists(relativePath))
                 {
                     return File.ReadAllTextAsync(relativePath);
                 }
+
                 throw new FileNotFoundException($"File not found: {relativePath}");
-            }
-        }
-
-        [Test]
-        public async Task ManageTriage_WithQueryAction_ReturnsStatusAndPrioritizedFindingsInSingleResponse()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "facade-query.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-QUERY",
-                      "level": "error",
-                      "message": { "text": "query me" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Query.cs" },
-                            "region": { "startLine": 11 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var queryResult = await SarifTools.manage_triage("query", filters: "{\"limit\":1}");
-                var queryText = queryResult.Content[0] as TextContentBlock;
-
-                Assert.That(queryText, Is.Not.Null);
-                Assert.That(queryText!.Text, Contains.Substring("## SARIF Triage Query"));
-                Assert.That(queryText.Text, Contains.Substring("Total findings"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task ManageTriage_WithDecideActionAndFindingIdsFilter_AppliesMultiTargetDecision()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "facade-decide-ids.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-IDS-1",
-                      "level": "error",
-                      "message": { "text": "first" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Ids1.cs" },
-                            "region": { "startLine": 5 }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "ruleId": "RULE-IDS-2",
-                      "level": "warning",
-                      "message": { "text": "second" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Ids2.cs" },
-                            "region": { "startLine": 7 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 2);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingIds = string.Join(",", listPayload!.Select(item => item.GetProperty("FindingId").GetString()));
-
-                var decideResult = await SarifTools.manage_triage(
-                    "decide",
-                    state: "FP",
-                    reason: "campaign",
-                    filters: $"{{\"findingIds\":\"{findingIds}\"}}");
-
-                var decideText = decideResult.Content[0] as TextContentBlock;
-                Assert.That(decideText, Is.Not.Null);
-                Assert.That(decideText!.Text, Contains.Substring("## Bulk Triage Result"));
-                Assert.That(decideText.Text, Contains.Substring("Affected Findings: **2**"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageList_WithLatestPerToolPreload_IncludesOnlyNewestFilePerTool()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var olderToolAPath = Path.Combine(sarifDirectory, "tool-a-older.sarif");
-            File.WriteAllText(olderToolAPath, """
-            {
-              "runs": [
-                {
-                  "tool": { "driver": { "name": "ToolA" } },
-                  "results": [
-                    {
-                      "ruleId": "RULE-OLD",
-                      "level": "warning",
-                      "message": { "text": "old" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/old.cs" },
-                            "region": { "startLine": 1 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            var latestToolAPath = Path.Combine(sarifDirectory, "tool-a-latest.sarif");
-            File.WriteAllText(latestToolAPath, """
-            {
-              "runs": [
-                {
-                  "tool": { "driver": { "name": "ToolA" } },
-                  "results": [
-                    {
-                      "ruleId": "RULE-NEW",
-                      "level": "error",
-                      "message": { "text": "new" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/new.cs" },
-                            "region": { "startLine": 2 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            var toolBPath = Path.Combine(sarifDirectory, "tool-b.sarif");
-            File.WriteAllText(toolBPath, """
-            {
-              "runs": [
-                {
-                  "tool": { "driver": { "name": "ToolB" } },
-                  "results": [
-                    {
-                      "ruleId": "RULE-B",
-                      "level": "warning",
-                      "message": { "text": "b" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/b.cs" },
-                            "region": { "startLine": 3 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            var baseline = DateTime.UtcNow;
-            File.SetLastWriteTimeUtc(olderToolAPath, baseline.AddMinutes(-5));
-            File.SetLastWriteTimeUtc(latestToolAPath, baseline.AddMinutes(-1));
-            File.SetLastWriteTimeUtc(toolBPath, baseline.AddMinutes(-2));
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { olderToolAPath, latestToolAPath, toolBPath });
-
-            try
-            {
-                var responseJson = await SarifTools.TriageList(limit: 10);
-                var payload = JsonSerializer.Deserialize<List<JsonElement>>(responseJson);
-                var ruleNames = payload!.Select(item => item.GetProperty("RuleName").GetString()).ToList();
-
-                Assert.That(ruleNames, Is.EqualTo(new[] { "RULE-NEW", "RULE-B" }));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task ManageTriage_WithDecideAndBulkActions_ReturnsMarkdownSummaries()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "facade-decide-bulk.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-FACADE-DECIDE",
-                      "level": "error",
-                      "message": { "text": "triage me" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Facade.cs" },
-                            "region": { "startLine": 9 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
-
-                var decideResult = await SarifTools.manage_triage("decide", findingId!, state: "TP", reason: "validated");
-                var decideText = decideResult.Content[0] as TextContentBlock;
-
-                Assert.That(decideText, Is.Not.Null);
-                Assert.That(decideText!.Text, Contains.Substring("## Triage Decision Result"));
-                Assert.That(decideText.Text, Does.Not.Contain("```json"));
-
-                var bulkResult = await SarifTools.manage_triage("bulk_decide", state: "FP", reason: "bulk-noise", filters: "{\"rule\":\"RULE-FACADE-DECIDE\",\"dryRun\":true}");
-                var bulkText = bulkResult.Content[0] as TextContentBlock;
-
-                Assert.That(bulkText, Is.Not.Null);
-                Assert.That(bulkText!.Text, Contains.Substring("## Bulk Triage Result"));
-                Assert.That(bulkText.Text, Does.Not.Contain("```json"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [TestCase("true positive", "TP")]
-        [TestCase("false positive", "FP")]
-        public async Task Triage_WithNaturalLanguageState_MapsToExpectedState(string inputState, string expectedState)
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "triage-state-alias.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-ALIAS",
-                      "level": "error",
-                      "message": { "text": "Alias test" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/a.cs" },
-                            "region": { "startLine": 7 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-            SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
-
-                var triageJson = await SarifTools.Triage(findingId!, inputState, "confirmed", "AI");
-                var triagePayload = JsonSerializer.Deserialize<JsonElement>(triageJson);
-
-                Assert.That(triagePayload.GetProperty("State").GetString(), Is.EqualTo(expectedState));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageInspect_WithLineWindowConcatenated_MergesNearbySteps()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            var sourceDirectory = Path.Combine(workspace, "src");
-            Directory.CreateDirectory(sarifDirectory);
-            Directory.CreateDirectory(sourceDirectory);
-
-            var sourcePath = Path.Combine(sourceDirectory, "Flow.cs");
-            File.WriteAllText(sourcePath, string.Join("\n", Enumerable.Range(1, 40).Select(index => $"line {index}")));
-
-            var sarifPath = Path.Combine(sarifDirectory, "inspect.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-FLOW",
-                      "message": { "text": "flow" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Flow.cs" },
-                            "region": { "startLine": 10 }
-                          }
-                        }
-                      ],
-                      "codeFlows": [
-                        {
-                          "threadFlows": [
-                            {
-                              "locations": [
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 10 } } } },
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 14 } } } },
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Flow.cs" }, "region": { "startLine": 30 } } } }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
-
-                var inspectJson = await SarifTools.TriageInspect(findingId!, "line-window-concatenated");
-                var inspectPayload = JsonSerializer.Deserialize<JsonElement>(inspectJson);
-
-                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceMode").GetString(), Is.EqualTo("line-window-concatenated"));
-                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceBlocks").GetArrayLength(), Is.EqualTo(2));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageInspect_WithLineWindowStrict_UsesPerStepBlocks()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            var sourceDirectory = Path.Combine(workspace, "src");
-            Directory.CreateDirectory(sarifDirectory);
-            Directory.CreateDirectory(sourceDirectory);
-
-            var sourcePath = Path.Combine(sourceDirectory, "Strict.cs");
-            File.WriteAllText(sourcePath, string.Join("\n", Enumerable.Range(1, 20).Select(index => $"line {index}")));
-
-            var sarifPath = Path.Combine(sarifDirectory, "strict-inspect.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-STRICT",
-                      "message": { "text": "flow" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Strict.cs" },
-                            "region": { "startLine": 4 }
-                          }
-                        }
-                      ],
-                      "codeFlows": [
-                        {
-                          "threadFlows": [
-                            {
-                              "locations": [
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Strict.cs" }, "region": { "startLine": 4 } } } },
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Strict.cs" }, "region": { "startLine": 9 } } } }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
-
-                var inspectJson = await SarifTools.TriageInspect(findingId!, "line-window-strict");
-                var inspectPayload = JsonSerializer.Deserialize<JsonElement>(inspectJson);
-
-                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceMode").GetString(), Is.EqualTo("line-window-strict"));
-                Assert.That(inspectPayload.GetProperty("DataFlowEvidenceBlocks").GetArrayLength(), Is.EqualTo(2));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
             }
         }
 
@@ -550,84 +68,13 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task TriageInspect_WithSharedSnippetCache_ReusesExtractedMethodAcrossCalls()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            var sourceDirectory = Path.Combine(workspace, "src");
-            Directory.CreateDirectory(sarifDirectory);
-            Directory.CreateDirectory(sourceDirectory);
-
-            var sourcePath = Path.Combine(sourceDirectory, "Cached.cs");
-            File.WriteAllText(sourcePath, "class Cached { void Run() { } }");
-
-            var sarifPath = Path.Combine(sarifDirectory, "cached-inspect.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-CACHED",
-                      "message": { "text": "flow" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Cached.cs" },
-                            "region": { "startLine": 1 }
-                          }
-                        }
-                      ],
-                      "codeFlows": [
-                        {
-                          "threadFlows": [
-                            {
-                              "locations": [
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/Cached.cs" }, "region": { "startLine": 1, "endLine": 1 } } } }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-            SetInternalSarifToolsProperty("SnippetCache", CreateInternalTypeInstance("Sarifintown.AgentEngine.SnippetCacheService"));
-
-            try
-            {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
-
-                var firstInspect = await SarifTools.TriageInspect(findingId!);
-                var secondInspect = await SarifTools.TriageInspect(findingId!);
-
-                Assert.That(firstInspect, Contains.Substring("extracted_code_snippet"));
-                Assert.That(secondInspect, Contains.Substring("extracted_code_snippet"));
-                Assert.That(FakeTreeSitterEngine.ExtractMethodCallCount, Is.EqualTo(1));
-            }
-            finally
-            {
-                SetInternalSarifToolsProperty("SnippetCache", null);
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageStatus_WithTriageState_ReturnsAggregatedCounts()
+        public async Task SarifGet_WithScopeLifecycle_ReturnsScopedEnvelopeAndMetrics()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
             Directory.CreateDirectory(sarifDirectory);
 
-            var sarifPath = Path.Combine(sarifDirectory, "status.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "scope-lifecycle.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
@@ -636,11 +83,11 @@ namespace Sarifintown.AgentEngine.Tests
                     {
                       "ruleId": "RULE-HIGH",
                       "level": "error",
-                      "message": { "text": "High issue" },
+                      "message": { "text": "high" },
                       "locations": [
                         {
                           "physicalLocation": {
-                            "artifactLocation": { "uri": "src/one.cs" },
+                            "artifactLocation": { "uri": "src/high.cs" },
                             "region": { "startLine": 10 }
                           }
                         }
@@ -649,11 +96,11 @@ namespace Sarifintown.AgentEngine.Tests
                     {
                       "ruleId": "RULE-MED",
                       "level": "warning",
-                      "message": { "text": "Medium issue" },
+                      "message": { "text": "med" },
                       "locations": [
                         {
                           "physicalLocation": {
-                            "artifactLocation": { "uri": "src/two.cs" },
+                            "artifactLocation": { "uri": "src/med.cs" },
                             "region": { "startLine": 20 }
                           }
                         }
@@ -670,33 +117,25 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                var findingsJson = await SarifTools.TriageList(limit: 5);
-                var findings = JsonSerializer.Deserialize<List<JsonElement>>(findingsJson);
-                var findingId = findings![0].GetProperty("FindingId").GetString();
+                var setResult = await SarifTools.SarifGet(scope: "set", filter: "severity:high", limit: 10);
+                var setMeta = JsonSerializer.SerializeToElement(setResult.Meta);
 
-                var triagePath = Path.Combine(sarifDirectory, "triage.json");
-                File.WriteAllText(triagePath, JsonSerializer.Serialize(new
-                {
-                    schemaVersion = 1,
-                    entries = new[]
-                    {
-                        new
-                        {
-                            findingId,
-                            state = "FP",
-                            reason = "known noise",
-                            author = "AI",
-                            updatedUtc = "2025-01-01T00:00:00Z"
-                        }
-                    }
-                }));
+                Assert.That(setMeta.GetProperty("context").GetProperty("active_scope").GetProperty("severity").GetString(), Is.EqualTo("high"));
+                Assert.That(setMeta.GetProperty("context").GetProperty("metrics").GetProperty("total_in_scope").GetInt32(), Is.EqualTo(1));
+                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## SARIF Scoped Query"));
+                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring(SarifTools.StateContextDelimiter));
 
-                var responseJson = await SarifTools.TriageStatus();
-                var payload = JsonSerializer.Deserialize<JsonElement>(responseJson);
+                var refineResult = await SarifTools.SarifGet(scope: "refine", filter: "rule:RULE-HIGH", limit: 10);
+                var refineMeta = JsonSerializer.SerializeToElement(refineResult.Meta);
 
-                Assert.That(payload.GetProperty("TotalFindings").GetInt32(), Is.EqualTo(2));
-                Assert.That(payload.GetProperty("TriagedCount").GetInt32(), Is.EqualTo(1));
-                Assert.That(payload.GetProperty("OpenCount").GetInt32(), Is.EqualTo(1));
+                Assert.That(refineMeta.GetProperty("context").GetProperty("active_scope").GetProperty("severity").GetString(), Is.EqualTo("high"));
+                Assert.That(refineMeta.GetProperty("context").GetProperty("active_scope").GetProperty("rule").GetString(), Is.EqualTo("RULE-HIGH"));
+
+                var clearResult = await SarifTools.SarifGet(scope: "clear", limit: 10);
+                var clearMeta = JsonSerializer.SerializeToElement(clearResult.Meta);
+
+                Assert.That(clearMeta.GetProperty("context").GetProperty("active_scope").EnumerateObject().Count(), Is.EqualTo(0));
+                Assert.That(clearMeta.GetProperty("context").GetProperty("metrics").GetProperty("total_in_scope").GetInt32(), Is.EqualTo(2));
             }
             finally
             {
@@ -705,88 +144,13 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task TriageList_WithFilters_ReturnsPrioritizedItems()
+        public async Task SarifTriage_WithScopeTarget_AppliesDecisionToActiveScope()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
             Directory.CreateDirectory(sarifDirectory);
 
-            var sarifPath = Path.Combine(sarifDirectory, "list.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "SQLInjection",
-                      "level": "error",
-                      "message": { "text": "Critical path" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/UserController.cs" },
-                            "region": { "startLine": 15 }
-                          }
-                        }
-                      ],
-                      "codeFlows": [
-                        {
-                          "threadFlows": [
-                            {
-                              "locations": [
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/UserController.cs" }, "region": { "startLine": 15 } } } },
-                                { "location": { "physicalLocation": { "artifactLocation": { "uri": "src/UserController.cs" }, "region": { "startLine": 32 } } } }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "ruleId": "CA1031",
-                      "level": "warning",
-                      "message": { "text": "Lower priority" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "tests/Ignore.cs" },
-                            "region": { "startLine": 8 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var responseJson = await SarifTools.TriageList(severity: "High", file: "*UserController.cs", limit: 5);
-                var payload = JsonSerializer.Deserialize<List<JsonElement>>(responseJson);
-
-                Assert.That(payload, Is.Not.Null);
-                Assert.That(payload!.Count, Is.EqualTo(1));
-                Assert.That(payload[0].GetProperty("RuleName").GetString(), Is.EqualTo("SQLInjection"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task Triage_And_TriageBulkDryRun_UpdateAndPreviewState()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "triage.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "scope-target.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
@@ -795,28 +159,17 @@ namespace Sarifintown.AgentEngine.Tests
                     {
                       "ruleId": "RULE-ONE",
                       "level": "error",
-                      "message": { "text": "One" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/a.cs" },
-                            "region": { "startLine": 7 }
-                          }
-                        }
-                      ]
+                      "message": { "text": "one" }
                     },
                     {
                       "ruleId": "RULE-TWO",
+                      "level": "error",
+                      "message": { "text": "two" }
+                    },
+                    {
+                      "ruleId": "RULE-THREE",
                       "level": "warning",
-                      "message": { "text": "Two" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/b.cs" },
-                            "region": { "startLine": 9 }
-                          }
-                        }
-                      ]
+                      "message": { "text": "three" }
                     }
                   ]
                 }
@@ -829,21 +182,16 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                var listJson = await SarifTools.TriageList(limit: 1);
-                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
-                var findingId = listPayload![0].GetProperty("FindingId").GetString();
+                await SarifTools.SarifGet(scope: "set", filter: "severity:high");
 
-                var triageJson = await SarifTools.Triage(findingId!, "TP", "validated", "User");
-                var triagePayload = JsonSerializer.Deserialize<JsonElement>(triageJson);
-                Assert.That(triagePayload.GetProperty("Success").GetBoolean(), Is.True);
+                var triageResult = await SarifTools.SarifTriage(
+                    state: "TP",
+                    reason: "validated",
+                    target: "scope");
 
-                var triageFileJson = File.ReadAllText(Path.Combine(sarifDirectory, "triage.json"));
-                Assert.That(triageFileJson, Does.Contain("validated"));
-
-                var dryRunJson = await SarifTools.TriageBulk("FP", "noise", severity: "Medium", dryRun: true);
-                var dryRunPayload = JsonSerializer.Deserialize<JsonElement>(dryRunJson);
-                Assert.That(dryRunPayload.GetProperty("DryRun").GetBoolean(), Is.True);
-                Assert.That(dryRunPayload.GetProperty("AffectedCount").GetInt32(), Is.EqualTo(1));
+                var triageText = triageResult.Content[0] as TextContentBlock;
+                Assert.That(triageText, Is.Not.Null);
+                Assert.That(triageText!.Text, Contains.Substring("Affected findings: **2**"));
             }
             finally
             {
@@ -852,9 +200,19 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
+        public void ResolveInteractiveSurface_WithCursorHostHint_ReturnsUiUri()
+        {
+            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Cursor");
+            var payload = JsonSerializer.Deserialize<JsonElement>(result);
+
+            Assert.That(payload.GetProperty("uri").GetString(), Is.EqualTo("ui://sarifintown/mcp/dashboard"));
+            Assert.That(payload.GetProperty("bridge").GetProperty("transport").GetString(), Is.EqualTo("postMessage"));
+            Assert.That(payload.GetProperty("bridge").GetProperty("channel").GetString(), Is.EqualTo("sarifintown.mcp.v1"));
+        }
+
+        [Test]
         public void GenerateAnalysisReport_WithValidData_CreatesMarkdownFile()
         {
-            // Arrange
             var resultId = "0";
             var extractedFlowData = @"{
                 ""rule_id"": ""RULE001"",
@@ -871,10 +229,8 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                // Act
                 var result = SarifTools.GenerateAnalysisReport(resultId, extractedFlowData, outputPath);
 
-                // Assert
                 Assert.That(result, Contains.Substring("Report generated successfully"));
                 var fileContent = File.ReadAllText(outputPath);
                 Assert.That(fileContent, Contains.Substring("# Vulnerability Analysis Report"));
@@ -889,425 +245,16 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task TriageStatusGuided_ReturnsDirectiveAndNextStepMetadata()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "guided-status.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-GUIDED",
-                      "level": "warning",
-                      "message": { "text": "Guided status" }
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.TriageStatusGuided();
-                var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-                Assert.That(payload.GetProperty("protocol").GetString(), Is.EqualTo("sarifintown.guided.v1"));
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
-                Assert.That(payload.GetProperty("pause").GetProperty("required").GetBoolean(), Is.True);
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageListGuided_ReturnsTableAndInspectNextStep()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "guided-list.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-LIST",
-                      "level": "error",
-                      "message": { "text": "Guided list" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/list.cs" },
-                            "region": { "startLine": 12 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.TriageListGuided(limit: 5);
-                var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
-                Assert.That(payload.GetProperty("markdown").GetString(), Contains.Substring("| FindingId | Severity | State | Rule | Location |"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task TriageInspectGuided_WithUnknownFinding_ReturnsListRecoveryStep()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "guided-inspect.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-INSPECT",
-                      "level": "warning",
-                      "message": { "text": "Guided inspect" }
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.TriageInspectGuided("missing-id");
-                var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
-                Assert.That(payload.GetProperty("markdown").GetString(), Contains.Substring("Finding Not Found"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithVsCodeHostHint_ReturnsUiMode()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Visual Studio Code");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("mode").GetString(), Is.EqualTo("ide-ui"));
-            Assert.That(payload.GetProperty("host_family").GetString(), Is.EqualTo("vscode-family"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithCursorHostHint_ReturnsUiUri()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Cursor");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("uri").GetString(), Is.EqualTo("ui://sarifintown/mcp/dashboard"));
-            Assert.That(payload.GetProperty("bridge").GetProperty("transport").GetString(), Is.EqualTo("postMessage"));
-            Assert.That(payload.GetProperty("bridge").GetProperty("channel").GetString(), Is.EqualTo("sarifintown.mcp.v1"));
-            Assert.That(payload.GetProperty("local_http_ui").GetProperty("available").GetBoolean(), Is.False);
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithLocalUiBaseUrl_ReturnsLocalhostFallbackUri()
-        {
-            // Arrange
-            SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
-
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Visual Studio Code");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("local_http_ui").GetProperty("available").GetBoolean(), Is.True);
-            Assert.That(payload.GetProperty("local_http_ui").GetProperty("uri").GetString(), Is.EqualTo("http://127.0.0.1:54321/mcp/dashboard"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithClaudeHostHint_ReturnsSpectreTui()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Claude Code");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("tui").GetProperty("library").GetString(), Is.EqualTo("Spectre.Console"));
-            Assert.That(payload.GetProperty("host_family").GetString(), Is.EqualTo("terminal-family"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithWindsurfHostHint_ReturnsIdeUiMode()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Windsurf");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("mode").GetString(), Is.EqualTo("ide-ui"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithRiderHostHint_ReturnsIdeUiMode()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "JetBrains Rider");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("mode").GetString(), Is.EqualTo("ide-ui"));
-            Assert.That(payload.GetProperty("host_family").GetString(), Is.EqualTo("jetbrains-family"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithPowerShellHostHint_ReturnsCliTuiMode()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "PowerShell");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("mode").GetString(), Is.EqualTo("cli-tui"));
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithUnknownHostHint_DoesNotSetFallbackUsed()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "Some Future MCP Host");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("fallback_used").GetBoolean(), Is.False);
-        }
-
-        [Test]
-        public void ResolveInteractiveSurface_WithEmptyHint_UsesFallback()
-        {
-            // Act
-            var result = SarifTools.ResolveInteractiveSurface(null!, hostHint: "");
-            var payload = JsonSerializer.Deserialize<JsonElement>(result);
-
-            // Assert
-            Assert.That(payload.GetProperty("fallback_used").GetBoolean(), Is.True);
-        }
-
-        [Test]
-        public async Task ManageTriage_WithGuidedStatusAction_ReturnsGuidedPayload()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "guided-facade.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-FACADE",
-                      "level": "warning",
-                      "message": { "text": "facade" }
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.manage_triage("status", filters: "{\"guided\":true}");
-                Assert.That(result.Content, Is.Not.Null);
-                Assert.That(result.Content.Count, Is.EqualTo(1));
-
-                var textBlock = result.Content[0] as TextContentBlock;
-                Assert.That(textBlock, Is.Not.Null);
-                Assert.That(textBlock!.Text, Contains.Substring("[INSTRUCTIONS FOR LLM]"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task ManageTriage_WithStatusAction_ReturnsRealPayloadWithoutDummyContent()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "status-facade.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "RULE-STATUS",
-                      "level": "warning",
-                      "message": { "text": "status" }
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.manage_triage("status");
-                var textBlock = result.Content[0] as TextContentBlock;
-
-                Assert.That(textBlock, Is.Not.Null);
-                Assert.That(textBlock!.Text, Does.Not.Contain("Dummy payload"));
-                Assert.That(textBlock.Text, Contains.Substring("## SARIF Triage Status"));
-                Assert.That(textBlock.Text, Does.Not.Contain("```json"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public async Task ManageTriage_WithSqlIssuesAction_FiltersToSqlRelatedRules()
-        {
-            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var sarifDirectory = Path.Combine(workspace, ".sarif");
-            Directory.CreateDirectory(sarifDirectory);
-
-            var sarifPath = Path.Combine(sarifDirectory, "sql-issues.sarif");
-            File.WriteAllText(sarifPath, """
-            {
-              "runs": [
-                {
-                  "results": [
-                    {
-                      "ruleId": "csharp/Sqli",
-                      "level": "error",
-                      "message": { "text": "SQL injection" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Api.cs" },
-                            "region": { "startLine": 12 }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "ruleId": "CA1031",
-                      "level": "warning",
-                      "message": { "text": "catch all" },
-                      "locations": [
-                        {
-                          "physicalLocation": {
-                            "artifactLocation": { "uri": "src/Api.cs" },
-                            "region": { "startLine": 20 }
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-
-            SarifTools.SetWorkspaceRoot(workspace);
-            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-
-            try
-            {
-                var result = await SarifTools.manage_triage("sql_issues", filters: "{\"limit\":10}");
-                var textBlock = result.Content[0] as TextContentBlock;
-
-                Assert.That(textBlock, Is.Not.Null);
-                Assert.That(textBlock!.Text, Contains.Substring("csharp/Sqli"));
-                Assert.That(textBlock.Text, Does.Not.Contain("CA1031"));
-            }
-            finally
-            {
-                Directory.Delete(workspace, true);
-            }
-        }
-
-        [Test]
-        public void BuildUiResourceUri_WithDynamicLocalUiBaseUrl_UsesAssignedPort()
-        {
-            SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
-
-            var method = typeof(SarifTools)
-                .GetMethod("BuildUiResourceUri", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-            var value = method!.Invoke(null, new object[] { "triage", "status", string.Empty }) as string;
-
-            Assert.That(value, Does.StartWith("http://127.0.0.1:54321/"));
-        }
-
-        [Test]
-        public void McpToolExposure_IsLimitedToFacadeTools()
+        public void McpToolExposure_ContainsStatefulTools()
         {
             var toolMethods = typeof(SarifTools)
-                .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Where(method => method.GetCustomAttributes(typeof(McpServerToolAttribute), inherit: false).Length > 0)
                 .Select(method => method.Name)
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToList();
 
-            Assert.That(toolMethods, Is.EqualTo(new[] { "manage_triage" }));
-        }
-
-        private static object CreateInternalTypeInstance(string typeName)
-        {
-            var type = typeof(SarifTools).Assembly.GetType(typeName, throwOnError: true)!;
-            return Activator.CreateInstance(type)!;
+            Assert.That(toolMethods, Is.EqualTo(new[] { "SarifGet", "SarifTriage" }));
         }
 
         private static void SetInternalSarifToolsProperty(string propertyName, object? value)

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -1,3 +1,5 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
 using NUnit.Framework;
 using Sarifintown.AgentEngine;
 using Sarifintown.Core;
@@ -64,6 +66,7 @@ namespace Sarifintown.AgentEngine.Tests
 
             SarifTools.SetWorkspaceRoot(workspace);
             SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+            SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
 
             try
             {
@@ -799,7 +802,7 @@ namespace Sarifintown.AgentEngine.Tests
                 var payload = JsonSerializer.Deserialize<JsonElement>(result);
 
                 Assert.That(payload.GetProperty("protocol").GetString(), Is.EqualTo("sarifintown.guided.v1"));
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("TriageListGuided"));
+                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
                 Assert.That(payload.GetProperty("pause").GetProperty("required").GetBoolean(), Is.True);
             }
             finally
@@ -848,7 +851,7 @@ namespace Sarifintown.AgentEngine.Tests
                 var result = await SarifTools.TriageListGuided(limit: 5);
                 var payload = JsonSerializer.Deserialize<JsonElement>(result);
 
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("TriageInspectGuided"));
+                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
                 Assert.That(payload.GetProperty("markdown").GetString(), Contains.Substring("| FindingId | Severity | State | Rule | Location |"));
             }
             finally
@@ -889,7 +892,7 @@ namespace Sarifintown.AgentEngine.Tests
                 var result = await SarifTools.TriageInspectGuided("missing-id");
                 var payload = JsonSerializer.Deserialize<JsonElement>(result);
 
-                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("TriageListGuided"));
+                Assert.That(payload.GetProperty("next_step").GetProperty("tool").GetString(), Is.EqualTo("manage_triage"));
                 Assert.That(payload.GetProperty("markdown").GetString(), Contains.Substring("Finding Not Found"));
             }
             finally
@@ -1005,6 +1008,98 @@ namespace Sarifintown.AgentEngine.Tests
 
             // Assert
             Assert.That(payload.GetProperty("fallback_used").GetBoolean(), Is.True);
+        }
+
+        [Test]
+        public async Task ManageTriage_WithGuidedStatusAction_ReturnsGuidedPayload()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "guided-facade.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-FACADE",
+                      "level": "warning",
+                      "message": { "text": "facade" }
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var result = await SarifTools.manage_triage("status", filters: "{\"guided\":true}");
+                Assert.That(result.Content, Is.Not.Null);
+                Assert.That(result.Content.Count, Is.EqualTo(1));
+
+                var textBlock = result.Content[0] as TextContentBlock;
+                Assert.That(textBlock, Is.Not.Null);
+                Assert.That(textBlock!.Text, Contains.Substring("[INSTRUCTIONS FOR LLM]"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public void BuildUiResourceUri_WithDynamicLocalUiBaseUrl_UsesAssignedPort()
+        {
+            SarifTools.SetLocalUiBaseUrl("http://127.0.0.1:54321");
+
+            var method = typeof(SarifTools)
+                .GetMethod("BuildUiResourceUri", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+            var value = method!.Invoke(null, new object[] { "triage", "status", string.Empty }) as string;
+
+            Assert.That(value, Does.StartWith("http://127.0.0.1:54321/"));
+        }
+
+        [Test]
+        public async Task AnalyzeSarif_WithListFilesAction_ReturnsDiscoveredFiles()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDirectory);
+            var fileOne = Path.Combine(tempDirectory, "x.sarif");
+            File.WriteAllText(fileOne, "{}");
+            SarifTools.SetDiscoveredSarifFiles(new[] { fileOne });
+
+            try
+            {
+                var result = await SarifTools.analyze_sarif("list_files");
+                var textBlock = result.Content[0] as TextContentBlock;
+
+                Assert.That(textBlock, Is.Not.Null);
+                Assert.That(textBlock!.Text, Contains.Substring("x.sarif"));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        [Test]
+        public void McpToolExposure_IsLimitedToFacadeTools()
+        {
+            var toolMethods = typeof(SarifTools)
+                .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .Where(method => method.GetCustomAttributes(typeof(McpServerToolAttribute), inherit: false).Length > 0)
+                .Select(method => method.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.That(toolMethods, Is.EqualTo(new[] { "analyze_sarif", "manage_triage" }));
         }
     }
 }

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -34,6 +34,127 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
+        public async Task ManageTriage_WithQueryAction_ReturnsStatusAndPrioritizedFindingsInSingleResponse()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "facade-query.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-QUERY",
+                      "level": "error",
+                      "message": { "text": "query me" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Query.cs" },
+                            "region": { "startLine": 11 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var queryResult = await SarifTools.manage_triage("query", filters: "{\"limit\":1}");
+                var queryText = queryResult.Content[0] as TextContentBlock;
+
+                Assert.That(queryText, Is.Not.Null);
+                Assert.That(queryText!.Text, Contains.Substring("## SARIF Triage Query"));
+                Assert.That(queryText.Text, Contains.Substring("Total findings"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task ManageTriage_WithDecideActionAndFindingIdsFilter_AppliesMultiTargetDecision()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "facade-decide-ids.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "results": [
+                    {
+                      "ruleId": "RULE-IDS-1",
+                      "level": "error",
+                      "message": { "text": "first" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Ids1.cs" },
+                            "region": { "startLine": 5 }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "ruleId": "RULE-IDS-2",
+                      "level": "warning",
+                      "message": { "text": "second" },
+                      "locations": [
+                        {
+                          "physicalLocation": {
+                            "artifactLocation": { "uri": "src/Ids2.cs" },
+                            "region": { "startLine": 7 }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                var listJson = await SarifTools.TriageList(limit: 2);
+                var listPayload = JsonSerializer.Deserialize<List<JsonElement>>(listJson);
+                var findingIds = string.Join(",", listPayload!.Select(item => item.GetProperty("FindingId").GetString()));
+
+                var decideResult = await SarifTools.manage_triage(
+                    "decide",
+                    state: "FP",
+                    reason: "campaign",
+                    filters: $"{{\"findingIds\":\"{findingIds}\"}}");
+
+                var decideText = decideResult.Content[0] as TextContentBlock;
+                Assert.That(decideText, Is.Not.Null);
+                Assert.That(decideText!.Text, Contains.Substring("## Bulk Triage Result"));
+                Assert.That(decideText.Text, Contains.Substring("Affected Findings: **2**"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
         public async Task TriageList_WithLatestPerToolPreload_IncludesOnlyNewestFilePerTool()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/Sarifintown.AgentEngine/CodeLanguageResolver.cs
+++ b/Sarifintown.AgentEngine/CodeLanguageResolver.cs
@@ -1,0 +1,33 @@
+namespace Sarifintown.AgentEngine;
+
+internal static class CodeLanguageResolver
+{
+    internal static string GetLanguageFromExtension(string extension)
+    {
+        return extension.ToLowerInvariant() switch
+        {
+            ".cs" => "csharp",
+            ".js" => "javascript",
+            ".ts" => "typescript",
+            ".py" => "python",
+            ".java" => "java",
+            ".cpp" => "cpp",
+            ".c" => "c",
+            ".go" => "go",
+            ".rs" => "rust",
+            ".rb" => "ruby",
+            ".php" => "php",
+            ".html" => "html",
+            ".css" => "css",
+            ".json" => "json",
+            ".xml" => "xml",
+            ".yaml" => "yaml",
+            ".yml" => "yaml",
+            ".md" => "markdown",
+            ".sh" => "bash",
+            ".ps1" => "powershell",
+            ".sql" => "sql",
+            _ => string.Empty
+        };
+    }
+}

--- a/Sarifintown.AgentEngine/Configuration/SarifPreloadOptions.cs
+++ b/Sarifintown.AgentEngine/Configuration/SarifPreloadOptions.cs
@@ -1,0 +1,19 @@
+namespace Sarifintown.AgentEngine.Configuration;
+
+internal enum PreloadStrategy
+{
+    None = 0,
+    LatestPerTool = 1,
+    All = 2
+}
+
+internal sealed class SarifPreloadOptions
+{
+    public const string SectionName = "Preload";
+
+    public PreloadStrategy Strategy { get; set; } = PreloadStrategy.LatestPerTool;
+
+    public bool EnableSnippetPreload { get; set; } = true;
+
+    public int MaxPreloadedSnippets { get; set; } = 50;
+}

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -1,26 +1,90 @@
-﻿using Microsoft.AspNetCore.Hosting.Server;
+﻿using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
 using Sarifintown.AgentEngine;
+using Sarifintown.AgentEngine.Configuration;
 using Sarifintown.Core;
+
+AppDomain.CurrentDomain.UnhandledException += (_, eventArgs) =>
+{
+    if (eventArgs.ExceptionObject is Exception exception)
+    {
+        WriteStartupError("Unhandled exception", exception);
+        return;
+    }
+
+    WriteStartupError($"Unhandled non-exception error: {eventArgs.ExceptionObject}");
+};
+
+TaskScheduler.UnobservedTaskException += (_, eventArgs) =>
+{
+    WriteStartupError("Unobserved task exception", eventArgs.Exception);
+    eventArgs.SetObserved();
+};
 
 var builder = WebApplication.CreateSlimBuilder(args);
 builder.Logging.ClearProviders();
+builder.Logging.AddConsole(options =>
+{
+    options.FormatterName = ConsoleFormatterNames.Simple;
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+builder.Logging.AddSimpleConsole(options =>
+{
+    options.TimestampFormat = "HH:mm:ss.fff ";
+    options.SingleLine = true;
+    options.ColorBehavior = LoggerColorBehavior.Disabled;
+});
+builder.Logging.SetMinimumLevel(LogLevel.Information);
 builder.WebHost.UseUrls("http://127.0.0.1:0");
 
 var discovery = WorkspaceSarifDiscovery.Discover();
+var promptCompletionCache = new PromptCompletionCache(discovery.WorkspaceRoot, discovery.SarifFiles);
+WriteStartupInfo($"Workspace root: '{discovery.WorkspaceRoot}'");
+WriteStartupInfo($"Discovered SARIF files: {discovery.SarifFiles.Count}");
+
+builder.Configuration
+    .AddJsonFile(Path.Combine(discovery.WorkspaceRoot, ".sarif", "engine.json"), optional: true)
+    .AddEnvironmentVariables(prefix: "SARIFINTOWN_");
+
+builder.Services.Configure<SarifPreloadOptions>(
+    builder.Configuration.GetSection(SarifPreloadOptions.SectionName));
 
 // Register Headless Implementations
 builder.Services.AddSingleton<IFileReader>(new NativeFileReader(discovery.WorkspaceRoot));
 builder.Services.AddSingleton<ITreeSitterEngine, V8TreeSitterEngine>();
-builder.Services.AddSingleton<IPromptAssemblyService, PromptAssemblyService>();
+builder.Services.AddSingleton<IPromptAssemblyService>(_ => new PromptAssemblyService(discovery.WorkspaceRoot));
+builder.Services.AddSingleton<SnippetCacheService>();
+builder.Services.AddSingleton<SarifStateService>(serviceProvider =>
+    new SarifStateService(
+        serviceProvider.GetRequiredService<IFileReader>(),
+        serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<SarifPreloadOptions>>(),
+        discovery.WorkspaceRoot,
+        discovery.SarifFiles));
+builder.Services.AddSingleton<SnippetWarmupService>(serviceProvider =>
+    new SnippetWarmupService(
+        serviceProvider.GetRequiredService<SarifStateService>(),
+        serviceProvider.GetRequiredService<IFileReader>(),
+        serviceProvider.GetRequiredService<ITreeSitterEngine>(),
+        serviceProvider.GetRequiredService<SnippetCacheService>(),
+        discovery.WorkspaceRoot,
+        serviceProvider.GetRequiredService<ILogger<SnippetWarmupService>>()));
+builder.Services.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<SnippetWarmupService>());
 
 // Register MCP Server (if using the prerelease SDK)
 builder.Services.AddMcpServer()
        .WithStdioServerTransport()
        .WithToolsFromAssembly()
-       .WithPromptsFromAssembly();
+       .WithPromptsFromAssembly()
+       .WithCompleteHandler((request, cancellationToken) =>
+           HandleCompletionRequestAsync(request.Params, cancellationToken, promptCompletionCache));
 
 var app = builder.Build();
+WriteStartupInfo("Web application built.");
 
 app.UseBlazorFrameworkFiles();
 app.UseStaticFiles();
@@ -28,16 +92,201 @@ app.MapFallbackToFile("index.html");
 
 // Ensure TreeSitter is initialized before accepting AI requests
 var treeSitter = app.Services.GetRequiredService<ITreeSitterEngine>();
-await treeSitter.InitializeAsync();
+await RunStartupStageAsync("TreeSitter initialization", () => treeSitter.InitializeAsync());
+
+var sarifStateService = app.Services.GetRequiredService<SarifStateService>();
+await RunStartupStageAsync("SARIF state initialization", () => sarifStateService.InitializeAsync());
+
+var snippetCacheService = app.Services.GetRequiredService<SnippetCacheService>();
+var snippetWarmupService = app.Services.GetRequiredService<SnippetWarmupService>();
+var preloadOptions = app.Services.GetRequiredService<IOptions<SarifPreloadOptions>>().Value;
 
 // Inject dependencies into SarifTools
 SarifTools.FileReader = app.Services.GetRequiredService<IFileReader>();
 SarifTools.TreeSitterEngine = treeSitter;
+SarifTools.StateService = sarifStateService;
+SarifTools.SnippetCache = snippetCacheService;
+SarifTools.SnippetWarmupService = snippetWarmupService;
 SarifTools.SetDiscoveredSarifFiles(discovery.SarifFiles);
 SarifTools.SetLocalUiBaseUrl(string.Empty);
 SarifTools.SetWorkspaceRoot(discovery.WorkspaceRoot);
+WriteStartupInfo("MCP tool dependencies configured.");
 
-await app.StartAsync();
+await RunStartupStageAsync("Web host start", () => app.StartAsync());
+
+if (preloadOptions.EnableSnippetPreload)
+{
+    _ = RunSnippetPreloadInBackgroundAsync(
+        snippetWarmupService,
+        preloadOptions.MaxPreloadedSnippets,
+        app.Lifetime.ApplicationStopping);
+    WriteStartupInfo($"Snippet preload ({preloadOptions.MaxPreloadedSnippets} max): scheduled in background");
+}
+
+static async ValueTask<CompleteResult> HandleCompletionRequestAsync(
+    CompleteRequestParams request,
+    CancellationToken cancellationToken,
+    PromptCompletionCache completionCache)
+{
+    ArgumentNullException.ThrowIfNull(request);
+    ArgumentNullException.ThrowIfNull(completionCache);
+
+    var requestElement = JsonSerializer.SerializeToElement(request);
+    if (!TryGetProperty(requestElement, "ref", out var referenceElement)
+        || !TryGetProperty(referenceElement, "name", out var promptNameElement)
+        || promptNameElement.ValueKind != JsonValueKind.String)
+    {
+        return CreateCompletionResult(Array.Empty<string>());
+    }
+
+    var promptName = promptNameElement.GetString()?.Trim();
+    if (string.IsNullOrWhiteSpace(promptName)
+        || !TryGetProperty(requestElement, "argument", out var argumentElement)
+        || !TryGetProperty(argumentElement, "name", out var argumentNameElement)
+        || argumentNameElement.ValueKind != JsonValueKind.String)
+    {
+        return CreateCompletionResult(Array.Empty<string>());
+    }
+
+    var argumentName = argumentNameElement.GetString()?.Trim();
+    if (string.IsNullOrWhiteSpace(argumentName))
+    {
+        return CreateCompletionResult(Array.Empty<string>());
+    }
+
+    var argumentPrefix = string.Empty;
+    if (TryGetProperty(argumentElement, "value", out var valueElement)
+        && valueElement.ValueKind is JsonValueKind.String or JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False)
+    {
+        argumentPrefix = valueElement.ToString();
+    }
+
+    var completionData = await completionCache.GetAsync(cancellationToken);
+    var completionValues = ResolveCompletionValues(promptName, argumentName, argumentPrefix, completionData);
+    return CreateCompletionResult(completionValues);
+}
+
+static IReadOnlyList<string> ResolveCompletionValues(
+    string promptName,
+    string argumentName,
+    string prefix,
+    PromptCompletionData completionData)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(promptName);
+    ArgumentException.ThrowIfNullOrWhiteSpace(argumentName);
+    ArgumentNullException.ThrowIfNull(completionData);
+
+    var normalizedPrompt = promptName.Trim();
+    var normalizedArgument = argumentName.Trim();
+
+    IEnumerable<string> candidates = normalizedPrompt switch
+    {
+        "sarif.triage.list" => normalizedArgument switch
+        {
+            "severity" => completionData.Severities,
+            "rule" => completionData.Rules,
+            "file" => completionData.Files,
+            "state" => completionData.ListStates,
+            "limit" => completionData.Limits,
+            _ => Array.Empty<string>()
+        },
+        "sarif.triage.inspect" => normalizedArgument switch
+        {
+            "findingId" => completionData.FindingIds,
+            "evidenceMode" => completionData.EvidenceModes,
+            _ => Array.Empty<string>()
+        },
+        "sarif.triage.apply" => normalizedArgument switch
+        {
+            "findingId" => completionData.FindingIds,
+            "state" => completionData.DecisionStates,
+            "reason" => completionData.Reasons,
+            "author" => completionData.Authors,
+            _ => Array.Empty<string>()
+        },
+        "sarif.triage.bulk" => normalizedArgument switch
+        {
+            "state" => completionData.DecisionStates,
+            "reason" => completionData.Reasons,
+            "severity" => completionData.Severities,
+            "rule" => completionData.Rules,
+            "file" => completionData.Files,
+            "dryRun" => completionData.DryRunValues,
+            "author" => completionData.Authors,
+            _ => Array.Empty<string>()
+        },
+        "sarif.triage.status" => Array.Empty<string>(),
+        _ => Array.Empty<string>()
+    };
+
+    return ApplyPrefixFilter(candidates, prefix);
+}
+
+static IReadOnlyList<string> ApplyPrefixFilter(IEnumerable<string> candidates, string prefix)
+{
+    ArgumentNullException.ThrowIfNull(candidates);
+
+    var normalizedPrefix = prefix?.Trim() ?? string.Empty;
+
+    return candidates
+        .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(candidate => candidate, StringComparer.OrdinalIgnoreCase)
+        .Where(candidate => normalizedPrefix.Length == 0 || candidate.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+        .Take(50)
+        .ToArray();
+}
+
+static CompleteResult CreateCompletionResult(IReadOnlyList<string> values)
+{
+    ArgumentNullException.ThrowIfNull(values);
+
+    var result = new CompleteResult();
+    var completionProperty = typeof(CompleteResult).GetProperty("Completion");
+    if (completionProperty is null)
+    {
+        return result;
+    }
+
+    var completionInstance = Activator.CreateInstance(completionProperty.PropertyType);
+    if (completionInstance is null)
+    {
+        return result;
+    }
+
+    SetPropertyIfExists(completionInstance, "Values", values.ToArray());
+    SetPropertyIfExists(completionInstance, "Total", values.Count);
+    SetPropertyIfExists(completionInstance, "HasMore", false);
+    completionProperty.SetValue(result, completionInstance);
+
+    return result;
+}
+
+static void SetPropertyIfExists(object instance, string propertyName, object value)
+{
+    ArgumentNullException.ThrowIfNull(instance);
+    ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
+
+    var property = instance
+        .GetType()
+        .GetProperty(propertyName);
+
+    if (property?.CanWrite == true)
+    {
+        property.SetValue(instance, value);
+    }
+}
+
+static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+{
+    if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out value))
+    {
+        return true;
+    }
+
+    value = default;
+    return false;
+}
 
 var localUiBaseUrl = app.Urls.FirstOrDefault(url =>
     url.StartsWith("http://127.0.0.1:", StringComparison.OrdinalIgnoreCase));
@@ -51,5 +300,89 @@ if (string.IsNullOrWhiteSpace(localUiBaseUrl))
 }
 
 SarifTools.SetLocalUiBaseUrl(localUiBaseUrl ?? string.Empty);
+WriteStartupInfo($"Local UI base URL: '{localUiBaseUrl ?? string.Empty}'");
+WriteStartupInfo("Startup sequence completed. Waiting for MCP traffic.");
 
 await app.WaitForShutdownAsync();
+
+static async Task RunSnippetPreloadInBackgroundAsync(
+    SnippetWarmupService snippetWarmupService,
+    int maxPreloadedSnippets,
+    CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(snippetWarmupService);
+
+    try
+    {
+        await RunStartupStageAsync(
+            $"Snippet preload ({maxPreloadedSnippets} max)",
+            () => snippetWarmupService.PreloadSnippetsAsync(maxPreloadedSnippets, cancellationToken));
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        WriteStartupInfo("Snippet preload canceled during shutdown.");
+    }
+    catch (InvalidOperationException exception)
+    {
+        WriteStartupError("Snippet preload failed due to invalid state.", exception);
+    }
+    catch (IOException exception)
+    {
+        WriteStartupError("Snippet preload failed due to I/O error.", exception);
+    }
+    catch (UnauthorizedAccessException exception)
+    {
+        WriteStartupError("Snippet preload failed due to access restrictions.", exception);
+    }
+}
+
+static async Task RunStartupStageAsync(string stageName, Func<Task> stageAction)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(stageName);
+    ArgumentNullException.ThrowIfNull(stageAction);
+
+    var stopwatch = Stopwatch.StartNew();
+    WriteStartupInfo($"{stageName}: start");
+
+    try
+    {
+        await stageAction();
+        WriteStartupInfo($"{stageName}: completed in {stopwatch.ElapsedMilliseconds} ms");
+    }
+    catch (Exception exception)
+    {
+        WriteStartupError($"{stageName}: failed after {stopwatch.ElapsedMilliseconds} ms", exception);
+        throw;
+    }
+}
+
+static void WriteStartupInfo(string message)
+{
+    if (string.IsNullOrWhiteSpace(message))
+    {
+        return;
+    }
+
+    WriteStartupError($"[INFO] {message}");
+}
+
+static void WriteStartupError(string message, Exception? exception = null)
+{
+    if (string.IsNullOrWhiteSpace(message))
+    {
+        return;
+    }
+
+    try
+    {
+        Console.Error.WriteLine($"[sarifintown-mcp] {DateTimeOffset.UtcNow:O} {message}");
+        if (exception is not null)
+        {
+            Console.Error.WriteLine(exception.ToString());
+        }
+    }
+    catch
+    {
+        // best-effort logging only; avoid failing startup because stderr is unavailable
+    }
+}

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -181,14 +181,14 @@ static IReadOnlyList<string> ResolveCompletionValues(
 
     IEnumerable<string> candidates = normalizedPrompt switch
     {
-        "sarif.get" => normalizedArgument switch
+        "sarif_get" => normalizedArgument switch
         {
             "scope" => new[] { "keep", "set", "refine", "clear" },
             "includeEvidence" => new[] { "true", "false" },
             "limit" => completionData.Limits,
             _ => Array.Empty<string>()
         },
-        "sarif.triage" => normalizedArgument switch
+        "sarif_triage" => normalizedArgument switch
         {
             "state" => completionData.DecisionStates,
             "reason" => completionData.Reasons,

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -181,41 +181,20 @@ static IReadOnlyList<string> ResolveCompletionValues(
 
     IEnumerable<string> candidates = normalizedPrompt switch
     {
-        "sarif.triage.list" => normalizedArgument switch
+        "sarif.get" => normalizedArgument switch
         {
-            "severity" => completionData.Severities,
-            "rule" => completionData.Rules,
-            "file" => completionData.Files,
-            "state" => completionData.ListStates,
+            "scope" => new[] { "keep", "set", "refine", "clear" },
+            "includeEvidence" => new[] { "true", "false" },
             "limit" => completionData.Limits,
             _ => Array.Empty<string>()
         },
-        "sarif.triage.inspect" => normalizedArgument switch
-        {
-            "findingId" => completionData.FindingIds,
-            "evidenceMode" => completionData.EvidenceModes,
-            _ => Array.Empty<string>()
-        },
-        "sarif.triage.apply" => normalizedArgument switch
-        {
-            "findingId" => completionData.FindingIds,
-            "state" => completionData.DecisionStates,
-            "reason" => completionData.Reasons,
-            "author" => completionData.Authors,
-            _ => Array.Empty<string>()
-        },
-        "sarif.triage.bulk" => normalizedArgument switch
+        "sarif.triage" => normalizedArgument switch
         {
             "state" => completionData.DecisionStates,
             "reason" => completionData.Reasons,
-            "severity" => completionData.Severities,
-            "rule" => completionData.Rules,
-            "file" => completionData.Files,
-            "dryRun" => completionData.DryRunValues,
-            "author" => completionData.Authors,
+            "target" => new[] { "scope" },
             _ => Array.Empty<string>()
         },
-        "sarif.triage.status" => Array.Empty<string>(),
         _ => Array.Empty<string>()
     };
 

--- a/Sarifintown.AgentEngine/PromptCompletionCache.cs
+++ b/Sarifintown.AgentEngine/PromptCompletionCache.cs
@@ -1,0 +1,251 @@
+using System.Text.Json;
+
+namespace Sarifintown.AgentEngine;
+
+internal sealed record PromptCompletionData(
+    IReadOnlyList<string> Severities,
+    IReadOnlyList<string> Rules,
+    IReadOnlyList<string> Files,
+    IReadOnlyList<string> FindingIds,
+    IReadOnlyList<string> ListStates,
+    IReadOnlyList<string> DecisionStates,
+    IReadOnlyList<string> EvidenceModes,
+    IReadOnlyList<string> DryRunValues,
+    IReadOnlyList<string> Limits,
+    IReadOnlyList<string> Reasons,
+    IReadOnlyList<string> Authors);
+
+internal sealed class PromptCompletionCache
+{
+    private static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(30);
+
+    private readonly string _workspaceRoot;
+    private readonly IReadOnlyList<string> _sarifFiles;
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
+
+    private PromptCompletionData? _cachedData;
+    private DateTimeOffset _cachedAtUtc = DateTimeOffset.MinValue;
+
+    internal PromptCompletionCache(string workspaceRoot, IEnumerable<string> sarifFiles)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(sarifFiles);
+
+        _workspaceRoot = workspaceRoot;
+        _sarifFiles = sarifFiles
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    internal async Task<PromptCompletionData> GetAsync(CancellationToken cancellationToken)
+    {
+        if (_cachedData is not null && DateTimeOffset.UtcNow - _cachedAtUtc < CacheLifetime)
+        {
+            return _cachedData;
+        }
+
+        await _cacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_cachedData is not null && DateTimeOffset.UtcNow - _cachedAtUtc < CacheLifetime)
+            {
+                return _cachedData;
+            }
+
+            _cachedData = await LoadDataAsync(cancellationToken);
+            _cachedAtUtc = DateTimeOffset.UtcNow;
+            return _cachedData;
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    private async Task<PromptCompletionData> LoadDataAsync(CancellationToken cancellationToken)
+    {
+        var severities = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "error",
+            "warning",
+            "note",
+            "none",
+            "high",
+            "medium",
+            "low",
+            "critical"
+        };
+
+        var rules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var findingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var reasons = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Confirmed true positive",
+            "False positive - acceptable pattern",
+            "Needs manual review"
+        };
+        var authors = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "AI"
+        };
+
+        foreach (var sarifFile in _sarifFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(sarifFile))
+            {
+                continue;
+            }
+
+            await using var stream = File.OpenRead(sarifFile);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+
+            if (!TryGetPropertyInsensitive(document.RootElement, "runs", out var runsElement) || runsElement.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var runElement in runsElement.EnumerateArray())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!TryGetPropertyInsensitive(runElement, "results", out var resultsElement) || resultsElement.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var resultElement in resultsElement.EnumerateArray())
+                {
+                    if (TryGetPropertyInsensitive(resultElement, "resultIdentity", out var findingIdElement)
+                        && findingIdElement.ValueKind == JsonValueKind.String)
+                    {
+                        var findingId = findingIdElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(findingId))
+                        {
+                            findingIds.Add(findingId.Trim());
+                        }
+                    }
+
+                    if (TryGetPropertyInsensitive(resultElement, "ruleId", out var ruleElement)
+                        && ruleElement.ValueKind == JsonValueKind.String)
+                    {
+                        var rule = ruleElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(rule))
+                        {
+                            rules.Add(rule.Trim());
+                        }
+                    }
+
+                    if (TryGetPropertyInsensitive(resultElement, "level", out var levelElement)
+                        && levelElement.ValueKind == JsonValueKind.String)
+                    {
+                        var level = levelElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(level))
+                        {
+                            severities.Add(level.Trim());
+                        }
+                    }
+
+                    if (TryGetPropertyInsensitive(resultElement, "locations", out var locationsElement)
+                        && locationsElement.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var locationElement in locationsElement.EnumerateArray())
+                        {
+                            if (!TryGetPropertyInsensitive(locationElement, "physicalLocation", out var physicalLocationElement)
+                                || !TryGetPropertyInsensitive(physicalLocationElement, "artifactLocation", out var artifactLocationElement)
+                                || !TryGetPropertyInsensitive(artifactLocationElement, "uri", out var uriElement)
+                                || uriElement.ValueKind != JsonValueKind.String)
+                            {
+                                continue;
+                            }
+
+                            var uri = uriElement.GetString();
+                            if (!string.IsNullOrWhiteSpace(uri))
+                            {
+                                files.Add(uri.Trim());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        var triagePath = Path.Combine(_workspaceRoot, ".sarif", "triage.json");
+        if (File.Exists(triagePath))
+        {
+            await using var triageStream = File.OpenRead(triagePath);
+            using var triageDocument = await JsonDocument.ParseAsync(triageStream, cancellationToken: cancellationToken);
+
+            if (TryGetPropertyInsensitive(triageDocument.RootElement, "entries", out var entriesElement)
+                && entriesElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var entryElement in entriesElement.EnumerateArray())
+                {
+                    if (TryGetPropertyInsensitive(entryElement, "findingId", out var triageFindingIdElement)
+                        && triageFindingIdElement.ValueKind == JsonValueKind.String)
+                    {
+                        var findingId = triageFindingIdElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(findingId))
+                        {
+                            findingIds.Add(findingId.Trim());
+                        }
+                    }
+
+                    if (TryGetPropertyInsensitive(entryElement, "reason", out var reasonElement)
+                        && reasonElement.ValueKind == JsonValueKind.String)
+                    {
+                        var reason = reasonElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(reason))
+                        {
+                            reasons.Add(reason.Trim());
+                        }
+                    }
+
+                    if (TryGetPropertyInsensitive(entryElement, "author", out var authorElement)
+                        && authorElement.ValueKind == JsonValueKind.String)
+                    {
+                        var author = authorElement.GetString();
+                        if (!string.IsNullOrWhiteSpace(author))
+                        {
+                            authors.Add(author.Trim());
+                        }
+                    }
+                }
+            }
+        }
+
+        return new PromptCompletionData(
+            Severities: severities.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+            Rules: rules.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+            Files: files.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+            FindingIds: findingIds.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+            ListStates: new[] { "open", "tp", "fp" },
+            DecisionStates: new[] { "tp", "fp" },
+            EvidenceModes: new[] { "line-window-strict", "line-window-concatenated", "tree-sitter-method" },
+            DryRunValues: new[] { "false", "true" },
+            Limits: new[] { "10", "25", "50", "100" },
+            Reasons: reasons.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray(),
+            Authors: authors.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray());
+    }
+
+    private static bool TryGetPropertyInsensitive(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -7,16 +7,6 @@ namespace Sarifintown.AgentEngine;
 public static class SarifPrompts
 {
     /// <summary>
-    /// Builds a slash-command prompt that forces workspace SARIF discovery before analysis.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.list-files", Title = "List Discovered SARIF Files")]
-    [Description("MUST: Use this slash command to enumerate discovered SARIF files before any SARIF-path-dependent action.")]
-    public static string ListWorkspaceSarifFilesPrompt()
-    {
-        return "MUST call `analyze_sarif` with action='list_files' and use only returned file names/paths for follow-up tools.";
-    }
-
-    /// <summary>
     /// Builds a slash-command prompt that requests non-guided triage status.
     /// </summary>
     [McpServerPrompt(Name = "sarif.triage.status", Title = "Triage Status")]
@@ -47,20 +37,58 @@ public static class SarifPrompts
     }
 
     /// <summary>
-    /// Builds a kickoff slash-command prompt that starts file analysis through the facade.
+    /// Builds a slash-command prompt to inspect one finding from the aggregated triage state.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.analyze.file", Title = "Analyze SARIF File")]
-    [Description("MUST: Use this kickoff slash command to start SARIF file analysis via the facade.")]
-    public static string AnalyzeFilePrompt(
-        [Description("SARIF file path or discovered filename.")]
-        string sarifPath,
+    [McpServerPrompt(Name = "sarif.triage.inspect", Title = "Inspect Finding")]
+    [Description("MUST: Use this prompt to inspect technical evidence for one FindingId from triage list results.")]
+    public static string TriageInspectPrompt(
+        [Description("Finding identifier returned by triage listing commands.")]
+        string findingId,
+        [Description("Optional evidence mode override (line-window-strict, line-window-concatenated, tree-sitter-method).")]
+        string evidenceMode = "")
+    {
+        return $"Call `manage_triage` with action='inspect', findingId='{findingId}', filters='{{\"evidenceMode\":\"{evidenceMode}\"}}'.";
+    }
+
+    /// <summary>
+    /// Builds a slash-command prompt to apply TP/FP decision to one finding.
+    /// </summary>
+    [McpServerPrompt(Name = "sarif.triage.apply", Title = "Apply Triage Decision")]
+    [Description("MUST: Use this prompt to persist TP/FP for one finding via the triage facade.")]
+    public static string TriageApplyPrompt(
+        [Description("Finding identifier returned by triage listing commands.")]
+        string findingId,
+        [Description("Decision state TP or FP.")]
+        string state,
+        [Description("Required decision reason.")]
+        string reason,
+        [Description("Optional decision author label.")]
+        string author = "AI")
+    {
+        return $"Call `manage_triage` with action='decide', findingId='{findingId}', state='{state}', reason='{reason}', filters='{{\"author\":\"{author}\"}}'.";
+    }
+
+    /// <summary>
+    /// Builds a slash-command prompt to apply TP/FP decision to multiple findings.
+    /// </summary>
+    [McpServerPrompt(Name = "sarif.triage.bulk", Title = "Bulk Triage Decision")]
+    [Description("MUST: Use this prompt to run bulk TP/FP triage updates over filtered findings.")]
+    public static string TriageBulkPrompt(
+        [Description("Decision state TP or FP.")]
+        string state,
+        [Description("Required decision reason.")]
+        string reason,
         [Description("Optional severity filter.")]
         string severity = "",
         [Description("Optional rule filter.")]
-        string ruleId = "",
-        [Description("Optional category keyword filter.")]
-        string category = "")
+        string rule = "",
+        [Description("Optional file filter.")]
+        string file = "",
+        [Description("When true, preview affected findings without writing triage state.")]
+        bool dryRun = false,
+        [Description("Optional decision author label.")]
+        string author = "AI")
     {
-        return $"Call `analyze_sarif` with action='filter', sarifPath='{sarifPath}', filters='{{\"severity\":\"{severity}\",\"ruleId\":\"{ruleId}\",\"category\":\"{category}\"}}'.";
+        return $"Call `manage_triage` with action='bulk_decide', state='{state}', reason='{reason}', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"dryRun\":{dryRun.ToString().ToLowerInvariant()},\"author\":\"{author}\"}}'.";
     }
 }

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Sarifintown.AgentEngine;
 
@@ -9,9 +10,13 @@ public static class SarifPrompts
     /// <summary>
     /// Builds a slash-command prompt for consolidated triage read operations.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.query", Title = "Query Triage Posture")]
+    [McpServerPrompt(Name = "sarif_triage_query", Title = "Query Triage Posture")]
     [Description("MUST: Use this kickoff slash command to retrieve posture summary and prioritized findings in one response.")]
     public static string TriageQueryPrompt(
+        [Description("Scope action (keep, set, refine, clear).")]
+        string scope = "keep",
+        [Description("Optional scope filter expression (for example: severity:high, rule:SQLI).")]
+        string filter = "",
         [Description("Optional severity filter.")]
         string severity = "",
         [Description("Optional rule filter.")]
@@ -29,34 +34,32 @@ public static class SarifPrompts
         [Description("Optional evidence mode override (line-window-strict, line-window-concatenated, tree-sitter-method).")]
         string evidenceMode = "")
     {
-        return $"Call `manage_triage` with action='query', findingId='{findingId}', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"state\":\"{state}\",\"limit\":{limit},\"includeEvidence\":{includeEvidence.ToString().ToLowerInvariant()},\"evidenceMode\":\"{evidenceMode}\"}}'.";
+        var effectiveFilter = string.IsNullOrWhiteSpace(filter)
+            ? string.Join(", ", new[]
+            {
+                string.IsNullOrWhiteSpace(severity) ? string.Empty : $"severity:{severity}",
+                string.IsNullOrWhiteSpace(rule) ? string.Empty : $"rule:{rule}",
+                string.IsNullOrWhiteSpace(file) ? string.Empty : $"file:{file}",
+                string.IsNullOrWhiteSpace(state) ? string.Empty : $"state:{state}"
+            }.Where(item => !string.IsNullOrWhiteSpace(item)))
+            : filter;
+
+        return $"Call `sarif_get` with scope='{scope}', filter='{effectiveFilter}', includeEvidence={includeEvidence.ToString().ToLowerInvariant()}, limit={limit}.";
     }
 
     /// <summary>
     /// Builds a slash-command prompt for consolidated triage write operations.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.decide", Title = "Decide Triage State")]
-    [Description("MUST: Use this prompt to persist TP/FP decisions for one or many findings via IDs or filters.")]
+    [McpServerPrompt(Name = "sarif_triage_decide", Title = "Decide Triage State")]
+    [Description("MUST: Use this prompt to persist decisions for one or many findings via displayid aliases or scope.")]
     public static string TriageDecidePrompt(
-        [Description("Decision state TP or FP.")]
+        [Description("Decision state (confirmed, false_positive, test_code, wont_fix, mitigated).")]
         string state,
         [Description("Required decision reason.")]
         string reason,
-        [Description("Optional single finding identifier.")]
-        string findingId = "",
-        [Description("Optional comma-separated finding IDs for multi-target decisions.")]
-        string findingIds = "",
-        [Description("Optional severity filter.")]
-        string severity = "",
-        [Description("Optional rule filter.")]
-        string rule = "",
-        [Description("Optional file filter.")]
-        string file = "",
-        [Description("When true, preview affected findings without writing triage state.")]
-        bool dryRun = false,
-        [Description("Optional decision author label.")]
-        string author = "AI")
+        [Description("Target displayid, CSV displayid list, or scope.")]
+        string target = "scope")
     {
-        return $"Call `manage_triage` with action='decide', findingId='{findingId}', state='{state}', reason='{reason}', filters='{{\"findingIds\":\"{findingIds}\",\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"dryRun\":{dryRun.ToString().ToLowerInvariant()},\"author\":\"{author}\"}}'.";
+        return $"Call `sarif_triage` with state='{state}', reason='{reason}', target='{target}'.";
     }
 }

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -7,22 +7,12 @@ namespace Sarifintown.AgentEngine;
 public static class SarifPrompts
 {
     /// <summary>
-    /// Builds a slash-command prompt that requests non-guided triage status.
+    /// Builds a slash-command prompt for consolidated triage read operations.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.status", Title = "Triage Status")]
-    [Description("Use this kickoff slash command to retrieve authoritative triage status counts and posture summary.")]
-    public static string TriageStatusPrompt()
-    {
-        return "Call `manage_triage` with action='status' to retrieve current triage posture from SARIF findings and triage state.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that retrieves prioritized findings.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.list", Title = "List Prioritized Findings")]
-    [Description("MUST: Use this kickoff slash command to retrieve prioritized findings with filters instead of inferring finding sets.")]
-    public static string TriageListPrompt(
-        [Description("Optional severity filter for the follow-up guided list step.")]
+    [McpServerPrompt(Name = "sarif.triage.query", Title = "Query Triage Posture")]
+    [Description("MUST: Use this kickoff slash command to retrieve posture summary and prioritized findings in one response.")]
+    public static string TriageQueryPrompt(
+        [Description("Optional severity filter.")]
         string severity = "",
         [Description("Optional rule filter.")]
         string rule = "",
@@ -31,53 +21,31 @@ public static class SarifPrompts
         [Description("Optional triage state filter.")]
         string state = "",
         [Description("Maximum finding count to return.")]
-        int limit = 10)
-    {
-        return $"Call `manage_triage` with action='list', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"state\":\"{state}\",\"limit\":{limit}}}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt to inspect one finding from the aggregated triage state.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.inspect", Title = "Inspect Finding")]
-    [Description("MUST: Use this prompt to inspect technical evidence for one FindingId from triage list results.")]
-    public static string TriageInspectPrompt(
-        [Description("Finding identifier returned by triage listing commands.")]
-        string findingId,
+        int limit = 10,
+        [Description("When true, include evidence for returned findings.")]
+        bool includeEvidence = false,
+        [Description("Optional finding identifier for deep-dive mode.")]
+        string findingId = "",
         [Description("Optional evidence mode override (line-window-strict, line-window-concatenated, tree-sitter-method).")]
         string evidenceMode = "")
     {
-        return $"Call `manage_triage` with action='inspect', findingId='{findingId}', filters='{{\"evidenceMode\":\"{evidenceMode}\"}}'.";
+        return $"Call `manage_triage` with action='query', findingId='{findingId}', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"state\":\"{state}\",\"limit\":{limit},\"includeEvidence\":{includeEvidence.ToString().ToLowerInvariant()},\"evidenceMode\":\"{evidenceMode}\"}}'.";
     }
 
     /// <summary>
-    /// Builds a slash-command prompt to apply TP/FP decision to one finding.
+    /// Builds a slash-command prompt for consolidated triage write operations.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.apply", Title = "Apply Triage Decision")]
-    [Description("MUST: Use this prompt to persist TP/FP for one finding via the triage facade.")]
-    public static string TriageApplyPrompt(
-        [Description("Finding identifier returned by triage listing commands.")]
-        string findingId,
+    [McpServerPrompt(Name = "sarif.triage.decide", Title = "Decide Triage State")]
+    [Description("MUST: Use this prompt to persist TP/FP decisions for one or many findings via IDs or filters.")]
+    public static string TriageDecidePrompt(
         [Description("Decision state TP or FP.")]
         string state,
         [Description("Required decision reason.")]
         string reason,
-        [Description("Optional decision author label.")]
-        string author = "AI")
-    {
-        return $"Call `manage_triage` with action='decide', findingId='{findingId}', state='{state}', reason='{reason}', filters='{{\"author\":\"{author}\"}}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt to apply TP/FP decision to multiple findings.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.bulk", Title = "Bulk Triage Decision")]
-    [Description("MUST: Use this prompt to run bulk TP/FP triage updates over filtered findings.")]
-    public static string TriageBulkPrompt(
-        [Description("Decision state TP or FP.")]
-        string state,
-        [Description("Required decision reason.")]
-        string reason,
+        [Description("Optional single finding identifier.")]
+        string findingId = "",
+        [Description("Optional comma-separated finding IDs for multi-target decisions.")]
+        string findingIds = "",
         [Description("Optional severity filter.")]
         string severity = "",
         [Description("Optional rule filter.")]
@@ -89,6 +57,6 @@ public static class SarifPrompts
         [Description("Optional decision author label.")]
         string author = "AI")
     {
-        return $"Call `manage_triage` with action='bulk_decide', state='{state}', reason='{reason}', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"dryRun\":{dryRun.ToString().ToLowerInvariant()},\"author\":\"{author}\"}}'.";
+        return $"Call `manage_triage` with action='decide', findingId='{findingId}', state='{state}', reason='{reason}', filters='{{\"findingIds\":\"{findingIds}\",\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"dryRun\":{dryRun.ToString().ToLowerInvariant()},\"author\":\"{author}\"}}'.";
     }
 }

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -13,34 +13,24 @@ public static class SarifPrompts
     [Description("MUST: Use this slash command to enumerate discovered SARIF files before any SARIF-path-dependent action.")]
     public static string ListWorkspaceSarifFilesPrompt()
     {
-        return "MUST call `ListWorkspaceSarifFiles` and use only returned file names/paths for follow-up tools.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that starts guided triage status flow.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.status.guided", Title = "Guided Triage Status")]
-    [Description("MUST: Start autonomous triage by calling TriageStatusGuided and following returned next_step/pause metadata.")]
-    public static string TriageStatusGuidedPrompt()
-    {
-        return "MUST call `TriageStatusGuided`, render markdown verbatim, then follow `next_step` instructions exactly.";
+        return "MUST call `analyze_sarif` with action='list_files' and use only returned file names/paths for follow-up tools.";
     }
 
     /// <summary>
     /// Builds a slash-command prompt that requests non-guided triage status.
     /// </summary>
     [McpServerPrompt(Name = "sarif.triage.status", Title = "Triage Status")]
-    [Description("Use this slash command to retrieve authoritative triage status counts and posture summary.")]
+    [Description("Use this kickoff slash command to retrieve authoritative triage status counts and posture summary.")]
     public static string TriageStatusPrompt()
     {
-        return "Call `TriageStatus` to retrieve current triage posture from SARIF findings and triage state.";
+        return "Call `manage_triage` with action='status' to retrieve current triage posture from SARIF findings and triage state.";
     }
 
     /// <summary>
     /// Builds a slash-command prompt that retrieves prioritized findings.
     /// </summary>
     [McpServerPrompt(Name = "sarif.triage.list", Title = "List Prioritized Findings")]
-    [Description("MUST: Use this slash command to retrieve prioritized findings with filters instead of inferring finding sets.")]
+    [Description("MUST: Use this kickoff slash command to retrieve prioritized findings with filters instead of inferring finding sets.")]
     public static string TriageListPrompt(
         [Description("Optional severity filter for the follow-up guided list step.")]
         string severity = "",
@@ -53,139 +43,15 @@ public static class SarifPrompts
         [Description("Maximum finding count to return.")]
         int limit = 10)
     {
-        return $"""
-        MUST call `TriageList` with:
-        - severity='{severity}'
-        - rule='{rule}'
-        - file='{file}'
-        - state='{state}'
-        - limit={limit}
-        """;
+        return $"Call `manage_triage` with action='list', filters='{{\"severity\":\"{severity}\",\"rule\":\"{rule}\",\"file\":\"{file}\",\"state\":\"{state}\",\"limit\":{limit}}}'.";
     }
 
     /// <summary>
-    /// Builds a slash-command prompt that retrieves guided prioritized findings.
+    /// Builds a kickoff slash-command prompt that starts file analysis through the facade.
     /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.list.guided", Title = "Guided List Prioritized Findings")]
-    [Description("MUST: Use this slash command for autonomous guided finding lists and follow returned next_step metadata.")]
-    public static string TriageListGuidedPrompt(
-        [Description("Optional severity filter.")]
-        string severity = "",
-        [Description("Optional rule filter.")]
-        string rule = "",
-        [Description("Optional file path filter.")]
-        string file = "",
-        [Description("Optional triage state filter.")]
-        string state = "",
-        [Description("Maximum finding count to return.")]
-        int limit = 10)
-    {
-        return $"""
-        MUST call `TriageListGuided` with:
-        - severity='{severity}'
-        - rule='{rule}'
-        - file='{file}'
-        - state='{state}'
-        - limit={limit}
-        Then render markdown exactly and pause for user input.
-        """;
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that inspects one finding.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.inspect", Title = "Inspect Finding Evidence")]
-    [Description("MUST: Use this slash command to retrieve authoritative technical evidence for a specific finding.")]
-    public static string TriageInspectPrompt(
-        [Description("Finding identifier from list output.")]
-        string findingId,
-        [Description("Optional evidence mode.")]
-        string evidenceMode = "")
-    {
-        return $"Call `TriageInspect` with findingId='{findingId}', evidenceMode='{evidenceMode}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that inspects one finding in guided mode.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.inspect.guided", Title = "Guided Inspect Finding")]
-    [Description("MUST: Use this slash command for guided evidence inspection and execute returned next_step exactly.")]
-    public static string TriageInspectGuidedPrompt(
-        [Description("Finding identifier selected from guided list output.")]
-        string findingId,
-        [Description("Evidence mode for guided inspection.")]
-        string evidenceMode = "line-window-concatenated")
-    {
-        return $"""
-        MUST call `TriageInspectGuided` with findingId='{findingId}', evidenceMode='{evidenceMode}'.
-        Render markdown exactly and pause for user input.
-        """;
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that records a single triage decision.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.apply", Title = "Apply Triage Decision")]
-    [Description("MUST: Use this slash command to persist TP/FP decision for one finding.")]
-    public static string TriagePrompt(
-        [Description("Finding identifier.")]
-        string findingId,
-        [Description("Decision state (TP or FP).")]
-        string state,
-        [Description("Reason for triage decision.")]
-        string reason,
-        [Description("Decision author label.")]
-        string author = "AI")
-    {
-        return $"Call `Triage` with findingId='{findingId}', state='{state}', reason='{reason}', author='{author}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that applies bulk triage decisions.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.triage.bulk", Title = "Apply Bulk Triage")]
-    [Description("MUST: Use this slash command to apply TP/FP decisions to multiple findings using filters.")]
-    public static string TriageBulkPrompt(
-        [Description("Decision state (TP or FP).")]
-        string state,
-        [Description("Reason for triage decision.")]
-        string reason,
-        [Description("Optional severity filter.")]
-        string severity = "",
-        [Description("Optional rule filter.")]
-        string rule = "",
-        [Description("Optional file filter.")]
-        string file = "",
-        [Description("Set true for dry-run preview only.")]
-        bool dryRun = false,
-        [Description("Decision author label.")]
-        string author = "AI")
-    {
-        return $"""
-        Call `TriageBulk` with state='{state}', reason='{reason}', severity='{severity}', rule='{rule}', file='{file}', dryRun={dryRun.ToString().ToLowerInvariant()}, author='{author}'.
-        """;
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that resolves interactive host surface.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.resolve-surface", Title = "Resolve Interactive Surface")]
-    [Description("Use this slash command to resolve host-specific UI/TUI surface metadata before starting interactive flows.")]
-    public static string ResolveInteractiveSurfacePrompt(
-        [Description("Optional host hint override.")]
-        string hostHint = "",
-        [Description("When true, starts CLI menu when host resolves to terminal mode.")]
-        bool startCliMenu = false)
-    {
-        return $"Call `ResolveInteractiveSurface` with hostHint='{hostHint}', startCliMenu={startCliMenu.ToString().ToLowerInvariant()}.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that loads and filters SARIF issues.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.load-filter", Title = "Load and Filter SARIF")]
-    [Description("MUST: Use this slash command to parse SARIF and filter issues by severity/rule/category.")]
-    public static string LoadAndFilterSarifPrompt(
+    [McpServerPrompt(Name = "sarif.analyze.file", Title = "Analyze SARIF File")]
+    [Description("MUST: Use this kickoff slash command to start SARIF file analysis via the facade.")]
+    public static string AnalyzeFilePrompt(
         [Description("SARIF file path or discovered filename.")]
         string sarifPath,
         [Description("Optional severity filter.")]
@@ -195,68 +61,6 @@ public static class SarifPrompts
         [Description("Optional category keyword filter.")]
         string category = "")
     {
-        return $"Call `LoadAndFilterSarif` with sarifPath='{sarifPath}', severity='{severity}', ruleId='{ruleId}', category='{category}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that extracts code flow evidence.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.extract-flow", Title = "Extract Code Flow")]
-    [Description("MUST: Use this slash command to extract full source-to-sink flow for one SARIF result.")]
-    public static string ExtractCodeFlowPrompt(
-        [Description("SARIF file path or discovered filename.")]
-        string sarifPath,
-        [Description("Result index from filtered output.")]
-        string resultId,
-        [Description("Workspace source root for path resolution.")]
-        string sourceCodeRoot)
-    {
-        return $"Call `ExtractCodeFlow` with sarifPath='{sarifPath}', resultId='{resultId}', sourceCodeRoot='{sourceCodeRoot}'.";
-    }
-
-    /// <summary>
-    /// Builds a slash-command prompt that generates markdown report from extracted flow.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.generate-report", Title = "Generate Analysis Report")]
-    [Description("MUST: Use this slash command to produce markdown report output from extracted flow JSON.")]
-    public static string GenerateAnalysisReportPrompt(
-        [Description("Result identifier for metadata.")]
-        string resultId,
-        [Description("Flow data JSON from ExtractCodeFlow.")]
-        string extractedFlowData,
-        [Description("Output report path.")]
-        string outputPath)
-    {
-        return $"Call `GenerateAnalysisReport` with resultId='{resultId}', extractedFlowData='{{...}}', outputPath='{outputPath}'.";
-    }
-
-    /// <summary>
-    /// Builds a compatibility slash-command prompt for guided kickoff flow.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.force-check", Title = "Force Guided Check")]
-    [Description("MUST: Compatibility prompt alias for guided triage kickoff.")]
-    public static string SarifintownForceCheck(
-        [Description("Optional severity filter.")]
-        string severity = "",
-        [Description("Optional rule filter.")]
-        string rule = "",
-        [Description("Maximum findings to return.")]
-        int limit = 10)
-    {
-        return TriageListGuidedPrompt(severity, rule, file: "", state: "", limit);
-    }
-
-    /// <summary>
-    /// Builds a compatibility slash-command prompt for guided inspection.
-    /// </summary>
-    [McpServerPrompt(Name = "sarif.inspect-finding", Title = "Inspect Finding (Guided)")]
-    [Description("MUST: Compatibility prompt alias for guided finding inspection.")]
-    public static string SarifintownInspectFinding(
-        [Description("Finding identifier.")]
-        string findingId,
-        [Description("Evidence mode for inspection.")]
-        string evidenceMode = "line-window-concatenated")
-    {
-        return TriageInspectGuidedPrompt(findingId, evidenceMode);
+        return $"Call `analyze_sarif` with action='filter', sarifPath='{sarifPath}', filters='{{\"severity\":\"{severity}\",\"ruleId\":\"{ruleId}\",\"category\":\"{category}\"}}'.";
     }
 }

--- a/Sarifintown.AgentEngine/SarifStateService.cs
+++ b/Sarifintown.AgentEngine/SarifStateService.cs
@@ -1,0 +1,641 @@
+using Microsoft.Extensions.Options;
+using Sarifintown.AgentEngine.Configuration;
+using Sarifintown.Core;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Sarifintown.AgentEngine;
+
+public sealed class SarifStateService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+    private readonly IFileReader _fileReader;
+    private readonly string _workspaceRoot;
+    private readonly IReadOnlyList<string> _sarifFiles;
+    private readonly SarifPreloadOptions _options;
+
+    private List<TriageFindingEnvelope> _findings = new();
+    private TriageStateDocument _triageDocument = new();
+    private bool _isInitialized;
+
+    internal SarifStateService(
+        IFileReader fileReader,
+        IOptions<SarifPreloadOptions> options,
+        string workspaceRoot,
+        IEnumerable<string> sarifFiles)
+    {
+        ArgumentNullException.ThrowIfNull(fileReader);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(sarifFiles);
+
+        _fileReader = fileReader;
+        _workspaceRoot = Path.GetFullPath(workspaceRoot);
+        _sarifFiles = sarifFiles
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        _options = options.Value;
+    }
+
+    internal async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_isInitialized)
+            {
+                return;
+            }
+
+            _triageDocument = await LoadTriageStateDocumentCoreAsync(cancellationToken).ConfigureAwait(false);
+            var triageMap = BuildTriageMap(_triageDocument);
+
+            var findings = new List<TriageFindingEnvelope>();
+            var filesToLoad = await SelectFilesForInitialLoadAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var sarifPath in filesToLoad)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var parsed = await LoadFindingsFromSarifAsync(sarifPath, triageMap, cancellationToken).ConfigureAwait(false);
+                findings.AddRange(parsed);
+            }
+
+            _findings = findings;
+            _isInitialized = true;
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    internal async Task<IReadOnlyList<TriageFindingEnvelope>> GetFindingsAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return _findings.ToList();
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    internal async Task<TriageStateDocument> GetTriageStateDocumentAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return CloneDocument(_triageDocument);
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    internal async Task SaveTriageStateDocumentAsync(TriageStateDocument document, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _triageDocument = CloneDocument(document);
+            var triageMap = BuildTriageMap(_triageDocument);
+            _findings = _findings
+                .Select(finding => finding with { State = ResolveState(triageMap, finding.FindingId) })
+                .ToList();
+
+            await SaveTriageStateDocumentCoreAsync(_triageDocument, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        await InitializeAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<string>> SelectFilesForInitialLoadAsync(CancellationToken cancellationToken)
+    {
+        if (_sarifFiles.Count == 0 || _options.Strategy == PreloadStrategy.None)
+        {
+            return Array.Empty<string>();
+        }
+
+        var ordered = _sarifFiles
+            .Select(path => new FileInfo(path))
+            .Where(file => file.Exists)
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .ToList();
+
+        if (_options.Strategy == PreloadStrategy.All)
+        {
+            return ordered.Select(file => file.FullName).ToList();
+        }
+
+        var metadata = new List<SarifFileMetadata>(ordered.Count);
+        foreach (var file in ordered)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var toolName = await ResolveToolNameAsync(file.FullName, cancellationToken).ConfigureAwait(false);
+            metadata.Add(new SarifFileMetadata(file.FullName, toolName, file.LastWriteTimeUtc));
+        }
+
+        return metadata
+            .GroupBy(item => item.ToolName, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group
+                .OrderByDescending(item => item.LastWriteTimeUtc)
+                .ThenBy(item => item.FilePath, StringComparer.OrdinalIgnoreCase)
+                .First())
+            .OrderByDescending(item => item.LastWriteTimeUtc)
+            .Select(item => item.FilePath)
+            .ToList();
+    }
+
+    private async Task<string> ResolveToolNameAsync(string sarifFile, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var content = await _fileReader.ReadFileAsync(sarifFile).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return "unknown-tool";
+        }
+
+        using var document = JsonDocument.Parse(content);
+        if (!document.RootElement.TryGetProperty("runs", out var runsElement)
+            || runsElement.ValueKind != JsonValueKind.Array)
+        {
+            return "unknown-tool";
+        }
+
+        foreach (var run in runsElement.EnumerateArray())
+        {
+            if (!run.TryGetProperty("tool", out var toolElement)
+                || toolElement.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!toolElement.TryGetProperty("driver", out var driverElement)
+                || driverElement.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!driverElement.TryGetProperty("name", out var nameElement)
+                || nameElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var toolName = nameElement.GetString();
+            if (!string.IsNullOrWhiteSpace(toolName))
+            {
+                return toolName.Trim();
+            }
+        }
+
+        return "unknown-tool";
+    }
+
+    private async Task<IReadOnlyList<TriageFindingEnvelope>> LoadFindingsFromSarifAsync(
+        string sarifFile,
+        IReadOnlyDictionary<string, TriageStateEntry> triageMap,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(sarifFile))
+        {
+            return Array.Empty<TriageFindingEnvelope>();
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var content = await _fileReader.ReadFileAsync(sarifFile).ConfigureAwait(false);
+        var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, JsonOptions);
+        if (sarifLog?.Runs == null)
+        {
+            return Array.Empty<TriageFindingEnvelope>();
+        }
+
+        var findings = new List<TriageFindingEnvelope>();
+
+        foreach (var run in sarifLog.Runs)
+        {
+            var rules = (run.Tool?.Driver?.Rule ?? new List<Rule>())
+                .Where(rule => !string.IsNullOrWhiteSpace(rule.Id))
+                .GroupBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var result in run.Results ?? new List<Result>())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrWhiteSpace(result.ResultIdentity))
+                {
+                    result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result, run.Tool?.Driver?.Name ?? string.Empty);
+                }
+
+                var findingId = result.ResultIdentity;
+                if (string.IsNullOrWhiteSpace(findingId))
+                {
+                    continue;
+                }
+
+                var rule = ResolveRule(rules, run, result);
+                var severity = ResolveSeverity(result, rule);
+                var state = ResolveState(triageMap, findingId);
+                var filePath = ResolveResultFilePath(run, result);
+                var lineNumber = result.Locations?.FirstOrDefault()?.PhysicalLocation?.Region?.StartLine;
+                var priority = CalculatePriorityScore(severity, result);
+                var ruleName = !string.IsNullOrWhiteSpace(rule?.Name)
+                    ? rule!.Name
+                    : result.RuleId ?? "UnknownRule";
+                var ruleCategory = ResolveRuleCategory(rule, result);
+                var ruleDescription = rule?.ShortDescription?.Text ?? string.Empty;
+                var remediation = ResolveRemediation(rule, result);
+
+                findings.Add(new TriageFindingEnvelope(
+                    findingId,
+                    result,
+                    run,
+                    sarifFile,
+                    severity,
+                    state,
+                    ruleName,
+                    filePath,
+                    lineNumber,
+                    priority,
+                    ruleCategory,
+                    ruleDescription,
+                    remediation));
+            }
+        }
+
+        return findings;
+    }
+
+    private async Task<TriageStateDocument> LoadTriageStateDocumentCoreAsync(CancellationToken cancellationToken)
+    {
+        var triagePath = GetTriageFilePath();
+
+        if (!File.Exists(triagePath))
+        {
+            return new TriageStateDocument();
+        }
+
+        var json = await File.ReadAllTextAsync(triagePath, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new TriageStateDocument();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<TriageStateDocument>(json, JsonOptions) ?? new TriageStateDocument();
+        }
+        catch (JsonException jsonException)
+        {
+            throw new InvalidOperationException($"Invalid triage state file format at {triagePath}.", jsonException);
+        }
+    }
+
+    private async Task SaveTriageStateDocumentCoreAsync(TriageStateDocument document, CancellationToken cancellationToken)
+    {
+        var triagePath = GetTriageFilePath();
+        var triageDirectory = Path.GetDirectoryName(triagePath);
+
+        if (string.IsNullOrWhiteSpace(triageDirectory))
+        {
+            throw new InvalidOperationException("Unable to resolve triage state directory.");
+        }
+
+        Directory.CreateDirectory(triageDirectory);
+        var json = JsonSerializer.Serialize(document, JsonOptions);
+        await File.WriteAllTextAsync(triagePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static TriageStateDocument CloneDocument(TriageStateDocument source)
+    {
+        return new TriageStateDocument
+        {
+            SchemaVersion = source.SchemaVersion,
+            Entries = source.Entries
+                .Select(entry => new TriageStateEntry
+                {
+                    FindingId = entry.FindingId,
+                    State = entry.State,
+                    Reason = entry.Reason,
+                    Author = entry.Author,
+                    UpdatedUtc = entry.UpdatedUtc
+                })
+                .ToList()
+        };
+    }
+
+    private static IReadOnlyDictionary<string, TriageStateEntry> BuildTriageMap(TriageStateDocument triageState)
+    {
+        return triageState.Entries
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.FindingId))
+            .GroupBy(entry => entry.FindingId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.OrderByDescending(item => item.UpdatedUtc).First(), StringComparer.Ordinal);
+    }
+
+    private static Rule? ResolveRule(IReadOnlyDictionary<string, Rule> rules, Run run, Result result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.RuleId)
+            && rules.TryGetValue(result.RuleId, out var byRuleId))
+        {
+            return byRuleId;
+        }
+
+        if (result.RuleIndex >= 0
+            && run.Tool?.Driver?.Rule != null
+            && result.RuleIndex < run.Tool.Driver.Rule.Count)
+        {
+            return run.Tool.Driver.Rule[result.RuleIndex];
+        }
+
+        return result.Rule;
+    }
+
+    private static string ResolveSeverity(Result result, Rule? rule)
+    {
+        if (TryResolveSecuritySeverity(result.Properties, out var fromResultProperties))
+        {
+            return fromResultProperties;
+        }
+
+        if (TryResolveSecuritySeverity(rule?.Properties, out var fromRuleProperties))
+        {
+            return fromRuleProperties;
+        }
+
+        var level = result.Level;
+        if (string.IsNullOrWhiteSpace(level))
+        {
+            level = rule?.DefaultConfiguration?.Level;
+        }
+
+        return NormalizeSeverity(level);
+    }
+
+    private static bool TryResolveSecuritySeverity(Dictionary<string, object>? properties, out string severity)
+    {
+        severity = string.Empty;
+
+        if (properties == null || properties.Count == 0)
+        {
+            return false;
+        }
+
+        if (!properties.TryGetValue("security-severity", out var rawValue) || rawValue == null)
+        {
+            return false;
+        }
+
+        if (!TryConvertToDouble(rawValue, out var score))
+        {
+            return false;
+        }
+
+        severity = score switch
+        {
+            >= 9.0 => "Critical",
+            >= 7.0 => "High",
+            >= 4.0 => "Medium",
+            _ => "Low"
+        };
+
+        return true;
+    }
+
+    private static bool TryResolveSecuritySeverity(Dictionary<string, JsonElement>? properties, out string severity)
+    {
+        severity = string.Empty;
+
+        if (properties == null || properties.Count == 0)
+        {
+            return false;
+        }
+
+        if (!properties.TryGetValue("security-severity", out var rawValue))
+        {
+            return false;
+        }
+
+        if (!TryConvertToDouble(rawValue, out var score))
+        {
+            return false;
+        }
+
+        severity = score switch
+        {
+            >= 9.0 => "Critical",
+            >= 7.0 => "High",
+            >= 4.0 => "Medium",
+            _ => "Low"
+        };
+
+        return true;
+    }
+
+    private static bool TryConvertToDouble(object value, out double parsed)
+    {
+        parsed = 0;
+
+        return value switch
+        {
+            double doubleValue => (parsed = doubleValue) >= 0,
+            float floatValue => (parsed = floatValue) >= 0,
+            decimal decimalValue => (parsed = (double)decimalValue) >= 0,
+            int intValue => (parsed = intValue) >= 0,
+            long longValue => (parsed = longValue) >= 0,
+            JsonElement element => TryConvertToDouble(element, out parsed),
+            string text => double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
+            _ => false
+        };
+    }
+
+    private static bool TryConvertToDouble(JsonElement element, out double parsed)
+    {
+        parsed = 0;
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetDouble(out parsed),
+            JsonValueKind.String => double.TryParse(element.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
+            _ => false
+        };
+    }
+
+    private static string NormalizeSeverity(string? rawSeverity)
+    {
+        if (string.IsNullOrWhiteSpace(rawSeverity))
+        {
+            return "Medium";
+        }
+
+        var normalized = rawSeverity.Trim().ToLowerInvariant();
+
+        return normalized switch
+        {
+            "critical" => "Critical",
+            "error" => "High",
+            "high" => "High",
+            "warning" => "Medium",
+            "medium" => "Medium",
+            "note" => "Low",
+            "low" => "Low",
+            _ => "Medium"
+        };
+    }
+
+    private static string ResolveRuleCategory(Rule? rule, Result result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.RuleId))
+        {
+            return result.RuleId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(rule?.Id))
+        {
+            return rule.Id;
+        }
+
+        return "UnknownRule";
+    }
+
+    private static string ResolveRemediation(Rule? rule, Result result)
+    {
+        if (TryResolvePropertyText(result.Properties, "remediation", out var remediationFromResult))
+        {
+            return remediationFromResult;
+        }
+
+        if (TryResolvePropertyText(rule?.Properties, "help", out var remediationFromRuleHelp))
+        {
+            return remediationFromRuleHelp;
+        }
+
+        if (TryResolvePropertyText(rule?.Properties, "recommendation", out var recommendationFromRule))
+        {
+            return recommendationFromRule;
+        }
+
+        return string.Empty;
+    }
+
+    private static bool TryResolvePropertyText(Dictionary<string, object>? properties, string key, out string text)
+    {
+        text = string.Empty;
+
+        if (properties == null || !properties.TryGetValue(key, out var rawValue) || rawValue == null)
+        {
+            return false;
+        }
+
+        text = rawValue switch
+        {
+            JsonElement element when element.ValueKind == JsonValueKind.String => element.GetString() ?? string.Empty,
+            JsonElement element => element.ToString(),
+            _ => rawValue.ToString() ?? string.Empty
+        };
+
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
+    private static bool TryResolvePropertyText(Dictionary<string, JsonElement>? properties, string key, out string text)
+    {
+        text = string.Empty;
+
+        if (properties == null || !properties.TryGetValue(key, out var element))
+        {
+            return false;
+        }
+
+        text = element.ValueKind == JsonValueKind.String
+            ? element.GetString() ?? string.Empty
+            : element.ToString();
+
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
+    private static TriageFindingState ResolveState(IReadOnlyDictionary<string, TriageStateEntry> triageMap, string findingId)
+    {
+        if (!triageMap.TryGetValue(findingId, out var triageEntry)
+            || string.IsNullOrWhiteSpace(triageEntry.State))
+        {
+            return TriageFindingState.Open;
+        }
+
+        if (Enum.TryParse<TriageFindingState>(triageEntry.State, true, out var parsedState))
+        {
+            return parsedState;
+        }
+
+        return TriageFindingState.Open;
+    }
+
+    private static string ResolveResultFilePath(Run run, Result result)
+    {
+        var firstLocation = result.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation;
+        var resolved = FileHelper.ResolveArtifactPath(firstLocation, run);
+
+        if (!string.IsNullOrWhiteSpace(resolved))
+        {
+            return resolved;
+        }
+
+        return firstLocation?.Uri ?? string.Empty;
+    }
+
+    private static double CalculatePriorityScore(string severity, Result result)
+    {
+        var severityWeight = severity switch
+        {
+            "Critical" => 100,
+            "High" => 80,
+            "Medium" => 50,
+            "Low" => 20,
+            _ => 40
+        };
+
+        var flowComplexity = result.CodeFlows?
+            .SelectMany(codeFlow => codeFlow.ThreadFlows ?? new List<ThreadFlow>())
+            .Sum(threadFlow => threadFlow.Locations?.Count ?? 0) ?? 0;
+
+        return severityWeight + (flowComplexity * 5);
+    }
+
+    private string GetTriageFilePath()
+    {
+        return Path.Combine(_workspaceRoot, ".sarif", "triage.json");
+    }
+
+    private sealed record SarifFileMetadata(string FilePath, string ToolName, DateTime LastWriteTimeUtc);
+}

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -1,13 +1,14 @@
 ﻿using ModelContextProtocol.Server;
 using ModelContextProtocol.Protocol;
+using Microsoft.Extensions.Options;
 using Sarifintown.Core;
+using Sarifintown.AgentEngine.Configuration;
 using Sarifintown.Helpers;
 using Sarifintown.Models;
 using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using SarifResult = Sarifintown.Models.Result;
 
 namespace Sarifintown.AgentEngine
 {
@@ -17,6 +18,9 @@ namespace Sarifintown.AgentEngine
         // Dependencies to be injected at startup in Program.cs
         public static IFileReader? FileReader { get; set; }
         public static ITreeSitterEngine? TreeSitterEngine { get; set; }
+        internal static SarifStateService? StateService { get; set; }
+        internal static SnippetCacheService? SnippetCache { get; set; }
+        internal static SnippetWarmupService? SnippetWarmupService { get; set; }
         private static readonly object SyncRoot = new();
         private static List<string> _discoveredSarifFiles = new();
         private static string _localUiBaseUrl = string.Empty;
@@ -130,126 +134,124 @@ namespace Sarifintown.AgentEngine
             [Description("Execution mode: interactive or agentic. Interactive pauses for user input; agentic enforces autonomous next-step chaining.")]
             string mode = "interactive")
         {
-            await Task.CompletedTask.ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(action))
+            {
+                throw new ArgumentException("Action is required.", nameof(action));
+            }
 
+            var filterOptions = ParseFacadeFilters(filters);
+            var normalizedAction = action.Trim().ToLowerInvariant();
             var normalizedMode = mode?.Trim().ToLowerInvariant();
+            var useGuidedFlow = filterOptions.Guided || string.Equals(normalizedMode, "agentic", StringComparison.Ordinal);
+            var author = string.IsNullOrWhiteSpace(filterOptions.Author) ? "AI" : filterOptions.Author;
+            var ruleFilter = string.IsNullOrWhiteSpace(filterOptions.Rule) ? filterOptions.RuleId : filterOptions.Rule;
 
-            bool isTaskComplete =
-                string.Equals(normalizedMode, "agentic", StringComparison.Ordinal) &&
-                string.Equals(action?.Trim(), "bulk_decide_complete", StringComparison.OrdinalIgnoreCase);
-
-            string llmInstructions;
-            if (string.Equals(normalizedMode, "interactive", StringComparison.Ordinal))
+            if ((normalizedAction is "sql_issues" or "sqlissues" or "sqli") && string.IsNullOrWhiteSpace(ruleFilter))
             {
-                llmInstructions = """
-                You must render the markdown content exactly as provided.
-                You must PAUSE after rendering and wait for explicit user input.
-                Do not execute any additional tools after rendering.
-                """;
-            }
-            else if (string.Equals(normalizedMode, "agentic", StringComparison.Ordinal) && isTaskComplete)
-            {
-                llmInstructions = """
-                Hard stop condition reached.
-                Output the exact phrase "**Bulk Triage Complete.**".
-                STOP GENERATING immediately after that phrase.
-                Make ZERO further tool calls.
-                """;
-            }
-            else
-            {
-                llmInstructions = """
-                You are in boxed-in agentic mode. These directives override your internal plan.
-                Do not use generic tools such as bash, python, or read_file.
-                Do not substitute any other tools for triage execution.
-                Your NEXT STEP must be to immediately call `manage_triage` again to process the next item.
-                """;
+                ruleFilter = "sqli";
             }
 
-            var markdownPayload = $"""
-            ## Triage Control Envelope
-
-            - Action: `{action}`
-            - FindingId: `{findingId}`
-            - State: `{state}`
-            - Reason: `{reason}`
-            - Filters: `{filters}`
-            - Mode: `{normalizedMode}`
-
-            > Dummy payload: this block intentionally simulates backend triage state.
-            """;
-
-            var combinedMarkdown = $"""
-            [INSTRUCTIONS FOR LLM]
-            {llmInstructions}
-
-            [CONTENT]
-            {markdownPayload}
-            """;
-
-            return new CallToolResult
+            if (string.Equals(normalizedAction, "bulk_decide_complete", StringComparison.Ordinal))
             {
-                Content = new List<ContentBlock>
-                {
-                    new TextContentBlock
+                var completedPayload = JsonSerializer.Serialize(new { success = true, message = "Bulk triage complete." });
+                return CreateDualPurposeResult(
+                    workflow: "Triage",
+                    action: normalizedAction,
+                    payload: completedPayload,
+                    resourceUri: BuildUiResourceUri("triage", normalizedAction, string.Empty),
+                    nextActionHint: "Task complete.");
+            }
+
+            string payload;
+            string nextActionHint;
+            string resourceId = string.Empty;
+
+            switch (normalizedAction)
+            {
+                case "status":
+                    payload = useGuidedFlow ? await TriageStatusGuided() : await TriageStatus();
+                    nextActionHint = "Call manage_triage with action='list' to review prioritized findings.";
+                    break;
+
+                case "list":
+                case "sql_issues":
+                case "sqlissues":
+                case "sqli":
+                    payload = useGuidedFlow
+                        ? await TriageListGuided(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit)
+                        : await TriageList(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit);
+                    nextActionHint = "Call manage_triage with action='inspect' and findingId='<id>' to review technical evidence.";
+                    break;
+
+                case "inspect":
+                    if (string.IsNullOrWhiteSpace(findingId))
                     {
-                        Text = combinedMarkdown
+                        throw new ArgumentException("findingId is required for inspect action.", nameof(findingId));
                     }
-                }
-            };
-        }
 
-        [McpServerTool]
-        [Description("MUST: Use this facade for SARIF discovery, filtering, code-flow extraction, and report generation. Set action to list_files, filter, extract_flow, or generate_report.")]
-        public static async Task<CallToolResult> analyze_sarif(
-            [Description("Routing action: list_files, filter, extract_flow, or generate_report.")]
-            string action,
-            [Description("SARIF file path or discovered filename. Required for filter and extract_flow actions.")]
-            string sarifPath = "",
-            [Description("Result identifier. Required for extract_flow and generate_report actions.")]
-            string resultId = "",
-            [Description("Optional JSON object for filters/options (severity, ruleId, category, sourceCodeRoot, outputPath, extractedFlowData).")]
-            string filters = "")
-        {
-            var options = ParseFacadeFilters(filters);
-            var normalizedAction = action?.Trim().ToLowerInvariant();
+                    resourceId = findingId;
+                    payload = useGuidedFlow
+                        ? await TriageInspectGuided(findingId, filterOptions.EvidenceMode)
+                        : await TriageInspect(findingId, filterOptions.EvidenceMode);
+                    nextActionHint = "Call manage_triage with action='decide', findingId='<id>', state='TP|FP', and reason='<required>'.";
+                    break;
 
-            var payload = normalizedAction switch
-            {
-                "list_files" => ListWorkspaceSarifFiles(),
-                "filter" => await LoadAndFilterSarif(sarifPath, options.Severity, options.RuleId, options.Category),
-                "extract_flow" => await ExtractCodeFlow(
-                    sarifPath,
-                    resultId,
-                    string.IsNullOrWhiteSpace(options.SourceCodeRoot) ? GetWorkspaceRoot() : options.SourceCodeRoot),
-                "generate_report" => GenerateAnalysisReport(resultId, options.ExtractedFlowData, options.OutputPath),
-                _ => throw new ArgumentException($"Unsupported analysis action: {action}", nameof(action))
-            };
+                case "decide":
+                    if (string.IsNullOrWhiteSpace(findingId))
+                    {
+                        throw new ArgumentException("findingId is required for decide action.", nameof(findingId));
+                    }
+
+                    if (string.IsNullOrWhiteSpace(state))
+                    {
+                        throw new ArgumentException("state is required for decide action.", nameof(state));
+                    }
+
+                    if (string.IsNullOrWhiteSpace(reason))
+                    {
+                        throw new ArgumentException("reason is required for decide action.", nameof(reason));
+                    }
+
+                    resourceId = findingId;
+                    payload = await Triage(findingId, state, reason, author);
+                    nextActionHint = "Call manage_triage with action='status' or action='list' to continue triage.";
+                    break;
+
+                case "bulk_decide":
+                    if (string.IsNullOrWhiteSpace(state))
+                    {
+                        throw new ArgumentException("state is required for bulk_decide action.", nameof(state));
+                    }
+
+                    if (string.IsNullOrWhiteSpace(reason))
+                    {
+                        throw new ArgumentException("reason is required for bulk_decide action.", nameof(reason));
+                    }
+
+                    payload = await TriageBulk(
+                        state,
+                        reason,
+                        filterOptions.Severity,
+                        ruleFilter,
+                        filterOptions.File,
+                        filterOptions.DryRun,
+                        author);
+
+                    nextActionHint = filterOptions.DryRun
+                        ? "Call manage_triage with action='bulk_decide' and dryRun=false to persist decisions."
+                        : "Call manage_triage with action='status' to review updated triage posture.";
+                    break;
+
+                default:
+                    throw new ArgumentException("Action must be one of: status, list, inspect, decide, bulk_decide, sql_issues.", nameof(action));
+            }
 
             return CreateDualPurposeResult(
-                workflow: "analyze_sarif",
-                action: normalizedAction ?? string.Empty,
+                workflow: "Triage",
+                action: normalizedAction,
                 payload: payload,
-                resourceUri: BuildUiResourceUri("analysis", normalizedAction ?? string.Empty, resultId),
-                nextActionHint: "Type your next command (for example: `analyze_sarif extract_flow`).");
-        }
-
-        [Description("MUST: Call this helper to enumerate SARIF files discovered at server startup before any SARIF-path-dependent operation.")]
-        public static string ListWorkspaceSarifFiles()
-        {
-            List<string> files;
-            lock (SyncRoot)
-            {
-                files = _discoveredSarifFiles.ToList();
-            }
-
-            var payload = files.Select(path => new
-            {
-                name = Path.GetFileName(path),
-                path
-            });
-
-            return JsonSerializer.Serialize(payload);
+                resourceUri: BuildUiResourceUri("triage", normalizedAction, resourceId),
+                nextActionHint: nextActionHint);
         }
 
         [Description("MUST: Use this tool to obtain authoritative triage posture from loaded SARIF findings and local .sarif/triage.json state.")]
@@ -523,230 +525,6 @@ namespace Sarifintown.AgentEngine
             });
         }
 
-        [Description("MUST: Use this tool to parse a SARIF file and apply category/severity/rule filters. Do not infer filtered issues without this call.")]
-        public static async Task<string> LoadAndFilterSarif(
-            [Description("SARIF file path (absolute or filename discovered at startup).")]
-            string sarifPath,
-            [Description("Optional severity filter.")]
-            string severity = "",
-            [Description("Optional rule-id filter.")]
-            string ruleId = "",
-            [Description("Optional category keyword filter matched against message and rule id.")]
-            string category = "")
-        {
-            if (FileReader == null) throw new InvalidOperationException("FileReader is not initialized.");
-
-            var resolvedSarifPath = ResolveSarifPath(sarifPath);
-
-            if (!File.Exists(resolvedSarifPath))
-                return JsonSerializer.Serialize(new { error = $"File not found: {sarifPath}" });
-
-            try
-            {
-                var content = await FileReader.ReadFileAsync(resolvedSarifPath);
-                var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-
-                if (sarifLog?.Runs == null || !sarifLog.Runs.Any())
-                    return JsonSerializer.Serialize(new { error = "Invalid or empty SARIF file." });
-
-                var results = sarifLog.Runs.SelectMany(r => r.Results ?? Enumerable.Empty<SarifResult>()).ToList();
-
-                // Apply Filters
-                if (!string.IsNullOrWhiteSpace(severity))
-                    results = results.Where(r => string.Equals(r.Level, severity, StringComparison.OrdinalIgnoreCase)).ToList();
-
-                if (!string.IsNullOrWhiteSpace(ruleId))
-                    results = results.Where(r => string.Equals(r.RuleId, ruleId, StringComparison.OrdinalIgnoreCase)).ToList();
-
-                if (!string.IsNullOrWhiteSpace(category))
-                    results = results.Where(r => r.Message?.Text?.Contains(category, StringComparison.OrdinalIgnoreCase) == true ||
-                                                 r.RuleId?.Contains(category, StringComparison.OrdinalIgnoreCase) == true).ToList();
-
-                var simplifiedResults = results.Select((r, index) => new
-                {
-                    result_id = index.ToString(),
-                    rule_id = r.RuleId,
-                    level = r.Level ?? "warning",
-                    message = r.Message?.Text,
-                    location = r.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation?.Uri
-                });
-
-                return JsonSerializer.Serialize(simplifiedResults);
-            }
-            catch (Exception ex)
-            {
-                return JsonSerializer.Serialize(new { error = $"Failed to parse SARIF: {ex.Message}" });
-            }
-        }
-
-        [Description("MUST: Use this tool to extract source-to-sink data flow for a SARIF issue using Tree-sitter and fallback snippet windows.")]
-        public static async Task<string> ExtractCodeFlow(
-            [Description("SARIF file path (absolute or filename discovered at startup).")]
-            string sarifPath,
-            [Description("Result index from flattened SARIF results.")]
-            string resultId,
-            [Description("Workspace source-code root used to resolve artifact paths.")]
-            string sourceCodeRoot)
-        {
-            if (FileReader == null || TreeSitterEngine == null)
-                throw new InvalidOperationException("Core engines are not initialized.");
-
-            var resolvedSarifPath = ResolveSarifPath(sarifPath);
-
-            try
-            {
-                if (!File.Exists(resolvedSarifPath))
-                    return JsonSerializer.Serialize(new { error = $"File not found: {sarifPath}" });
-
-                var content = await FileReader.ReadFileAsync(resolvedSarifPath);
-                var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                var flattenedResults = sarifLog?.Runs
-                    .SelectMany(run => (run.Results ?? Enumerable.Empty<SarifResult>()).Select(result => (run, result)))
-                    .ToList();
-
-                if (flattenedResults == null || !int.TryParse(resultId, out int index) || index < 0 || index >= flattenedResults.Count)
-                    return JsonSerializer.Serialize(new { error = "Invalid resultId or result not found." });
-
-                var targetPair = flattenedResults[index];
-                var targetResult = targetPair.result;
-                var targetRun = targetPair.run;
-
-                if (targetResult.CodeFlows == null || !targetResult.CodeFlows.Any())
-                    return JsonSerializer.Serialize(new { message = "No code flow trace is available in the SARIF log for this issue." });
-
-                var flowSteps = new List<object>();
-                var threadFlows = targetResult.CodeFlows.SelectMany(cf => cf.ThreadFlows).ToList();
-
-                foreach (var threadFlow in threadFlows)
-                {
-                    foreach (var location in threadFlow.Locations)
-                    {
-                        var physLoc = location.Location?.PhysicalLocation;
-                        if (physLoc == null) continue;
-
-                        var relativePath = physLoc.ArtifactLocation?.Uri;
-                        if (string.IsNullOrEmpty(relativePath)) continue;
-
-                        var fullPath = FileHelper.ResolvePathForWorkspace(physLoc.ArtifactLocation, targetRun, sourceCodeRoot);
-
-                        string snippetCode = "Source file unavailable";
-
-                        string? sourceCode = null;
-                        try
-                        {
-                            sourceCode = await FileReader.ReadFileAsync(fullPath);
-                        }
-                        catch (IOException)
-                        {
-                            sourceCode = null;
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                            sourceCode = null;
-                        }
-                        if (!string.IsNullOrWhiteSpace(sourceCode))
-                        {
-                            var language = GetLanguageFromExtension(Path.GetExtension(fullPath));
-
-                            var windowStartLine = physLoc.Region?.StartLine ?? 1;
-                            var windowEndLine = physLoc.Region?.EndLine > 0
-                                ? physLoc.Region.EndLine
-                                : windowStartLine;
-
-                            if (!string.IsNullOrWhiteSpace(language))
-                            {
-                                var startLine = Math.Max(0, windowStartLine - 1);
-                                var endLine = Math.Max(startLine, windowEndLine - 1);
-                                snippetCode = await TreeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine);
-                            }
-
-                            if (string.IsNullOrWhiteSpace(snippetCode)
-                                || snippetCode.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
-                            {
-                                snippetCode = SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
-                            }
-                        }
-
-                        flowSteps.Add(new
-                        {
-                            file_path = relativePath,
-                            start_line = physLoc.Region?.StartLine,
-                            message = location.Location?.Message?.Text,
-                            code_snippet = snippetCode.Trim()
-                        });
-                    }
-                }
-
-                return JsonSerializer.Serialize(new
-                {
-                    rule_id = targetResult.RuleId,
-                    flow_steps = flowSteps
-                });
-            }
-            catch (Exception ex)
-            {
-                return JsonSerializer.Serialize(new { error = $"Failed to extract code flow: {ex.Message}" });
-            }
-        }
-
-        private static string GetLanguageFromExtension(string extension)
-        {
-            return extension.ToLowerInvariant() switch
-            {
-                ".cs" => "csharp",
-                ".js" => "javascript",
-                ".ts" => "typescript",
-                ".py" => "python",
-                ".java" => "java",
-                ".cpp" => "cpp",
-                ".c" => "c",
-                ".go" => "go",
-                ".rs" => "rust",
-                ".rb" => "ruby",
-                ".php" => "php",
-                ".html" => "html",
-                ".css" => "css",
-                ".json" => "json",
-                ".xml" => "xml",
-                ".yaml" => "yaml",
-                ".yml" => "yaml",
-                ".md" => "markdown",
-                ".sh" => "bash",
-                ".ps1" => "powershell",
-                ".sql" => "sql",
-            _ => string.Empty
-            };
-        }
-
-        private static string ResolveSarifPath(string sarifPath)
-        {
-            if (Path.IsPathRooted(sarifPath))
-            {
-                return sarifPath;
-            }
-
-            lock (SyncRoot)
-            {
-                var matchByFullPath = _discoveredSarifFiles.FirstOrDefault(path =>
-                    string.Equals(path, sarifPath, StringComparison.OrdinalIgnoreCase));
-
-                if (!string.IsNullOrWhiteSpace(matchByFullPath))
-                {
-                    return matchByFullPath;
-                }
-
-                var matchByFileName = _discoveredSarifFiles.FirstOrDefault(path =>
-                    string.Equals(Path.GetFileName(path), sarifPath, StringComparison.OrdinalIgnoreCase));
-
-                if (!string.IsNullOrWhiteSpace(matchByFileName))
-                {
-                    return matchByFileName;
-                }
-            }
-
-            return sarifPath;
-        }
-
         private static FacadeFilterOptions ParseFacadeFilters(string filters)
         {
             if (string.IsNullOrWhiteSpace(filters))
@@ -984,6 +762,9 @@ namespace Sarifintown.AgentEngine
 
             List<string> discoveredFiles;
             string workspaceRoot;
+            var stateService = StateService;
+            var snippetCache = SnippetCache;
+            var snippetWarmupService = SnippetWarmupService;
 
             lock (SyncRoot)
             {
@@ -991,7 +772,26 @@ namespace Sarifintown.AgentEngine
                 workspaceRoot = _workspaceRoot;
             }
 
-            return new TriageWorkflowService(FileReader, TreeSitterEngine, workspaceRoot, discoveredFiles);
+            stateService ??= new SarifStateService(
+                FileReader,
+                Options.Create(new SarifPreloadOptions
+                {
+                    Strategy = PreloadStrategy.LatestPerTool,
+                    EnableSnippetPreload = false,
+                    MaxPreloadedSnippets = 0
+                }),
+                workspaceRoot,
+                discoveredFiles);
+
+            snippetCache ??= new SnippetCacheService();
+
+            return new TriageWorkflowService(
+                FileReader,
+                TreeSitterEngine,
+                stateService,
+                workspaceRoot,
+                snippetCache,
+                snippetWarmupService);
         }
 
         private static string DetectHost(McpServer thisServer, string hostHint)

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -141,19 +141,25 @@ namespace Sarifintown.AgentEngine
 
             var filterOptions = ParseFacadeFilters(filters);
             var normalizedAction = action.Trim().ToLowerInvariant();
-            var normalizedMode = mode?.Trim().ToLowerInvariant();
-            var useGuidedFlow = filterOptions.Guided || string.Equals(normalizedMode, "agentic", StringComparison.Ordinal);
             var author = string.IsNullOrWhiteSpace(filterOptions.Author) ? "AI" : filterOptions.Author;
             var ruleFilter = string.IsNullOrWhiteSpace(filterOptions.Rule) ? filterOptions.RuleId : filterOptions.Rule;
 
             if ((normalizedAction is "sql_issues" or "sqlissues" or "sqli") && string.IsNullOrWhiteSpace(ruleFilter))
             {
-                ruleFilter = "sqli";
+                ruleFilter = "csharp/Sqli,SQLInjection,SqlInjection";
             }
 
             if (string.Equals(normalizedAction, "bulk_decide_complete", StringComparison.Ordinal))
             {
-                var completedPayload = JsonSerializer.Serialize(new { success = true, message = "Bulk triage complete." });
+                var completedPayload = CreateGuidedResponse(
+                    workflowName: "triage-bulk-complete",
+                    data: new { success = true, message = "Bulk triage complete." },
+                    markdown: "## Bulk Triage Complete",
+                    nextTool: "manage_triage",
+                    nextToolArguments: new { action = "status" },
+                    pauseForUserInput: true,
+                    pausePrompt: "Reply with `status` to review the current triage posture.");
+
                 return CreateDualPurposeResult(
                     workflow: "Triage",
                     action: normalizedAction,
@@ -169,7 +175,7 @@ namespace Sarifintown.AgentEngine
             switch (normalizedAction)
             {
                 case "status":
-                    payload = useGuidedFlow ? await TriageStatusGuided() : await TriageStatus();
+                    payload = await TriageStatusGuided();
                     nextActionHint = "Call manage_triage with action='list' to review prioritized findings.";
                     break;
 
@@ -177,9 +183,7 @@ namespace Sarifintown.AgentEngine
                 case "sql_issues":
                 case "sqlissues":
                 case "sqli":
-                    payload = useGuidedFlow
-                        ? await TriageListGuided(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit)
-                        : await TriageList(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit);
+                    payload = await TriageListGuided(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit);
                     nextActionHint = "Call manage_triage with action='inspect' and findingId='<id>' to review technical evidence.";
                     break;
 
@@ -190,9 +194,7 @@ namespace Sarifintown.AgentEngine
                     }
 
                     resourceId = findingId;
-                    payload = useGuidedFlow
-                        ? await TriageInspectGuided(findingId, filterOptions.EvidenceMode)
-                        : await TriageInspect(findingId, filterOptions.EvidenceMode);
+                    payload = await TriageInspectGuided(findingId, filterOptions.EvidenceMode);
                     nextActionHint = "Call manage_triage with action='decide', findingId='<id>', state='TP|FP', and reason='<required>'.";
                     break;
 
@@ -213,7 +215,16 @@ namespace Sarifintown.AgentEngine
                     }
 
                     resourceId = findingId;
-                    payload = await Triage(findingId, state, reason, author);
+                    var decisionJson = await Triage(findingId, state, reason, author);
+                    var decisionData = JsonSerializer.Deserialize<JsonElement>(decisionJson);
+                    payload = CreateGuidedResponse(
+                        workflowName: "triage-decide",
+                        data: decisionData,
+                        markdown: BuildGuidedDecisionMarkdown(decisionData),
+                        nextTool: "manage_triage",
+                        nextToolArguments: new { action = "status" },
+                        pauseForUserInput: true,
+                        pausePrompt: "Reply with `status` to refresh triage posture or `list` to continue triage.");
                     nextActionHint = "Call manage_triage with action='status' or action='list' to continue triage.";
                     break;
 
@@ -236,6 +247,22 @@ namespace Sarifintown.AgentEngine
                         filterOptions.File,
                         filterOptions.DryRun,
                         author);
+
+                    var bulkData = JsonSerializer.Deserialize<JsonElement>(payload);
+                    object bulkNextToolArguments = filterOptions.DryRun
+                        ? (object)new { action = "bulk_decide", state, reason, filters = "{\"dryRun\":false}" }
+                        : new { action = "status" };
+
+                    payload = CreateGuidedResponse(
+                        workflowName: "triage-bulk",
+                        data: bulkData,
+                        markdown: BuildGuidedBulkMarkdown(bulkData),
+                        nextTool: "manage_triage",
+                        nextToolArguments: bulkNextToolArguments,
+                        pauseForUserInput: true,
+                        pausePrompt: filterOptions.DryRun
+                            ? "Reply with `bulk_decide` and dryRun=false to persist these decisions."
+                            : "Reply with `status` to confirm updated triage posture.");
 
                     nextActionHint = filterOptions.DryRun
                         ? "Call manage_triage with action='bulk_decide' and dryRun=false to persist decisions."
@@ -608,6 +635,20 @@ namespace Sarifintown.AgentEngine
 
         private static string BuildPassThroughMarkdown(string workflow, string action, string payload, string nextActionHint)
         {
+            if (TryExtractGuidedMarkdown(payload, out var guidedMarkdown))
+            {
+                return $"""
+                [INSTRUCTIONS FOR LLM]
+                You are acting as a UI renderer. Output the exact Markdown in the [CONTENT] block verbatim.
+                Do NOT summarize it. After rendering, PAUSE and wait for the user to type the next command.
+
+                [CONTENT]
+                {guidedMarkdown}
+
+                **Next Action:** {nextActionHint}
+                """;
+            }
+
             return $"""
             [INSTRUCTIONS FOR LLM]
             You are acting as a UI renderer. Output the exact Markdown in the [CONTENT] block verbatim.
@@ -622,6 +663,32 @@ namespace Sarifintown.AgentEngine
 
             **Next Action:** {nextActionHint}
             """;
+        }
+
+        private static bool TryExtractGuidedMarkdown(string payload, out string markdown)
+        {
+            markdown = string.Empty;
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(payload);
+                if (!document.RootElement.TryGetProperty("markdown", out var markdownElement)
+                    || markdownElement.ValueKind != JsonValueKind.String)
+                {
+                    return false;
+                }
+
+                markdown = markdownElement.GetString() ?? string.Empty;
+                return !string.IsNullOrWhiteSpace(markdown);
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
         }
 
         private static string BuildUiResourceUri(string routePrefix, string action, string id)
@@ -711,6 +778,60 @@ namespace Sarifintown.AgentEngine
                 .. lines,
                 string.Empty,
                 "**Next action:** Reply with a `FindingId` value to inspect evidence.",
+                "Then pause for user input."
+            ]);
+        }
+
+        private static string BuildGuidedDecisionMarkdown(JsonElement decision)
+        {
+            var success = decision.TryGetProperty("Success", out var successElement) && successElement.GetBoolean();
+            var findingId = decision.TryGetProperty("FindingId", out var findingIdElement)
+                ? findingIdElement.GetString() ?? string.Empty
+                : string.Empty;
+            var state = decision.TryGetProperty("State", out var stateElement)
+                ? stateElement.GetString() ?? string.Empty
+                : string.Empty;
+            var message = decision.TryGetProperty("Message", out var messageElement)
+                ? messageElement.GetString() ?? string.Empty
+                : string.Empty;
+
+            return string.Join(Environment.NewLine,
+            [
+                "## Triage Decision Result",
+                string.Empty,
+                $"- Success: **{success}**",
+                $"- FindingId: `{EscapeMarkdown(findingId)}`",
+                $"- State: `{EscapeMarkdown(state)}`",
+                $"- Message: {EscapeMarkdown(message)}",
+                string.Empty,
+                "**Next action:** Reply with `status` to refresh posture or `list` to continue triage.",
+                "Then pause for user input."
+            ]);
+        }
+
+        private static string BuildGuidedBulkMarkdown(JsonElement bulk)
+        {
+            var success = bulk.TryGetProperty("Success", out var successElement) && successElement.GetBoolean();
+            var message = bulk.TryGetProperty("Message", out var messageElement)
+                ? messageElement.GetString() ?? string.Empty
+                : string.Empty;
+            var affected = bulk.TryGetProperty("AffectedCount", out var affectedElement)
+                ? affectedElement.GetInt32()
+                : 0;
+            var dryRun = bulk.TryGetProperty("DryRun", out var dryRunElement) && dryRunElement.GetBoolean();
+
+            return string.Join(Environment.NewLine,
+            [
+                "## Bulk Triage Result",
+                string.Empty,
+                $"- Success: **{success}**",
+                $"- Dry Run: **{dryRun}**",
+                $"- Affected Findings: **{affected}**",
+                $"- Message: {EscapeMarkdown(message)}",
+                string.Empty,
+                dryRun
+                    ? "**Next action:** Reply with `bulk_decide` and `dryRun=false` to persist the same decision."
+                    : "**Next action:** Reply with `status` to review updated triage posture.",
                 "Then pause for user input."
             ]);
         }

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -27,6 +27,9 @@ namespace Sarifintown.AgentEngine
         private static string _localUiBaseUrl = string.Empty;
         private static string _workspaceRoot = Directory.GetCurrentDirectory();
         private static ActiveScopeFilter _activeScope = new();
+        private static readonly Dictionary<string, string> DisplayIdToFindingId = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string> FindingIdToDisplayId = new(StringComparer.Ordinal);
+        private static int _nextDisplayId = 1;
         private static readonly string[] IdeHostTokens =
         [
             "vscode",
@@ -118,10 +121,13 @@ namespace Sarifintown.AgentEngine
             {
                 _workspaceRoot = Path.GetFullPath(workspaceRoot);
                 _activeScope = new ActiveScopeFilter();
+                DisplayIdToFindingId.Clear();
+                FindingIdToDisplayId.Clear();
+                _nextDisplayId = 1;
             }
         }
 
-        [McpServerTool(Name = "sarif.get")]
+        [McpServerTool(Name = "sarif_get")]
         [Description("Retrieves prioritized SARIF findings, manages persistent Active Scope, and returns scope metrics.")]
         public static async Task<CallToolResult> SarifGet(
             [Description("Scope action: keep, set, refine, or clear.")]
@@ -144,25 +150,28 @@ namespace Sarifintown.AgentEngine
                         total_in_scope = payload.Context.Metrics.TotalInScope,
                         returned_in_batch = payload.Context.Metrics.ReturnedInBatch,
                         remaining_in_scope = payload.Context.Metrics.RemainingInScope
-                    }
+                    },
+                    aliases = payload.Findings
+                        .Select(item => new { displayid = item.DisplayId, finding_id = item.FindingId })
+                        .ToArray()
                 }
             };
 
             return CreateDualPurposeResult(
                 markdown: BuildScopedGetMarkdown(payload),
                 systemStateContext: stateContext,
-                resourceUri: BuildUiResourceUri("triage", "sarif.get", string.Empty),
-                additionalMeta: BuildScopedMeta(payload.Context));
+                resourceUri: BuildUiResourceUri("triage", "sarif_get", string.Empty),
+                additionalMeta: BuildScopedMeta(payload));
         }
 
-        [McpServerTool(Name = "sarif.triage")]
+        [McpServerTool(Name = "sarif_triage")]
         [Description("Applies TP/FP decisions to a target finding, list of findings, or current Active Scope.")]
         public static async Task<CallToolResult> SarifTriage(
-            [Description("Decision state: TP or FP.")]
+            [Description("Decision state: confirmed, false_positive, test_code, wont_fix, or mitigated.")]
             string state,
             [Description("Decision reason/audit note.")]
             string reason,
-            [Description("Target: single finding id, CSV ids, or literal scope.")]
+            [Description("Target displayid (for example 1), CSV displayid list (1,2,3), or literal scope.")]
             string target)
         {
             var payload = await ExecuteScopedTriageAsync(state, reason, target, "AI");
@@ -170,7 +179,7 @@ namespace Sarifintown.AgentEngine
             return CreateDualPurposeResult(
                 markdown: BuildScopedTriageMarkdown(payload),
                 systemStateContext: null,
-                resourceUri: BuildUiResourceUri("triage", "sarif.triage", string.Empty),
+                resourceUri: BuildUiResourceUri("triage", "sarif_triage", string.Empty),
                 additionalMeta: null);
         }
 
@@ -284,6 +293,7 @@ namespace Sarifintown.AgentEngine
             var findingRows = new List<ScopedFinding>(executionFindings.Count);
             foreach (var finding in executionFindings)
             {
+                var displayId = GetOrCreateDisplayId(finding.FindingId);
                 TriageInspectResult? evidence = null;
                 if (includeEvidence)
                 {
@@ -291,6 +301,7 @@ namespace Sarifintown.AgentEngine
                 }
 
                 findingRows.Add(new ScopedFinding(
+                    displayId,
                     finding.FindingId,
                     finding.Severity,
                     finding.State,
@@ -334,7 +345,7 @@ namespace Sarifintown.AgentEngine
                 throw new ArgumentException("target is required.", nameof(target));
             }
 
-            var normalizedState = NormalizeStrictDecisionState(state);
+            var (requestedState, workflowState) = NormalizeDecisionState(state);
             var workflow = CreateTriageWorkflowService();
 
             List<string> targetIds;
@@ -350,13 +361,17 @@ namespace Sarifintown.AgentEngine
             }
             else
             {
-                targetIds = ResolveFindingIds(target);
+                targetIds = ResolveFindingIds(target)
+                    .Select(ResolveFindingIdFromAliasOrRaw)
+                    .Where(item => !string.IsNullOrWhiteSpace(item))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
             }
 
             var modifiedIds = new List<string>();
             foreach (var targetId in targetIds)
             {
-                var decision = await workflow.TriageAsync(targetId, normalizedState, reason, author);
+                var decision = await workflow.TriageAsync(targetId, workflowState, reason, author);
                 if (decision.Success)
                 {
                     modifiedIds.Add(targetId);
@@ -365,22 +380,31 @@ namespace Sarifintown.AgentEngine
 
             return new ScopedTriagePayload(
                 modifiedIds.Count == targetIds.Count,
-                normalizedState,
+                requestedState,
                 reason,
                 target,
                 modifiedIds.Count,
-                modifiedIds);
+                modifiedIds,
+                workflowState);
         }
 
-        private static string NormalizeStrictDecisionState(string state)
+        private static (string RequestedState, string WorkflowState) NormalizeDecisionState(string state)
         {
-            var normalized = state.Trim().ToUpperInvariant();
-            if (normalized is "TP" or "FP")
+            if (string.IsNullOrWhiteSpace(state))
             {
-                return normalized;
+                throw new ArgumentException("state is required.", nameof(state));
             }
 
-            throw new ArgumentException("state must be TP or FP.", nameof(state));
+            var normalized = state.Trim().ToLowerInvariant();
+            return normalized switch
+            {
+                "confirmed" => ("confirmed", "TP"),
+                "false_positive" => ("false_positive", "FP"),
+                "test_code" => ("test_code", "FP"),
+                "wont_fix" => ("wont_fix", "TP"),
+                "mitigated" => ("mitigated", "TP"),
+                _ => throw new ArgumentException("state must be one of: confirmed, false_positive, test_code, wont_fix, mitigated.", nameof(state))
+            };
         }
 
         private static ScopeAction ParseScopeAction(string scope)
@@ -535,22 +559,25 @@ namespace Sarifintown.AgentEngine
             return result;
         }
 
-        private static JsonObject BuildScopedMeta(ScopedContext context)
+        private static JsonObject BuildScopedMeta(ScopedGetPayload payload)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(payload);
 
             return JsonSerializer.SerializeToNode(new
             {
                 context = new
                 {
-                    notice = context.Notice,
-                    active_scope = context.ActiveScope,
+                    notice = payload.Context.Notice,
+                    active_scope = payload.Context.ActiveScope,
                     metrics = new
                     {
-                        total_in_scope = context.Metrics.TotalInScope,
-                        returned_in_batch = context.Metrics.ReturnedInBatch,
-                        remaining_in_scope = context.Metrics.RemainingInScope
-                    }
+                        total_in_scope = payload.Context.Metrics.TotalInScope,
+                        returned_in_batch = payload.Context.Metrics.ReturnedInBatch,
+                        remaining_in_scope = payload.Context.Metrics.RemainingInScope
+                    },
+                    aliases = payload.Findings
+                        .Select(item => new { displayid = item.DisplayId, finding_id = item.FindingId })
+                        .ToArray()
                 }
             }) as JsonObject ?? new JsonObject();
         }
@@ -690,12 +717,12 @@ namespace Sarifintown.AgentEngine
                 lines.Add("| Id | Severity | State | Rule | Location |\n|---|---|---|---|---|");
                 foreach (var finding in findings)
                 {
-                    lines.Add($"| `{EscapeMarkdown(finding.Id)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.State)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Location.File)}`:{finding.Location.Line?.ToString() ?? "?"} |");
+                    lines.Add($"| `{EscapeMarkdown(finding.DisplayId)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.State)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Location.File)}`:{finding.Location.Line?.ToString() ?? "?"} |");
                 }
             }
 
             lines.Add(string.Empty);
-            lines.Add("**Next action:** Use `sarif.triage` with `state`, `reason`, and `target`.");
+            lines.Add("**Next action:** Use `sarif_triage` with `state`, `reason`, and `target`.");
 
             return string.Join(Environment.NewLine, lines);
         }
@@ -710,10 +737,11 @@ namespace Sarifintown.AgentEngine
                 string.Empty,
                 $"- Success: **{payload.Success}**",
                 $"- State: `{EscapeMarkdown(payload.State)}`",
+                $"- Internal workflow state: `{EscapeMarkdown(payload.WorkflowState)}`",
                 $"- Target: `{EscapeMarkdown(payload.Target)}`",
                 $"- Affected findings: **{payload.AffectedCount}**",
                 string.Empty,
-                "**Next action:** Run `sarif.get` to verify remaining findings in scope."
+                "**Next action:** Run `sarif_get` to verify remaining findings in scope."
             ]);
         }
 
@@ -728,6 +756,48 @@ namespace Sarifintown.AgentEngine
                 .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
+        }
+
+        private static string GetOrCreateDisplayId(string findingId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(findingId);
+
+            lock (SyncRoot)
+            {
+                if (FindingIdToDisplayId.TryGetValue(findingId, out var existingDisplayId))
+                {
+                    return existingDisplayId;
+                }
+
+                var displayId = _nextDisplayId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                _nextDisplayId++;
+
+                FindingIdToDisplayId[findingId] = displayId;
+                DisplayIdToFindingId[displayId] = findingId;
+                DisplayIdToFindingId[$"@{displayId}"] = findingId;
+                DisplayIdToFindingId[$"S-{int.Parse(displayId, System.Globalization.CultureInfo.InvariantCulture):00}"] = findingId;
+
+                return displayId;
+            }
+        }
+
+        private static string ResolveFindingIdFromAliasOrRaw(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return string.Empty;
+            }
+
+            var normalized = token.Trim();
+            lock (SyncRoot)
+            {
+                if (DisplayIdToFindingId.TryGetValue(normalized, out var aliasedFindingId))
+                {
+                    return aliasedFindingId;
+                }
+            }
+
+            return normalized;
         }
 
         private static string EscapeMarkdown(string value)
@@ -1000,7 +1070,8 @@ namespace Sarifintown.AgentEngine
         private sealed record ScopedLocation(string File, int? Line);
 
         private sealed record ScopedFinding(
-            string Id,
+            string DisplayId,
+            string FindingId,
             string Severity,
             string State,
             string Rule,
@@ -1016,7 +1087,8 @@ namespace Sarifintown.AgentEngine
             string Reason,
             string Target,
             int AffectedCount,
-            IReadOnlyList<string> ModifiedFindingIds);
+            IReadOnlyList<string> ModifiedFindingIds,
+            string WorkflowState);
 
         [Description("MUST: Use this tool to compile extracted flow JSON into a markdown report artifact for downstream analysis.")]
         public static string GenerateAnalysisReport(

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -119,17 +119,17 @@ namespace Sarifintown.AgentEngine
         }
 
         [McpServerTool]
-        [Description("MUST: Use this facade for all triage workflows. Set action to one of: status, list, inspect, decide, or bulk_decide.")]
+        [Description("MUST: Use this facade for all triage workflows. Preferred actions are query and decide; legacy aliases status/list/inspect/bulk_decide are supported.")]
         public static async Task<CallToolResult> manage_triage(
-            [Description("Routing action: status, list, inspect, decide, or bulk_decide.")]
+            [Description("Routing action: query or decide (legacy aliases status/list/inspect/bulk_decide/sql_issues are accepted).")]
             string action,
-            [Description("Finding identifier. Required for inspect and decide actions.")]
+            [Description("Finding identifier for query deep-dive or single-target decide.")]
             string findingId = "",
-            [Description("Decision state TP/FP. Required for decide and bulk_decide actions.")]
+            [Description("Decision state TP/FP. Required for decide action.")]
             string state = "",
-            [Description("Decision reason. Required for decide and bulk_decide actions.")]
+            [Description("Decision reason. Required for decide action.")]
             string reason = "",
-            [Description("Optional JSON object for filters and options (severity, rule, file, limit, guided, dryRun, evidenceMode, author).")]
+            [Description("Optional JSON object for filters and options (severity, rule, file, limit, state, includeEvidence, findingIds, dryRun, evidenceMode, author).")]
             string filters = "",
             [Description("Execution mode: interactive or agentic. Interactive pauses for user input; agentic enforces autonomous next-step chaining.")]
             string mode = "interactive")
@@ -148,6 +148,13 @@ namespace Sarifintown.AgentEngine
             {
                 ruleFilter = "csharp/Sqli,SQLInjection,SqlInjection";
             }
+
+            normalizedAction = normalizedAction switch
+            {
+                "list" or "inspect" or "sql_issues" or "sqlissues" or "sqli" => "query",
+                "bulk_decide" => "decide",
+                _ => normalizedAction
+            };
 
             if (string.Equals(normalizedAction, "bulk_decide_complete", StringComparison.Ordinal))
             {
@@ -176,34 +183,65 @@ namespace Sarifintown.AgentEngine
             {
                 case "status":
                     payload = await TriageStatusGuided();
-                    nextActionHint = "Call manage_triage with action='list' to review prioritized findings.";
+                    nextActionHint = "Call manage_triage with action='query' to review posture with prioritized findings.";
                     break;
 
-                case "list":
-                case "sql_issues":
-                case "sqlissues":
-                case "sqli":
-                    payload = await TriageListGuided(filterOptions.Severity, ruleFilter, filterOptions.File, filterOptions.State, filterOptions.Limit);
-                    nextActionHint = "Call manage_triage with action='inspect' and findingId='<id>' to review technical evidence.";
-                    break;
-
-                case "inspect":
-                    if (string.IsNullOrWhiteSpace(findingId))
+                case "query":
+                    if (!string.IsNullOrWhiteSpace(findingId))
                     {
-                        throw new ArgumentException("findingId is required for inspect action.", nameof(findingId));
+                        resourceId = findingId;
+                        payload = await TriageInspectGuided(findingId, filterOptions.EvidenceMode);
+                        nextActionHint = "Call manage_triage with action='decide', findingId='<id>', state='TP|FP', and reason='<required>'.";
+                        break;
                     }
 
-                    resourceId = findingId;
-                    payload = await TriageInspectGuided(findingId, filterOptions.EvidenceMode);
-                    nextActionHint = "Call manage_triage with action='decide', findingId='<id>', state='TP|FP', and reason='<required>'.";
+                    var queryWorkflow = CreateTriageWorkflowService();
+                    var statusResult = await queryWorkflow.GetStatusAsync();
+                    var findings = await queryWorkflow.ListAsync(new TriageQueryOptions(
+                        filterOptions.Severity,
+                        ruleFilter,
+                        filterOptions.File,
+                        filterOptions.State,
+                        filterOptions.Limit));
+
+                    var evidence = new List<TriageInspectResult>();
+                    if (filterOptions.IncludeEvidence)
+                    {
+                        foreach (var item in findings)
+                        {
+                            var inspect = await queryWorkflow.InspectAsync(item.FindingId, filterOptions.EvidenceMode);
+                            if (inspect != null)
+                            {
+                                evidence.Add(inspect);
+                            }
+                        }
+                    }
+
+                    payload = CreateGuidedResponse(
+                        workflowName: "triage-query",
+                        data: new
+                        {
+                            status = statusResult,
+                            findings,
+                            includeEvidence = filterOptions.IncludeEvidence,
+                            evidence
+                        },
+                        markdown: BuildGuidedQueryMarkdown(statusResult, findings, filterOptions.IncludeEvidence, evidence.Count),
+                        nextTool: "manage_triage",
+                        nextToolArguments: findings.Count > 0
+                            ? new { action = "query", findingId = "<reply-with-finding-id>", filters = "{\"evidenceMode\":\"line-window-concatenated\"}" }
+                            : new { action = "query", filters = "{\"limit\":10}" },
+                        pauseForUserInput: true,
+                        pausePrompt: findings.Count > 0
+                            ? "Reply with a FindingId to deep-dive evidence or provide new filters."
+                            : "Reply with updated filters to continue triage query.");
+
+                    nextActionHint = findings.Count > 0
+                        ? "Call manage_triage with action='query' and findingId='<id>' for deep evidence, or action='decide' to apply TP/FP."
+                        : "Call manage_triage with action='query' and broader filters to retrieve findings.";
                     break;
 
                 case "decide":
-                    if (string.IsNullOrWhiteSpace(findingId))
-                    {
-                        throw new ArgumentException("findingId is required for decide action.", nameof(findingId));
-                    }
-
                     if (string.IsNullOrWhiteSpace(state))
                     {
                         throw new ArgumentException("state is required for decide action.", nameof(state));
@@ -214,63 +252,96 @@ namespace Sarifintown.AgentEngine
                         throw new ArgumentException("reason is required for decide action.", nameof(reason));
                     }
 
-                    resourceId = findingId;
-                    var decisionJson = await Triage(findingId, state, reason, author);
-                    var decisionData = JsonSerializer.Deserialize<JsonElement>(decisionJson);
+                    JsonElement decisionData;
+                    string workflowName;
+                    string pausePrompt;
+
+                    if (!string.IsNullOrWhiteSpace(findingId))
+                    {
+                        resourceId = findingId;
+                        var singleDecisionJson = await Triage(findingId, state, reason, author);
+                        decisionData = JsonSerializer.Deserialize<JsonElement>(singleDecisionJson);
+                        workflowName = "triage-decide-single";
+                        pausePrompt = "Reply with `query` to refresh posture or continue triage.";
+                    }
+                    else
+                    {
+                        var decisionWorkflow = CreateTriageWorkflowService();
+                        var targetFindingIds = ResolveFindingIds(filterOptions.FindingIds);
+
+                        if (targetFindingIds.Count > 0)
+                        {
+                            if (filterOptions.DryRun)
+                            {
+                                var dryRunPayload = new TriageBulkResult(
+                                    true,
+                                    $"Dry run complete. {targetFindingIds.Count} findings would be triaged.",
+                                    targetFindingIds.Count,
+                                    targetFindingIds,
+                                    true);
+                                decisionData = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(dryRunPayload));
+                            }
+                            else
+                            {
+                                var modifiedFindingIds = new List<string>();
+                                foreach (var targetFindingId in targetFindingIds)
+                                {
+                                    var decision = await decisionWorkflow.TriageAsync(targetFindingId, state, reason, author);
+                                    if (decision.Success)
+                                    {
+                                        modifiedFindingIds.Add(targetFindingId);
+                                    }
+                                }
+
+                                var idsPayload = new TriageBulkResult(
+                                    modifiedFindingIds.Count > 0,
+                                    $"Triage updated {modifiedFindingIds.Count} findings.",
+                                    modifiedFindingIds.Count,
+                                    modifiedFindingIds,
+                                    false);
+                                decisionData = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(idsPayload));
+                            }
+
+                            workflowName = "triage-decide-ids";
+                            pausePrompt = filterOptions.DryRun
+                                ? "Reply with `decide` and dryRun=false to persist these decisions."
+                                : "Reply with `query` to refresh posture and continue triage.";
+                        }
+                        else
+                        {
+                            var bulkDecisionJson = await TriageBulk(
+                                state,
+                                reason,
+                                filterOptions.Severity,
+                                ruleFilter,
+                                filterOptions.File,
+                                filterOptions.DryRun,
+                                author);
+
+                            decisionData = JsonSerializer.Deserialize<JsonElement>(bulkDecisionJson);
+                            workflowName = "triage-decide-filtered";
+                            pausePrompt = filterOptions.DryRun
+                                ? "Reply with `decide` and dryRun=false to persist these decisions."
+                                : "Reply with `query` to confirm updated triage posture.";
+                        }
+                    }
+
                     payload = CreateGuidedResponse(
-                        workflowName: "triage-decide",
+                        workflowName: workflowName,
                         data: decisionData,
-                        markdown: BuildGuidedDecisionMarkdown(decisionData),
+                        markdown: BuildGuidedDecideMarkdown(decisionData),
                         nextTool: "manage_triage",
-                        nextToolArguments: new { action = "status" },
+                        nextToolArguments: new { action = "query", filters = "{\"limit\":10}" },
                         pauseForUserInput: true,
-                        pausePrompt: "Reply with `status` to refresh triage posture or `list` to continue triage.");
-                    nextActionHint = "Call manage_triage with action='status' or action='list' to continue triage.";
-                    break;
-
-                case "bulk_decide":
-                    if (string.IsNullOrWhiteSpace(state))
-                    {
-                        throw new ArgumentException("state is required for bulk_decide action.", nameof(state));
-                    }
-
-                    if (string.IsNullOrWhiteSpace(reason))
-                    {
-                        throw new ArgumentException("reason is required for bulk_decide action.", nameof(reason));
-                    }
-
-                    payload = await TriageBulk(
-                        state,
-                        reason,
-                        filterOptions.Severity,
-                        ruleFilter,
-                        filterOptions.File,
-                        filterOptions.DryRun,
-                        author);
-
-                    var bulkData = JsonSerializer.Deserialize<JsonElement>(payload);
-                    object bulkNextToolArguments = filterOptions.DryRun
-                        ? (object)new { action = "bulk_decide", state, reason, filters = "{\"dryRun\":false}" }
-                        : new { action = "status" };
-
-                    payload = CreateGuidedResponse(
-                        workflowName: "triage-bulk",
-                        data: bulkData,
-                        markdown: BuildGuidedBulkMarkdown(bulkData),
-                        nextTool: "manage_triage",
-                        nextToolArguments: bulkNextToolArguments,
-                        pauseForUserInput: true,
-                        pausePrompt: filterOptions.DryRun
-                            ? "Reply with `bulk_decide` and dryRun=false to persist these decisions."
-                            : "Reply with `status` to confirm updated triage posture.");
+                        pausePrompt: pausePrompt);
 
                     nextActionHint = filterOptions.DryRun
-                        ? "Call manage_triage with action='bulk_decide' and dryRun=false to persist decisions."
-                        : "Call manage_triage with action='status' to review updated triage posture.";
+                        ? "Call manage_triage with action='decide' and dryRun=false to persist decisions."
+                        : "Call manage_triage with action='query' to review updated triage posture.";
                     break;
 
                 default:
-                    throw new ArgumentException("Action must be one of: status, list, inspect, decide, bulk_decide, sql_issues.", nameof(action));
+                    throw new ArgumentException("Action must be one of: query or decide. Legacy aliases status/list/inspect/bulk_decide/sql_issues are also accepted.", nameof(action));
             }
 
             return CreateDualPurposeResult(
@@ -752,6 +823,68 @@ namespace Sarifintown.AgentEngine
             });
         }
 
+        private static string BuildGuidedQueryMarkdown(
+            TriageStatusResult status,
+            IReadOnlyList<TriageListItem> findings,
+            bool includeEvidence,
+            int evidenceCount)
+        {
+            var lines = new List<string>
+            {
+                "## SARIF Triage Query",
+                string.Empty,
+                $"- Total findings: **{status.TotalFindings}**",
+                $"- Open findings: **{status.OpenCount}**",
+                $"- Triaged findings: **{status.TriagedCount}**",
+                $"- True positives: **{status.TruePositiveCount}**",
+                $"- False positives: **{status.FalsePositiveCount}**",
+                string.Empty
+            };
+
+            if (findings.Count == 0)
+            {
+                lines.Add("No findings matched the provided filters.");
+            }
+            else
+            {
+                lines.Add("| FindingId | Severity | State | Rule | Location | Score |\n|---|---|---|---|---|---|");
+                lines.AddRange(findings.Select(item =>
+                    $"| `{EscapeMarkdown(item.FindingId)}` | `{EscapeMarkdown(item.Severity)}` | `{EscapeMarkdown(item.State)}` | `{EscapeMarkdown(item.RuleName)}` | `{EscapeMarkdown(item.FilePath)}`:{item.LineNumber?.ToString() ?? "?"} | {item.PriorityScore:F2} |"));
+            }
+
+            lines.Add(string.Empty);
+            lines.Add(includeEvidence
+                ? $"Included evidence payloads: **{evidenceCount}**"
+                : "Evidence snippets not included. Set `includeEvidence=true` for narrow scopes.");
+            lines.Add("**Next action:** Reply with a `FindingId` to deep-dive via `query`, or call `decide` to persist TP/FP.");
+            lines.Add("Then pause for user input.");
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private static string BuildGuidedDecideMarkdown(JsonElement decision)
+        {
+            if (decision.TryGetProperty("FindingId", out _))
+            {
+                return BuildGuidedDecisionMarkdown(decision);
+            }
+
+            return BuildGuidedBulkMarkdown(decision);
+        }
+
+        private static List<string> ResolveFindingIds(string findingIds)
+        {
+            if (string.IsNullOrWhiteSpace(findingIds))
+            {
+                return new List<string>();
+            }
+
+            return findingIds
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+        }
+
         private static string BuildGuidedFindingsMarkdown(IReadOnlyList<TriageListItem> findings)
         {
             if (findings.Count == 0)
@@ -1132,6 +1265,8 @@ namespace Sarifintown.AgentEngine
             public string File { get; init; } = string.Empty;
             public string State { get; init; } = string.Empty;
             public int Limit { get; init; } = 10;
+            public bool IncludeEvidence { get; init; }
+            public string FindingIds { get; init; } = string.Empty;
             public bool Guided { get; init; }
             public bool DryRun { get; init; }
             public string EvidenceMode { get; init; } = string.Empty;

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -1,10 +1,13 @@
 ﻿using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
 using Sarifintown.Core;
 using Sarifintown.Helpers;
 using Sarifintown.Models;
 using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using SarifResult = Sarifintown.Models.Result;
 
 namespace Sarifintown.AgentEngine
 {
@@ -112,7 +115,126 @@ namespace Sarifintown.AgentEngine
         }
 
         [McpServerTool]
-        [Description("MUST: Call this tool first to enumerate SARIF files discovered at server startup before any SARIF-path-dependent operation.")]
+        [Description("MUST: Use this facade for all triage workflows. Set action to one of: status, list, inspect, decide, or bulk_decide.")]
+        public static async Task<CallToolResult> manage_triage(
+            [Description("Routing action: status, list, inspect, decide, or bulk_decide.")]
+            string action,
+            [Description("Finding identifier. Required for inspect and decide actions.")]
+            string findingId = "",
+            [Description("Decision state TP/FP. Required for decide and bulk_decide actions.")]
+            string state = "",
+            [Description("Decision reason. Required for decide and bulk_decide actions.")]
+            string reason = "",
+            [Description("Optional JSON object for filters and options (severity, rule, file, limit, guided, dryRun, evidenceMode, author).")]
+            string filters = "",
+            [Description("Execution mode: interactive or agentic. Interactive pauses for user input; agentic enforces autonomous next-step chaining.")]
+            string mode = "interactive")
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            var normalizedMode = mode?.Trim().ToLowerInvariant();
+
+            bool isTaskComplete =
+                string.Equals(normalizedMode, "agentic", StringComparison.Ordinal) &&
+                string.Equals(action?.Trim(), "bulk_decide_complete", StringComparison.OrdinalIgnoreCase);
+
+            string llmInstructions;
+            if (string.Equals(normalizedMode, "interactive", StringComparison.Ordinal))
+            {
+                llmInstructions = """
+                You must render the markdown content exactly as provided.
+                You must PAUSE after rendering and wait for explicit user input.
+                Do not execute any additional tools after rendering.
+                """;
+            }
+            else if (string.Equals(normalizedMode, "agentic", StringComparison.Ordinal) && isTaskComplete)
+            {
+                llmInstructions = """
+                Hard stop condition reached.
+                Output the exact phrase "**Bulk Triage Complete.**".
+                STOP GENERATING immediately after that phrase.
+                Make ZERO further tool calls.
+                """;
+            }
+            else
+            {
+                llmInstructions = """
+                You are in boxed-in agentic mode. These directives override your internal plan.
+                Do not use generic tools such as bash, python, or read_file.
+                Do not substitute any other tools for triage execution.
+                Your NEXT STEP must be to immediately call `manage_triage` again to process the next item.
+                """;
+            }
+
+            var markdownPayload = $"""
+            ## Triage Control Envelope
+
+            - Action: `{action}`
+            - FindingId: `{findingId}`
+            - State: `{state}`
+            - Reason: `{reason}`
+            - Filters: `{filters}`
+            - Mode: `{normalizedMode}`
+
+            > Dummy payload: this block intentionally simulates backend triage state.
+            """;
+
+            var combinedMarkdown = $"""
+            [INSTRUCTIONS FOR LLM]
+            {llmInstructions}
+
+            [CONTENT]
+            {markdownPayload}
+            """;
+
+            return new CallToolResult
+            {
+                Content = new List<ContentBlock>
+                {
+                    new TextContentBlock
+                    {
+                        Text = combinedMarkdown
+                    }
+                }
+            };
+        }
+
+        [McpServerTool]
+        [Description("MUST: Use this facade for SARIF discovery, filtering, code-flow extraction, and report generation. Set action to list_files, filter, extract_flow, or generate_report.")]
+        public static async Task<CallToolResult> analyze_sarif(
+            [Description("Routing action: list_files, filter, extract_flow, or generate_report.")]
+            string action,
+            [Description("SARIF file path or discovered filename. Required for filter and extract_flow actions.")]
+            string sarifPath = "",
+            [Description("Result identifier. Required for extract_flow and generate_report actions.")]
+            string resultId = "",
+            [Description("Optional JSON object for filters/options (severity, ruleId, category, sourceCodeRoot, outputPath, extractedFlowData).")]
+            string filters = "")
+        {
+            var options = ParseFacadeFilters(filters);
+            var normalizedAction = action?.Trim().ToLowerInvariant();
+
+            var payload = normalizedAction switch
+            {
+                "list_files" => ListWorkspaceSarifFiles(),
+                "filter" => await LoadAndFilterSarif(sarifPath, options.Severity, options.RuleId, options.Category),
+                "extract_flow" => await ExtractCodeFlow(
+                    sarifPath,
+                    resultId,
+                    string.IsNullOrWhiteSpace(options.SourceCodeRoot) ? GetWorkspaceRoot() : options.SourceCodeRoot),
+                "generate_report" => GenerateAnalysisReport(resultId, options.ExtractedFlowData, options.OutputPath),
+                _ => throw new ArgumentException($"Unsupported analysis action: {action}", nameof(action))
+            };
+
+            return CreateDualPurposeResult(
+                workflow: "analyze_sarif",
+                action: normalizedAction ?? string.Empty,
+                payload: payload,
+                resourceUri: BuildUiResourceUri("analysis", normalizedAction ?? string.Empty, resultId),
+                nextActionHint: "Type your next command (for example: `analyze_sarif extract_flow`).");
+        }
+
+        [Description("MUST: Call this helper to enumerate SARIF files discovered at server startup before any SARIF-path-dependent operation.")]
         public static string ListWorkspaceSarifFiles()
         {
             List<string> files;
@@ -130,7 +252,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(payload);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to obtain authoritative triage posture from loaded SARIF findings and local .sarif/triage.json state.")]
         public static async Task<string> TriageStatus()
         {
@@ -139,7 +260,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(status);
         }
 
-        [McpServerTool]
         [Description("MUST: Start autonomous triage flow with this guided tool. Render markdown verbatim, then follow next_step; do not use terminal commands for SARIF-domain actions.")]
         public static async Task<string> TriageStatusGuided()
         {
@@ -162,13 +282,12 @@ namespace Sarifintown.AgentEngine
                 workflowName: "triage-status",
                 data: status,
                 markdown: markdown,
-                nextTool: "TriageListGuided",
-                nextToolArguments: new { severity = "", rule = "", file = "", state = "", limit = 10 },
+                nextTool: "manage_triage",
+                nextToolArguments: new { action = "list", filters = "{\"guided\":true,\"limit\":10}" },
                 pauseForUserInput: true,
                 pausePrompt: "Reply with `list` to continue to prioritized findings.");
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to retrieve prioritized findings with filters; do not infer finding sets without calling it.")]
         public static async Task<string> TriageList(
             [Description("Optional severity filter (for example: High, Medium, Low).")]
@@ -187,7 +306,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(findings);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this guided listing tool for autonomous chaining; response includes enforced next_step and pause directives.")]
         public static async Task<string> TriageListGuided(
             [Description("Optional severity filter (for example: High, Medium, Low).")]
@@ -209,13 +327,12 @@ namespace Sarifintown.AgentEngine
                 workflowName: "triage-list",
                 data: findings,
                 markdown: markdown,
-                nextTool: "TriageInspectGuided",
-                nextToolArguments: new { findingId = "<reply-with-finding-id>", evidenceMode = "line-window-concatenated" },
+                nextTool: "manage_triage",
+                nextToolArguments: new { action = "inspect", findingId = "<reply-with-finding-id>", filters = "{\"guided\":true,\"evidenceMode\":\"line-window-concatenated\"}" },
                 pauseForUserInput: true,
                 pausePrompt: "Reply with a FindingId from the table to inspect technical evidence.");
         }
 
-        [McpServerTool]
         [Description("Use this query-named alias when the MCP client requires query-style tool naming; behavior matches TriageList.")]
         public static Task<string> TriageQuery(
             [Description("Optional severity filter.")]
@@ -232,7 +349,6 @@ namespace Sarifintown.AgentEngine
             return TriageList(severity, rule, file, state, limit);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool for authoritative technical evidence of one finding, including ordered data-flow and snippets.")]
         public static async Task<string> TriageInspect(
             [Description("Finding identifier returned by TriageList or TriageListGuided.")]
@@ -255,7 +371,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(inspect);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this guided inspection tool in autonomous workflows. Render markdown verbatim and execute explicit next_step triage action.")]
         public static async Task<string> TriageInspectGuided(
             [Description("Finding identifier returned by guided list output.")]
@@ -280,8 +395,8 @@ namespace Sarifintown.AgentEngine
                     workflowName: "triage-inspect",
                     data: new { success = false, message = $"Finding not found: {findingId}" },
                     markdown: notFoundMarkdown,
-                    nextTool: "TriageListGuided",
-                    nextToolArguments: new { severity = "", rule = "", file = "", state = "", limit = 10 },
+                    nextTool: "manage_triage",
+                    nextToolArguments: new { action = "list", filters = "{\"guided\":true,\"limit\":10}" },
                     pauseForUserInput: true,
                     pausePrompt: "Reply with `list` to load findings, then provide a valid FindingId.");
             }
@@ -291,13 +406,12 @@ namespace Sarifintown.AgentEngine
                 workflowName: "triage-inspect",
                 data: inspect,
                 markdown: markdown,
-                nextTool: "Triage",
-                nextToolArguments: new { findingId = inspect.FindingId, state = "TP|FP", reason = "<required>", author = "AI" },
+                nextTool: "manage_triage",
+                nextToolArguments: new { action = "decide", findingId = inspect.FindingId, state = "TP|FP", reason = "<required>", filters = "{\"author\":\"AI\"}" },
                 pauseForUserInput: true,
                 pausePrompt: "Reply with `TP <reason>` or `FP <reason>` to record a triage decision.");
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to persist a TP/FP triage decision for one finding into .sarif/triage.json.")]
         public static async Task<string> Triage(
             [Description("Target finding identifier.")]
@@ -314,7 +428,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(result);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool for bulk TP/FP triage updates using filters. At least one of severity/rule/file is required.")]
         public static async Task<string> TriageBulk(
             [Description("Decision state to apply (TP or FP).")]
@@ -343,7 +456,6 @@ namespace Sarifintown.AgentEngine
             return JsonSerializer.Serialize(result);
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to resolve the correct interactive surface for the connected host before launching UI/TUI experiences.")]
         public static string ResolveInteractiveSurface(
             [Description("Active MCP server instance; used for host detection.")]
@@ -411,7 +523,6 @@ namespace Sarifintown.AgentEngine
             });
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to parse a SARIF file and apply category/severity/rule filters. Do not infer filtered issues without this call.")]
         public static async Task<string> LoadAndFilterSarif(
             [Description("SARIF file path (absolute or filename discovered at startup).")]
@@ -438,7 +549,7 @@ namespace Sarifintown.AgentEngine
                 if (sarifLog?.Runs == null || !sarifLog.Runs.Any())
                     return JsonSerializer.Serialize(new { error = "Invalid or empty SARIF file." });
 
-                var results = sarifLog.Runs.SelectMany(r => r.Results ?? Enumerable.Empty<Result>()).ToList();
+                var results = sarifLog.Runs.SelectMany(r => r.Results ?? Enumerable.Empty<SarifResult>()).ToList();
 
                 // Apply Filters
                 if (!string.IsNullOrWhiteSpace(severity))
@@ -468,7 +579,6 @@ namespace Sarifintown.AgentEngine
             }
         }
 
-        [McpServerTool]
         [Description("MUST: Use this tool to extract source-to-sink data flow for a SARIF issue using Tree-sitter and fallback snippet windows.")]
         public static async Task<string> ExtractCodeFlow(
             [Description("SARIF file path (absolute or filename discovered at startup).")]
@@ -491,7 +601,7 @@ namespace Sarifintown.AgentEngine
                 var content = await FileReader.ReadFileAsync(resolvedSarifPath);
                 var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 var flattenedResults = sarifLog?.Runs
-                    .SelectMany(run => (run.Results ?? Enumerable.Empty<Result>()).Select(result => (run, result)))
+                    .SelectMany(run => (run.Results ?? Enumerable.Empty<SarifResult>()).Select(result => (run, result)))
                     .ToList();
 
                 if (flattenedResults == null || !int.TryParse(resultId, out int index) || index < 0 || index >= flattenedResults.Count)
@@ -635,6 +745,137 @@ namespace Sarifintown.AgentEngine
             }
 
             return sarifPath;
+        }
+
+        private static FacadeFilterOptions ParseFacadeFilters(string filters)
+        {
+            if (string.IsNullOrWhiteSpace(filters))
+            {
+                return new FacadeFilterOptions();
+            }
+
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<FacadeFilterOptions>(filters, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return parsed ?? new FacadeFilterOptions();
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException("Filters must be a valid JSON object.", nameof(filters), ex);
+            }
+        }
+
+        private static string GetWorkspaceRoot()
+        {
+            lock (SyncRoot)
+            {
+                return _workspaceRoot;
+            }
+        }
+
+        private static CallToolResult CreateDualPurposeResult(
+            string workflow,
+            string action,
+            string payload,
+            string resourceUri,
+            string nextActionHint)
+        {
+            var markdown = BuildPassThroughMarkdown(workflow, action, payload, nextActionHint);
+            if (string.IsNullOrWhiteSpace(resourceUri))
+            {
+                string localUiBaseUrl;
+                lock (SyncRoot)
+                {
+                    localUiBaseUrl = _localUiBaseUrl;
+                }
+
+                if (Uri.TryCreate(localUiBaseUrl, UriKind.Absolute, out var baseUri))
+                {
+                    var builder = new UriBuilder(baseUri)
+                    {
+                        Path = "mcp/dashboard"
+                    };
+
+                    resourceUri = builder.Uri.ToString();
+                }
+            }
+
+            var meta = new JsonObject();
+            if (!string.IsNullOrWhiteSpace(resourceUri))
+            {
+                var csp = BuildUiCsp(resourceUri);
+                meta["ui"] = new JsonObject
+                {
+                    ["resourceUri"] = resourceUri,
+                    ["csp"] = csp
+                };
+            }
+
+            return new CallToolResult
+            {
+                Content = new List<ContentBlock>
+                {
+                    new TextContentBlock
+                    {
+                        Text = markdown
+                    }
+                },
+                Meta = meta
+            };
+        }
+
+        private static string BuildPassThroughMarkdown(string workflow, string action, string payload, string nextActionHint)
+        {
+            return $"""
+            [INSTRUCTIONS FOR LLM]
+            You are acting as a UI renderer. Output the exact Markdown in the [CONTENT] block verbatim.
+            Do NOT summarize it. After rendering, PAUSE and wait for the user to type the next command.
+
+            [CONTENT]
+            ### SARIF {workflow} {action}
+
+            ```json
+            {payload}
+            ```
+
+            **Next Action:** {nextActionHint}
+            """;
+        }
+
+        private static string BuildUiResourceUri(string routePrefix, string action, string id)
+        {
+            var localUi = CreateLocalHttpUiPayload();
+            var uri = GetPropertyValue(localUi, "uri")?.ToString();
+
+            if (!string.IsNullOrWhiteSpace(uri) && Uri.TryCreate(uri, UriKind.Absolute, out var baseUri))
+            {
+                var builder = new UriBuilder(baseUri)
+                {
+                    Path = $"mcp/{routePrefix}/{action}",
+                    Query = string.IsNullOrWhiteSpace(id)
+                        ? string.Empty
+                        : $"id={Uri.EscapeDataString(id)}"
+                };
+
+                return builder.Uri.ToString();
+            }
+
+            return string.Empty;
+        }
+
+        private static string BuildUiCsp(string resourceUri)
+        {
+            if (!Uri.TryCreate(resourceUri, UriKind.Absolute, out var absoluteUri))
+            {
+                return "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self';";
+            }
+
+            var origin = absoluteUri.GetLeftPart(UriPartial.Authority);
+            return $"default-src 'none'; script-src 'self' {origin}; style-src 'self' {origin}; connect-src 'self' {origin}; img-src 'self' data: {origin};";
         }
 
         private static string CreateGuidedResponse(
@@ -962,7 +1203,24 @@ namespace Sarifintown.AgentEngine
             return property.GetValue(instance);
         }
 
-        [McpServerTool]
+        private sealed class FacadeFilterOptions
+        {
+            public string Severity { get; init; } = string.Empty;
+            public string Rule { get; init; } = string.Empty;
+            public string RuleId { get; init; } = string.Empty;
+            public string File { get; init; } = string.Empty;
+            public string State { get; init; } = string.Empty;
+            public int Limit { get; init; } = 10;
+            public bool Guided { get; init; }
+            public bool DryRun { get; init; }
+            public string EvidenceMode { get; init; } = string.Empty;
+            public string Author { get; init; } = string.Empty;
+            public string Category { get; init; } = string.Empty;
+            public string SourceCodeRoot { get; init; } = string.Empty;
+            public string OutputPath { get; init; } = string.Empty;
+            public string ExtractedFlowData { get; init; } = string.Empty;
+        }
+
         [Description("MUST: Use this tool to compile extracted flow JSON into a markdown report artifact for downstream analysis.")]
         public static string GenerateAnalysisReport(
             [Description("Result identifier for report metadata.")]

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -22,9 +22,11 @@ namespace Sarifintown.AgentEngine
         internal static SnippetCacheService? SnippetCache { get; set; }
         internal static SnippetWarmupService? SnippetWarmupService { get; set; }
         private static readonly object SyncRoot = new();
+        public const string StateContextDelimiter = "===SARIF_STATE_CONTEXT===";
         private static List<string> _discoveredSarifFiles = new();
         private static string _localUiBaseUrl = string.Empty;
         private static string _workspaceRoot = Directory.GetCurrentDirectory();
+        private static ActiveScopeFilter _activeScope = new();
         private static readonly string[] IdeHostTokens =
         [
             "vscode",
@@ -115,445 +117,61 @@ namespace Sarifintown.AgentEngine
             lock (SyncRoot)
             {
                 _workspaceRoot = Path.GetFullPath(workspaceRoot);
+                _activeScope = new ActiveScopeFilter();
             }
         }
 
-        [McpServerTool]
-        [Description("MUST: Use this facade for all triage workflows. Preferred actions are query and decide; legacy aliases status/list/inspect/bulk_decide are supported.")]
-        public static async Task<CallToolResult> manage_triage(
-            [Description("Routing action: query or decide (legacy aliases status/list/inspect/bulk_decide/sql_issues are accepted).")]
-            string action,
-            [Description("Finding identifier for query deep-dive or single-target decide.")]
-            string findingId = "",
-            [Description("Decision state TP/FP. Required for decide action.")]
-            string state = "",
-            [Description("Decision reason. Required for decide action.")]
-            string reason = "",
-            [Description("Optional JSON object for filters and options (severity, rule, file, limit, state, includeEvidence, findingIds, dryRun, evidenceMode, author).")]
-            string filters = "",
-            [Description("Execution mode: interactive or agentic. Interactive pauses for user input; agentic enforces autonomous next-step chaining.")]
-            string mode = "interactive")
+        [McpServerTool(Name = "sarif.get")]
+        [Description("Retrieves prioritized SARIF findings, manages persistent Active Scope, and returns scope metrics.")]
+        public static async Task<CallToolResult> SarifGet(
+            [Description("Scope action: keep, set, refine, or clear.")]
+            string scope = "keep",
+            [Description("Filter expression, for example: severity:high, rule:SQLI.")]
+            string filter = "",
+            [Description("When true, attach evidence blocks per finding.")]
+            bool includeEvidence = false,
+            [Description("Maximum findings to return.")]
+            int limit = 10)
         {
-            if (string.IsNullOrWhiteSpace(action))
+            var payload = await ExecuteScopedGetAsync(scope, filter, includeEvidence, limit);
+            var stateContext = new
             {
-                throw new ArgumentException("Action is required.", nameof(action));
-            }
-
-            var filterOptions = ParseFacadeFilters(filters);
-            var normalizedAction = action.Trim().ToLowerInvariant();
-            var author = string.IsNullOrWhiteSpace(filterOptions.Author) ? "AI" : filterOptions.Author;
-            var ruleFilter = string.IsNullOrWhiteSpace(filterOptions.Rule) ? filterOptions.RuleId : filterOptions.Rule;
-
-            if ((normalizedAction is "sql_issues" or "sqlissues" or "sqli") && string.IsNullOrWhiteSpace(ruleFilter))
-            {
-                ruleFilter = "csharp/Sqli,SQLInjection,SqlInjection";
-            }
-
-            normalizedAction = normalizedAction switch
-            {
-                "list" or "inspect" or "sql_issues" or "sqlissues" or "sqli" => "query",
-                "bulk_decide" => "decide",
-                _ => normalizedAction
+                context = new
+                {
+                    active_scope = payload.Context.ActiveScope,
+                    metrics = new
+                    {
+                        total_in_scope = payload.Context.Metrics.TotalInScope,
+                        returned_in_batch = payload.Context.Metrics.ReturnedInBatch,
+                        remaining_in_scope = payload.Context.Metrics.RemainingInScope
+                    }
+                }
             };
 
-            if (string.Equals(normalizedAction, "bulk_decide_complete", StringComparison.Ordinal))
-            {
-                var completedPayload = CreateGuidedResponse(
-                    workflowName: "triage-bulk-complete",
-                    data: new { success = true, message = "Bulk triage complete." },
-                    markdown: "## Bulk Triage Complete",
-                    nextTool: "manage_triage",
-                    nextToolArguments: new { action = "status" },
-                    pauseForUserInput: true,
-                    pausePrompt: "Reply with `status` to review the current triage posture.");
+            return CreateDualPurposeResult(
+                markdown: BuildScopedGetMarkdown(payload),
+                systemStateContext: stateContext,
+                resourceUri: BuildUiResourceUri("triage", "sarif.get", string.Empty),
+                additionalMeta: BuildScopedMeta(payload.Context));
+        }
 
-                return CreateDualPurposeResult(
-                    workflow: "Triage",
-                    action: normalizedAction,
-                    payload: completedPayload,
-                    resourceUri: BuildUiResourceUri("triage", normalizedAction, string.Empty),
-                    nextActionHint: "Task complete.");
-            }
-
-            string payload;
-            string nextActionHint;
-            string resourceId = string.Empty;
-
-            switch (normalizedAction)
-            {
-                case "status":
-                    payload = await TriageStatusGuided();
-                    nextActionHint = "Call manage_triage with action='query' to review posture with prioritized findings.";
-                    break;
-
-                case "query":
-                    if (!string.IsNullOrWhiteSpace(findingId))
-                    {
-                        resourceId = findingId;
-                        payload = await TriageInspectGuided(findingId, filterOptions.EvidenceMode);
-                        nextActionHint = "Call manage_triage with action='decide', findingId='<id>', state='TP|FP', and reason='<required>'.";
-                        break;
-                    }
-
-                    var queryWorkflow = CreateTriageWorkflowService();
-                    var statusResult = await queryWorkflow.GetStatusAsync();
-                    var findings = await queryWorkflow.ListAsync(new TriageQueryOptions(
-                        filterOptions.Severity,
-                        ruleFilter,
-                        filterOptions.File,
-                        filterOptions.State,
-                        filterOptions.Limit));
-
-                    var evidence = new List<TriageInspectResult>();
-                    if (filterOptions.IncludeEvidence)
-                    {
-                        foreach (var item in findings)
-                        {
-                            var inspect = await queryWorkflow.InspectAsync(item.FindingId, filterOptions.EvidenceMode);
-                            if (inspect != null)
-                            {
-                                evidence.Add(inspect);
-                            }
-                        }
-                    }
-
-                    payload = CreateGuidedResponse(
-                        workflowName: "triage-query",
-                        data: new
-                        {
-                            status = statusResult,
-                            findings,
-                            includeEvidence = filterOptions.IncludeEvidence,
-                            evidence
-                        },
-                        markdown: BuildGuidedQueryMarkdown(statusResult, findings, filterOptions.IncludeEvidence, evidence.Count),
-                        nextTool: "manage_triage",
-                        nextToolArguments: findings.Count > 0
-                            ? new { action = "query", findingId = "<reply-with-finding-id>", filters = "{\"evidenceMode\":\"line-window-concatenated\"}" }
-                            : new { action = "query", filters = "{\"limit\":10}" },
-                        pauseForUserInput: true,
-                        pausePrompt: findings.Count > 0
-                            ? "Reply with a FindingId to deep-dive evidence or provide new filters."
-                            : "Reply with updated filters to continue triage query.");
-
-                    nextActionHint = findings.Count > 0
-                        ? "Call manage_triage with action='query' and findingId='<id>' for deep evidence, or action='decide' to apply TP/FP."
-                        : "Call manage_triage with action='query' and broader filters to retrieve findings.";
-                    break;
-
-                case "decide":
-                    if (string.IsNullOrWhiteSpace(state))
-                    {
-                        throw new ArgumentException("state is required for decide action.", nameof(state));
-                    }
-
-                    if (string.IsNullOrWhiteSpace(reason))
-                    {
-                        throw new ArgumentException("reason is required for decide action.", nameof(reason));
-                    }
-
-                    JsonElement decisionData;
-                    string workflowName;
-                    string pausePrompt;
-
-                    if (!string.IsNullOrWhiteSpace(findingId))
-                    {
-                        resourceId = findingId;
-                        var singleDecisionJson = await Triage(findingId, state, reason, author);
-                        decisionData = JsonSerializer.Deserialize<JsonElement>(singleDecisionJson);
-                        workflowName = "triage-decide-single";
-                        pausePrompt = "Reply with `query` to refresh posture or continue triage.";
-                    }
-                    else
-                    {
-                        var decisionWorkflow = CreateTriageWorkflowService();
-                        var targetFindingIds = ResolveFindingIds(filterOptions.FindingIds);
-
-                        if (targetFindingIds.Count > 0)
-                        {
-                            if (filterOptions.DryRun)
-                            {
-                                var dryRunPayload = new TriageBulkResult(
-                                    true,
-                                    $"Dry run complete. {targetFindingIds.Count} findings would be triaged.",
-                                    targetFindingIds.Count,
-                                    targetFindingIds,
-                                    true);
-                                decisionData = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(dryRunPayload));
-                            }
-                            else
-                            {
-                                var modifiedFindingIds = new List<string>();
-                                foreach (var targetFindingId in targetFindingIds)
-                                {
-                                    var decision = await decisionWorkflow.TriageAsync(targetFindingId, state, reason, author);
-                                    if (decision.Success)
-                                    {
-                                        modifiedFindingIds.Add(targetFindingId);
-                                    }
-                                }
-
-                                var idsPayload = new TriageBulkResult(
-                                    modifiedFindingIds.Count > 0,
-                                    $"Triage updated {modifiedFindingIds.Count} findings.",
-                                    modifiedFindingIds.Count,
-                                    modifiedFindingIds,
-                                    false);
-                                decisionData = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(idsPayload));
-                            }
-
-                            workflowName = "triage-decide-ids";
-                            pausePrompt = filterOptions.DryRun
-                                ? "Reply with `decide` and dryRun=false to persist these decisions."
-                                : "Reply with `query` to refresh posture and continue triage.";
-                        }
-                        else
-                        {
-                            var bulkDecisionJson = await TriageBulk(
-                                state,
-                                reason,
-                                filterOptions.Severity,
-                                ruleFilter,
-                                filterOptions.File,
-                                filterOptions.DryRun,
-                                author);
-
-                            decisionData = JsonSerializer.Deserialize<JsonElement>(bulkDecisionJson);
-                            workflowName = "triage-decide-filtered";
-                            pausePrompt = filterOptions.DryRun
-                                ? "Reply with `decide` and dryRun=false to persist these decisions."
-                                : "Reply with `query` to confirm updated triage posture.";
-                        }
-                    }
-
-                    payload = CreateGuidedResponse(
-                        workflowName: workflowName,
-                        data: decisionData,
-                        markdown: BuildGuidedDecideMarkdown(decisionData),
-                        nextTool: "manage_triage",
-                        nextToolArguments: new { action = "query", filters = "{\"limit\":10}" },
-                        pauseForUserInput: true,
-                        pausePrompt: pausePrompt);
-
-                    nextActionHint = filterOptions.DryRun
-                        ? "Call manage_triage with action='decide' and dryRun=false to persist decisions."
-                        : "Call manage_triage with action='query' to review updated triage posture.";
-                    break;
-
-                default:
-                    throw new ArgumentException("Action must be one of: query or decide. Legacy aliases status/list/inspect/bulk_decide/sql_issues are also accepted.", nameof(action));
-            }
+        [McpServerTool(Name = "sarif.triage")]
+        [Description("Applies TP/FP decisions to a target finding, list of findings, or current Active Scope.")]
+        public static async Task<CallToolResult> SarifTriage(
+            [Description("Decision state: TP or FP.")]
+            string state,
+            [Description("Decision reason/audit note.")]
+            string reason,
+            [Description("Target: single finding id, CSV ids, or literal scope.")]
+            string target)
+        {
+            var payload = await ExecuteScopedTriageAsync(state, reason, target, "AI");
 
             return CreateDualPurposeResult(
-                workflow: "Triage",
-                action: normalizedAction,
-                payload: payload,
-                resourceUri: BuildUiResourceUri("triage", normalizedAction, resourceId),
-                nextActionHint: nextActionHint);
-        }
-
-        [Description("MUST: Use this tool to obtain authoritative triage posture from loaded SARIF findings and local .sarif/triage.json state.")]
-        public static async Task<string> TriageStatus()
-        {
-            var workflow = CreateTriageWorkflowService();
-            var status = await workflow.GetStatusAsync();
-            return JsonSerializer.Serialize(status);
-        }
-
-        [Description("MUST: Start autonomous triage flow with this guided tool. Render markdown verbatim, then follow next_step; do not use terminal commands for SARIF-domain actions.")]
-        public static async Task<string> TriageStatusGuided()
-        {
-            var workflow = CreateTriageWorkflowService();
-            var status = await workflow.GetStatusAsync();
-
-            var markdown = $"""
-            ## SARIF Triage Status
-
-            - Total findings: **{status.TotalFindings}**
-            - Open findings: **{status.OpenCount}**
-            - Triaged findings: **{status.TriagedCount}**
-            - True positives: **{status.TruePositiveCount}**
-            - False positives: **{status.FalsePositiveCount}**
-
-            **Next action:** Reply with `list` to review prioritized findings.
-            """;
-
-            return CreateGuidedResponse(
-                workflowName: "triage-status",
-                data: status,
-                markdown: markdown,
-                nextTool: "manage_triage",
-                nextToolArguments: new { action = "list", filters = "{\"guided\":true,\"limit\":10}" },
-                pauseForUserInput: true,
-                pausePrompt: "Reply with `list` to continue to prioritized findings.");
-        }
-
-        [Description("MUST: Use this tool to retrieve prioritized findings with filters; do not infer finding sets without calling it.")]
-        public static async Task<string> TriageList(
-            [Description("Optional severity filter (for example: High, Medium, Low).")]
-            string severity = "",
-            [Description("Optional rule-id or rule-name filter.")]
-            string rule = "",
-            [Description("Optional file path filter (supports wildcard patterns handled by workflow service).")]
-            string file = "",
-            [Description("Optional triage state filter (Open, TP, FP).")]
-            string state = "",
-            [Description("Maximum findings to return.")]
-            int limit = 10)
-        {
-            var workflow = CreateTriageWorkflowService();
-            var findings = await workflow.ListAsync(new TriageQueryOptions(severity, rule, file, state, limit));
-            return JsonSerializer.Serialize(findings);
-        }
-
-        [Description("MUST: Use this guided listing tool for autonomous chaining; response includes enforced next_step and pause directives.")]
-        public static async Task<string> TriageListGuided(
-            [Description("Optional severity filter (for example: High, Medium, Low).")]
-            string severity = "",
-            [Description("Optional rule-id or rule-name filter.")]
-            string rule = "",
-            [Description("Optional file path filter.")]
-            string file = "",
-            [Description("Optional triage state filter (Open, TP, FP).")]
-            string state = "",
-            [Description("Maximum findings to return.")]
-            int limit = 10)
-        {
-            var workflow = CreateTriageWorkflowService();
-            var findings = await workflow.ListAsync(new TriageQueryOptions(severity, rule, file, state, limit));
-
-            var markdown = BuildGuidedFindingsMarkdown(findings);
-            return CreateGuidedResponse(
-                workflowName: "triage-list",
-                data: findings,
-                markdown: markdown,
-                nextTool: "manage_triage",
-                nextToolArguments: new { action = "inspect", findingId = "<reply-with-finding-id>", filters = "{\"guided\":true,\"evidenceMode\":\"line-window-concatenated\"}" },
-                pauseForUserInput: true,
-                pausePrompt: "Reply with a FindingId from the table to inspect technical evidence.");
-        }
-
-        [Description("Use this query-named alias when the MCP client requires query-style tool naming; behavior matches TriageList.")]
-        public static Task<string> TriageQuery(
-            [Description("Optional severity filter.")]
-            string severity = "",
-            [Description("Optional rule-id or rule-name filter.")]
-            string rule = "",
-            [Description("Optional file path filter.")]
-            string file = "",
-            [Description("Optional triage state filter.")]
-            string state = "",
-            [Description("Maximum findings to return.")]
-            int limit = 10)
-        {
-            return TriageList(severity, rule, file, state, limit);
-        }
-
-        [Description("MUST: Use this tool for authoritative technical evidence of one finding, including ordered data-flow and snippets.")]
-        public static async Task<string> TriageInspect(
-            [Description("Finding identifier returned by TriageList or TriageListGuided.")]
-            string findingId,
-            [Description("Optional evidence mode override (for example: line-window-strict, line-window-concatenated, tree-sitter-method).")]
-            string evidenceMode = "")
-        {
-            var workflow = CreateTriageWorkflowService();
-            var inspect = await workflow.InspectAsync(findingId, evidenceMode);
-
-            if (inspect == null)
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    message = $"Finding not found: {findingId}"
-                });
-            }
-
-            return JsonSerializer.Serialize(inspect);
-        }
-
-        [Description("MUST: Use this guided inspection tool in autonomous workflows. Render markdown verbatim and execute explicit next_step triage action.")]
-        public static async Task<string> TriageInspectGuided(
-            [Description("Finding identifier returned by guided list output.")]
-            string findingId,
-            [Description("Optional evidence mode override.")]
-            string evidenceMode = "")
-        {
-            var workflow = CreateTriageWorkflowService();
-            var inspect = await workflow.InspectAsync(findingId, evidenceMode);
-
-            if (inspect == null)
-            {
-                var notFoundMarkdown = $"""
-                ## Finding Not Found
-
-                No finding matched `{findingId}`.
-
-                **Next action:** Run a filtered list again and select a valid FindingId.
-                """;
-
-                return CreateGuidedResponse(
-                    workflowName: "triage-inspect",
-                    data: new { success = false, message = $"Finding not found: {findingId}" },
-                    markdown: notFoundMarkdown,
-                    nextTool: "manage_triage",
-                    nextToolArguments: new { action = "list", filters = "{\"guided\":true,\"limit\":10}" },
-                    pauseForUserInput: true,
-                    pausePrompt: "Reply with `list` to load findings, then provide a valid FindingId.");
-            }
-
-            var markdown = BuildGuidedInspectMarkdown(inspect);
-            return CreateGuidedResponse(
-                workflowName: "triage-inspect",
-                data: inspect,
-                markdown: markdown,
-                nextTool: "manage_triage",
-                nextToolArguments: new { action = "decide", findingId = inspect.FindingId, state = "TP|FP", reason = "<required>", filters = "{\"author\":\"AI\"}" },
-                pauseForUserInput: true,
-                pausePrompt: "Reply with `TP <reason>` or `FP <reason>` to record a triage decision.");
-        }
-
-        [Description("MUST: Use this tool to persist a TP/FP triage decision for one finding into .sarif/triage.json.")]
-        public static async Task<string> Triage(
-            [Description("Target finding identifier.")]
-            string findingId,
-            [Description("Decision state to persist (TP or FP; natural-language aliases are normalized by workflow service).")]
-            string state,
-            [Description("Required reason for the decision.")]
-            string reason,
-            [Description("Decision author label.")]
-            string author = "AI")
-        {
-            var workflow = CreateTriageWorkflowService();
-            var result = await workflow.TriageAsync(findingId, state, reason, author);
-            return JsonSerializer.Serialize(result);
-        }
-
-        [Description("MUST: Use this tool for bulk TP/FP triage updates using filters. At least one of severity/rule/file is required.")]
-        public static async Task<string> TriageBulk(
-            [Description("Decision state to apply (TP or FP).")]
-            string state,
-            [Description("Required reason applied to affected findings.")]
-            string reason,
-            [Description("Optional severity filter.")]
-            string severity = "",
-            [Description("Optional rule filter.")]
-            string rule = "",
-            [Description("Optional file filter.")]
-            string file = "",
-            [Description("When true, preview affected findings without persisting changes.")]
-            bool dryRun = false,
-            [Description("Decision author label.")]
-            string author = "AI")
-        {
-            var workflow = CreateTriageWorkflowService();
-            var result = await workflow.TriageBulkAsync(
-                state,
-                reason,
-                new TriageQueryOptions(severity, rule, file, string.Empty, int.MaxValue),
-                dryRun,
-                author);
-
-            return JsonSerializer.Serialize(result);
+                markdown: BuildScopedTriageMarkdown(payload),
+                systemStateContext: null,
+                resourceUri: BuildUiResourceUri("triage", "sarif.triage", string.Empty),
+                additionalMeta: null);
         }
 
         [Description("MUST: Use this tool to resolve the correct interactive surface for the connected host before launching UI/TUI experiences.")]
@@ -600,7 +218,7 @@ namespace Sarifintown.AgentEngine
                 if (selectedAction.StartsWith("Triage ", StringComparison.Ordinal))
                 {
                     commandResult = SpectreCliMenu
-                        .ExecuteTriageActionAsync(CreateTriageWorkflowService(), selectedAction)
+                        .ExecuteTriageActionAsync(selectedAction)
                         .GetAwaiter()
                         .GetResult();
                 }
@@ -623,26 +241,318 @@ namespace Sarifintown.AgentEngine
             });
         }
 
-        private static FacadeFilterOptions ParseFacadeFilters(string filters)
+        private static async Task<ScopedGetPayload> ExecuteScopedGetAsync(string scope, string filter, bool includeEvidence, int limit)
         {
-            if (string.IsNullOrWhiteSpace(filters))
+            var scopeAction = ParseScopeAction(scope);
+            var parsedFilter = string.IsNullOrWhiteSpace(filter)
+                ? new ActiveScopeFilter()
+                : ParseScopeFilter(filter);
+
+            if (scopeAction is ScopeAction.Set or ScopeAction.Refine && parsedFilter.IsEmpty)
             {
-                return new FacadeFilterOptions();
+                throw new ArgumentException("filter is required when scope is set or refine.", nameof(filter));
             }
 
-            try
+            var activeScope = GetActiveScope();
+
+            switch (scopeAction)
             {
-                var parsed = JsonSerializer.Deserialize<FacadeFilterOptions>(filters, new JsonSerializerOptions
+                case ScopeAction.Set:
+                    activeScope = parsedFilter;
+                    SetActiveScope(activeScope);
+                    break;
+                case ScopeAction.Refine:
+                    activeScope = MergeScope(activeScope, parsedFilter);
+                    SetActiveScope(activeScope);
+                    break;
+                case ScopeAction.Clear:
+                    activeScope = new ActiveScopeFilter();
+                    SetActiveScope(activeScope);
+                    break;
+            }
+
+            var executionScope = scopeAction == ScopeAction.Keep && !parsedFilter.IsEmpty
+                ? MergeScope(activeScope, parsedFilter)
+                : activeScope;
+
+            var workflow = CreateTriageWorkflowService();
+            var batchLimit = limit <= 0 ? 10 : limit;
+
+            var activeScopeFindings = await workflow.ListAsync(activeScope.ToQueryOptions(int.MaxValue));
+            var executionFindings = await workflow.ListAsync(executionScope.ToQueryOptions(batchLimit));
+
+            var findingRows = new List<ScopedFinding>(executionFindings.Count);
+            foreach (var finding in executionFindings)
+            {
+                TriageInspectResult? evidence = null;
+                if (includeEvidence)
                 {
-                    PropertyNameCaseInsensitive = true
-                });
+                    evidence = await workflow.InspectAsync(finding.FindingId, string.Empty);
+                }
 
-                return parsed ?? new FacadeFilterOptions();
+                findingRows.Add(new ScopedFinding(
+                    finding.FindingId,
+                    finding.Severity,
+                    finding.State,
+                    finding.RuleName,
+                    evidence?.Message ?? finding.RuleName,
+                    new ScopedLocation(finding.FilePath, finding.LineNumber),
+                    evidence));
             }
-            catch (JsonException ex)
+
+            var metrics = new SarifGetMetrics(
+                activeScopeFindings.Count,
+                findingRows.Count,
+                activeScopeFindings.Count(item => string.Equals(item.State, TriageFindingState.Open.ToString(), StringComparison.OrdinalIgnoreCase)));
+
+            return new ScopedGetPayload(
+                new ScopedContext(
+                    "Results are filtered by the persistent Active Scope.",
+                    ToScopeDictionary(activeScope),
+                    new ScopedMetrics(metrics.TotalInScope, metrics.ReturnedInBatch, metrics.RemainingInScope)),
+                findingRows);
+        }
+
+        private static async Task<ScopedTriagePayload> ExecuteScopedTriageAsync(
+            string state,
+            string reason,
+            string target,
+            string author)
+        {
+            if (string.IsNullOrWhiteSpace(state))
             {
-                throw new ArgumentException("Filters must be a valid JSON object.", nameof(filters), ex);
+                throw new ArgumentException("state is required.", nameof(state));
             }
+
+            if (string.IsNullOrWhiteSpace(reason))
+            {
+                throw new ArgumentException("reason is required.", nameof(reason));
+            }
+
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                throw new ArgumentException("target is required.", nameof(target));
+            }
+
+            var normalizedState = NormalizeStrictDecisionState(state);
+            var workflow = CreateTriageWorkflowService();
+
+            List<string> targetIds;
+            if (string.Equals(target, "scope", StringComparison.OrdinalIgnoreCase))
+            {
+                var activeScope = GetActiveScope();
+                var scopedFindings = await workflow.ListAsync(activeScope.ToQueryOptions(int.MaxValue));
+                targetIds = scopedFindings
+                    .Where(item => string.Equals(item.State, TriageFindingState.Open.ToString(), StringComparison.OrdinalIgnoreCase))
+                    .Select(item => item.FindingId)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
+            }
+            else
+            {
+                targetIds = ResolveFindingIds(target);
+            }
+
+            var modifiedIds = new List<string>();
+            foreach (var targetId in targetIds)
+            {
+                var decision = await workflow.TriageAsync(targetId, normalizedState, reason, author);
+                if (decision.Success)
+                {
+                    modifiedIds.Add(targetId);
+                }
+            }
+
+            return new ScopedTriagePayload(
+                modifiedIds.Count == targetIds.Count,
+                normalizedState,
+                reason,
+                target,
+                modifiedIds.Count,
+                modifiedIds);
+        }
+
+        private static string NormalizeStrictDecisionState(string state)
+        {
+            var normalized = state.Trim().ToUpperInvariant();
+            if (normalized is "TP" or "FP")
+            {
+                return normalized;
+            }
+
+            throw new ArgumentException("state must be TP or FP.", nameof(state));
+        }
+
+        private static ScopeAction ParseScopeAction(string scope)
+        {
+            if (string.IsNullOrWhiteSpace(scope))
+            {
+                return ScopeAction.Keep;
+            }
+
+            var normalized = scope.Trim().ToLowerInvariant();
+            return normalized switch
+            {
+                "keep" => ScopeAction.Keep,
+                "set" => ScopeAction.Set,
+                "refine" => ScopeAction.Refine,
+                "clear" => ScopeAction.Clear,
+                _ => throw new ArgumentException("scope must be one of: keep, set, refine, clear.", nameof(scope))
+            };
+        }
+
+        private static ActiveScopeFilter ParseScopeFilter(string filter)
+        {
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var token in SplitFilterTokens(filter))
+            {
+                var separatorIndex = token.IndexOf(':');
+                if (separatorIndex <= 0 || separatorIndex == token.Length - 1)
+                {
+                    continue;
+                }
+
+                var key = token[..separatorIndex].Trim();
+                var value = token[(separatorIndex + 1)..].Trim().Trim('"', '\'');
+
+                if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
+                {
+                    map[key] = value;
+                }
+            }
+
+            map.TryGetValue("severity", out var severity);
+            map.TryGetValue("rule", out var rule);
+
+            if (string.IsNullOrWhiteSpace(rule) && map.TryGetValue("ruleId", out var ruleId))
+            {
+                rule = ruleId;
+            }
+
+            map.TryGetValue("file", out var file);
+            if (string.IsNullOrWhiteSpace(file) && map.TryGetValue("path", out var path))
+            {
+                file = path;
+            }
+
+            map.TryGetValue("state", out var state);
+
+            return new ActiveScopeFilter(severity ?? string.Empty, rule ?? string.Empty, file ?? string.Empty, state ?? string.Empty);
+        }
+
+        private static IReadOnlyList<string> SplitFilterTokens(string filter)
+        {
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                return Array.Empty<string>();
+            }
+
+            var result = new List<string>();
+            var buffer = new System.Text.StringBuilder();
+            var inQuotes = false;
+
+            foreach (var ch in filter)
+            {
+                if (ch == '"')
+                {
+                    inQuotes = !inQuotes;
+                    buffer.Append(ch);
+                    continue;
+                }
+
+                if (ch == ',' && !inQuotes)
+                {
+                    var value = buffer.ToString().Trim();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        result.Add(value);
+                    }
+
+                    buffer.Clear();
+                    continue;
+                }
+
+                buffer.Append(ch);
+            }
+
+            var trailing = buffer.ToString().Trim();
+            if (!string.IsNullOrWhiteSpace(trailing))
+            {
+                result.Add(trailing);
+            }
+
+            return result;
+        }
+
+        private static ActiveScopeFilter MergeScope(ActiveScopeFilter baseline, ActiveScopeFilter overlay)
+        {
+            return new ActiveScopeFilter(
+                string.IsNullOrWhiteSpace(overlay.Severity) ? baseline.Severity : overlay.Severity,
+                string.IsNullOrWhiteSpace(overlay.Rule) ? baseline.Rule : overlay.Rule,
+                string.IsNullOrWhiteSpace(overlay.File) ? baseline.File : overlay.File,
+                string.IsNullOrWhiteSpace(overlay.State) ? baseline.State : overlay.State);
+        }
+
+        private static ActiveScopeFilter GetActiveScope()
+        {
+            lock (SyncRoot)
+            {
+                return _activeScope;
+            }
+        }
+
+        private static void SetActiveScope(ActiveScopeFilter activeScope)
+        {
+            lock (SyncRoot)
+            {
+                _activeScope = activeScope;
+            }
+        }
+
+        private static Dictionary<string, string> ToScopeDictionary(ActiveScopeFilter activeScope)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(activeScope.Severity))
+            {
+                result["severity"] = activeScope.Severity;
+            }
+
+            if (!string.IsNullOrWhiteSpace(activeScope.Rule))
+            {
+                result["rule"] = activeScope.Rule;
+            }
+
+            if (!string.IsNullOrWhiteSpace(activeScope.File))
+            {
+                result["file"] = activeScope.File;
+            }
+
+            if (!string.IsNullOrWhiteSpace(activeScope.State))
+            {
+                result["state"] = activeScope.State;
+            }
+
+            return result;
+        }
+
+        private static JsonObject BuildScopedMeta(ScopedContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return JsonSerializer.SerializeToNode(new
+            {
+                context = new
+                {
+                    notice = context.Notice,
+                    active_scope = context.ActiveScope,
+                    metrics = new
+                    {
+                        total_in_scope = context.Metrics.TotalInScope,
+                        returned_in_batch = context.Metrics.ReturnedInBatch,
+                        remaining_in_scope = context.Metrics.RemainingInScope
+                    }
+                }
+            }) as JsonObject ?? new JsonObject();
         }
 
         private static string GetWorkspaceRoot()
@@ -654,13 +564,24 @@ namespace Sarifintown.AgentEngine
         }
 
         private static CallToolResult CreateDualPurposeResult(
-            string workflow,
-            string action,
-            string payload,
+            string markdown,
+            object? systemStateContext,
             string resourceUri,
-            string nextActionHint)
+            JsonObject? additionalMeta = null)
         {
-            var markdown = BuildPassThroughMarkdown(workflow, action, payload, nextActionHint);
+            var text = markdown?.Trim() ?? string.Empty;
+
+            if (systemStateContext != null)
+            {
+                var contextJson = JsonSerializer.Serialize(systemStateContext);
+                text = $"""
+                {text}
+
+                {StateContextDelimiter}
+                {contextJson}
+                """;
+            }
+
             if (string.IsNullOrWhiteSpace(resourceUri))
             {
                 string localUiBaseUrl;
@@ -691,75 +612,25 @@ namespace Sarifintown.AgentEngine
                 };
             }
 
+            if (additionalMeta != null)
+            {
+                foreach (var property in additionalMeta)
+                {
+                    meta[property.Key] = property.Value?.DeepClone();
+                }
+            }
+
             return new CallToolResult
             {
                 Content = new List<ContentBlock>
                 {
                     new TextContentBlock
                     {
-                        Text = markdown
+                        Text = text
                     }
                 },
                 Meta = meta
             };
-        }
-
-        private static string BuildPassThroughMarkdown(string workflow, string action, string payload, string nextActionHint)
-        {
-            if (TryExtractGuidedMarkdown(payload, out var guidedMarkdown))
-            {
-                return $"""
-                [INSTRUCTIONS FOR LLM]
-                You are acting as a UI renderer. Output the exact Markdown in the [CONTENT] block verbatim.
-                Do NOT summarize it. After rendering, PAUSE and wait for the user to type the next command.
-
-                [CONTENT]
-                {guidedMarkdown}
-
-                **Next Action:** {nextActionHint}
-                """;
-            }
-
-            return $"""
-            [INSTRUCTIONS FOR LLM]
-            You are acting as a UI renderer. Output the exact Markdown in the [CONTENT] block verbatim.
-            Do NOT summarize it. After rendering, PAUSE and wait for the user to type the next command.
-
-            [CONTENT]
-            ### SARIF {workflow} {action}
-
-            ```json
-            {payload}
-            ```
-
-            **Next Action:** {nextActionHint}
-            """;
-        }
-
-        private static bool TryExtractGuidedMarkdown(string payload, out string markdown)
-        {
-            markdown = string.Empty;
-            if (string.IsNullOrWhiteSpace(payload))
-            {
-                return false;
-            }
-
-            try
-            {
-                using var document = JsonDocument.Parse(payload);
-                if (!document.RootElement.TryGetProperty("markdown", out var markdownElement)
-                    || markdownElement.ValueKind != JsonValueKind.String)
-                {
-                    return false;
-                }
-
-                markdown = markdownElement.GetString() ?? string.Empty;
-                return !string.IsNullOrWhiteSpace(markdown);
-            }
-            catch (JsonException)
-            {
-                return false;
-            }
         }
 
         private static string BuildUiResourceUri(string routePrefix, string action, string id)
@@ -794,82 +665,56 @@ namespace Sarifintown.AgentEngine
             return $"default-src 'none'; script-src 'self' {origin}; style-src 'self' {origin}; connect-src 'self' {origin}; img-src 'self' data: {origin};";
         }
 
-        private static string CreateGuidedResponse(
-            string workflowName,
-            object data,
-            string markdown,
-            string nextTool,
-            object nextToolArguments,
-            bool pauseForUserInput,
-            string pausePrompt)
+        private static string BuildScopedGetMarkdown(ScopedGetPayload payload)
         {
-            return JsonSerializer.Serialize(new
-            {
-                protocol = "sarifintown.guided.v1",
-                workflow = workflowName,
-                llm_directive = "INSTRUCTIONS FOR LLM: Output the following markdown verbatim. Do not summarize or rephrase. After rendering, respect pause.required.",
-                markdown,
-                next_step = new
-                {
-                    tool = nextTool,
-                    arguments = nextToolArguments
-                },
-                pause = new
-                {
-                    required = pauseForUserInput,
-                    prompt = pausePrompt
-                },
-                data
-            });
-        }
+            ArgumentNullException.ThrowIfNull(payload);
+            var metrics = payload.Context.Metrics;
+            var findings = payload.Findings;
 
-        private static string BuildGuidedQueryMarkdown(
-            TriageStatusResult status,
-            IReadOnlyList<TriageListItem> findings,
-            bool includeEvidence,
-            int evidenceCount)
-        {
             var lines = new List<string>
             {
-                "## SARIF Triage Query",
+                "## SARIF Scoped Query",
                 string.Empty,
-                $"- Total findings: **{status.TotalFindings}**",
-                $"- Open findings: **{status.OpenCount}**",
-                $"- Triaged findings: **{status.TriagedCount}**",
-                $"- True positives: **{status.TruePositiveCount}**",
-                $"- False positives: **{status.FalsePositiveCount}**",
+                $"- Total in scope: **{metrics.TotalInScope}**",
+                $"- Returned in batch: **{metrics.ReturnedInBatch}**",
+                $"- Remaining in scope: **{metrics.RemainingInScope}**",
                 string.Empty
             };
 
             if (findings.Count == 0)
             {
-                lines.Add("No findings matched the provided filters.");
+                lines.Add("No findings in current result set.");
             }
             else
             {
-                lines.Add("| FindingId | Severity | State | Rule | Location | Score |\n|---|---|---|---|---|---|");
-                lines.AddRange(findings.Select(item =>
-                    $"| `{EscapeMarkdown(item.FindingId)}` | `{EscapeMarkdown(item.Severity)}` | `{EscapeMarkdown(item.State)}` | `{EscapeMarkdown(item.RuleName)}` | `{EscapeMarkdown(item.FilePath)}`:{item.LineNumber?.ToString() ?? "?"} | {item.PriorityScore:F2} |"));
+                lines.Add("| Id | Severity | State | Rule | Location |\n|---|---|---|---|---|");
+                foreach (var finding in findings)
+                {
+                    lines.Add($"| `{EscapeMarkdown(finding.Id)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.State)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Location.File)}`:{finding.Location.Line?.ToString() ?? "?"} |");
+                }
             }
 
             lines.Add(string.Empty);
-            lines.Add(includeEvidence
-                ? $"Included evidence payloads: **{evidenceCount}**"
-                : "Evidence snippets not included. Set `includeEvidence=true` for narrow scopes.");
-            lines.Add("**Next action:** Reply with a `FindingId` to deep-dive via `query`, or call `decide` to persist TP/FP.");
-            lines.Add("Then pause for user input.");
+            lines.Add("**Next action:** Use `sarif.triage` with `state`, `reason`, and `target`.");
 
             return string.Join(Environment.NewLine, lines);
         }
 
-        private static string BuildGuidedDecideMarkdown(JsonElement decision)
+        private static string BuildScopedTriageMarkdown(ScopedTriagePayload payload)
         {
-            if (decision.TryGetProperty("FindingId", out _))
-            {
-                return BuildGuidedDecisionMarkdown(decision);
-            }
+            ArgumentNullException.ThrowIfNull(payload);
 
-            return BuildGuidedBulkMarkdown(decision);
+            return string.Join(Environment.NewLine,
+            [
+                "## SARIF Scoped Triage",
+                string.Empty,
+                $"- Success: **{payload.Success}**",
+                $"- State: `{EscapeMarkdown(payload.State)}`",
+                $"- Target: `{EscapeMarkdown(payload.Target)}`",
+                $"- Affected findings: **{payload.AffectedCount}**",
+                string.Empty,
+                "**Next action:** Run `sarif.get` to verify remaining findings in scope."
+            ]);
         }
 
         private static List<string> ResolveFindingIds(string findingIds)
@@ -883,118 +728,6 @@ namespace Sarifintown.AgentEngine
                 .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
-        }
-
-        private static string BuildGuidedFindingsMarkdown(IReadOnlyList<TriageListItem> findings)
-        {
-            if (findings.Count == 0)
-            {
-                return """
-                ## Prioritized Findings
-
-                No findings matched the provided filters.
-
-                **Next action:** Adjust filters and call `TriageListGuided` again.
-                """;
-            }
-
-            var lines = findings
-                .Select(item => $"| `{EscapeMarkdown(item.FindingId)}` | `{EscapeMarkdown(item.Severity)}` | `{EscapeMarkdown(item.State)}` | `{EscapeMarkdown(item.RuleName)}` | `{EscapeMarkdown(item.FilePath)}`:{item.LineNumber?.ToString() ?? "?"} |")
-                .ToList();
-
-            return string.Join(Environment.NewLine,
-            [
-                "## Prioritized Findings",
-                string.Empty,
-                "| FindingId | Severity | State | Rule | Location |",
-                "|---|---|---|---|---|",
-                .. lines,
-                string.Empty,
-                "**Next action:** Reply with a `FindingId` value to inspect evidence.",
-                "Then pause for user input."
-            ]);
-        }
-
-        private static string BuildGuidedDecisionMarkdown(JsonElement decision)
-        {
-            var success = decision.TryGetProperty("Success", out var successElement) && successElement.GetBoolean();
-            var findingId = decision.TryGetProperty("FindingId", out var findingIdElement)
-                ? findingIdElement.GetString() ?? string.Empty
-                : string.Empty;
-            var state = decision.TryGetProperty("State", out var stateElement)
-                ? stateElement.GetString() ?? string.Empty
-                : string.Empty;
-            var message = decision.TryGetProperty("Message", out var messageElement)
-                ? messageElement.GetString() ?? string.Empty
-                : string.Empty;
-
-            return string.Join(Environment.NewLine,
-            [
-                "## Triage Decision Result",
-                string.Empty,
-                $"- Success: **{success}**",
-                $"- FindingId: `{EscapeMarkdown(findingId)}`",
-                $"- State: `{EscapeMarkdown(state)}`",
-                $"- Message: {EscapeMarkdown(message)}",
-                string.Empty,
-                "**Next action:** Reply with `status` to refresh posture or `list` to continue triage.",
-                "Then pause for user input."
-            ]);
-        }
-
-        private static string BuildGuidedBulkMarkdown(JsonElement bulk)
-        {
-            var success = bulk.TryGetProperty("Success", out var successElement) && successElement.GetBoolean();
-            var message = bulk.TryGetProperty("Message", out var messageElement)
-                ? messageElement.GetString() ?? string.Empty
-                : string.Empty;
-            var affected = bulk.TryGetProperty("AffectedCount", out var affectedElement)
-                ? affectedElement.GetInt32()
-                : 0;
-            var dryRun = bulk.TryGetProperty("DryRun", out var dryRunElement) && dryRunElement.GetBoolean();
-
-            return string.Join(Environment.NewLine,
-            [
-                "## Bulk Triage Result",
-                string.Empty,
-                $"- Success: **{success}**",
-                $"- Dry Run: **{dryRun}**",
-                $"- Affected Findings: **{affected}**",
-                $"- Message: {EscapeMarkdown(message)}",
-                string.Empty,
-                dryRun
-                    ? "**Next action:** Reply with `bulk_decide` and `dryRun=false` to persist the same decision."
-                    : "**Next action:** Reply with `status` to review updated triage posture.",
-                "Then pause for user input."
-            ]);
-        }
-
-        private static string BuildGuidedInspectMarkdown(TriageInspectResult inspect)
-        {
-            var evidenceRows = inspect.DataFlowEvidenceBlocks
-                .Select(block => $"- Steps {block.StartStepIndex}-{block.EndStepIndex} in `{EscapeMarkdown(block.FilePath)}` ({block.StartLine?.ToString() ?? "?"}-{block.EndLine?.ToString() ?? "?"}) via `{EscapeMarkdown(block.Mode)}`")
-                .ToList();
-
-            if (evidenceRows.Count == 0)
-            {
-                evidenceRows.Add("- No data-flow evidence blocks were produced for this finding.");
-            }
-
-            return string.Join(Environment.NewLine,
-            [
-                "## Finding Inspection",
-                string.Empty,
-                $"- FindingId: `{EscapeMarkdown(inspect.FindingId)}`",
-                $"- Rule: `{EscapeMarkdown(inspect.RuleId)}`",
-                $"- Severity: `{EscapeMarkdown(inspect.Severity)}`",
-                $"- State: `{EscapeMarkdown(inspect.State)}`",
-                string.Empty,
-                "### Evidence Blocks",
-                .. evidenceRows,
-                string.Empty,
-                "**Next action:** Reply with `TP <reason>` or `FP <reason>` to store triage state.",
-                "Then pause for user input."
-            ]);
         }
 
         private static string EscapeMarkdown(string value)
@@ -1257,25 +990,33 @@ namespace Sarifintown.AgentEngine
             return property.GetValue(instance);
         }
 
-        private sealed class FacadeFilterOptions
-        {
-            public string Severity { get; init; } = string.Empty;
-            public string Rule { get; init; } = string.Empty;
-            public string RuleId { get; init; } = string.Empty;
-            public string File { get; init; } = string.Empty;
-            public string State { get; init; } = string.Empty;
-            public int Limit { get; init; } = 10;
-            public bool IncludeEvidence { get; init; }
-            public string FindingIds { get; init; } = string.Empty;
-            public bool Guided { get; init; }
-            public bool DryRun { get; init; }
-            public string EvidenceMode { get; init; } = string.Empty;
-            public string Author { get; init; } = string.Empty;
-            public string Category { get; init; } = string.Empty;
-            public string SourceCodeRoot { get; init; } = string.Empty;
-            public string OutputPath { get; init; } = string.Empty;
-            public string ExtractedFlowData { get; init; } = string.Empty;
-        }
+        private sealed record ScopedMetrics(int TotalInScope, int ReturnedInBatch, int RemainingInScope);
+
+        private sealed record ScopedContext(
+            string Notice,
+            IReadOnlyDictionary<string, string> ActiveScope,
+            ScopedMetrics Metrics);
+
+        private sealed record ScopedLocation(string File, int? Line);
+
+        private sealed record ScopedFinding(
+            string Id,
+            string Severity,
+            string State,
+            string Rule,
+            string Message,
+            ScopedLocation Location,
+            TriageInspectResult? Evidence);
+
+        private sealed record ScopedGetPayload(ScopedContext Context, IReadOnlyList<ScopedFinding> Findings);
+
+        private sealed record ScopedTriagePayload(
+            bool Success,
+            string State,
+            string Reason,
+            string Target,
+            int AffectedCount,
+            IReadOnlyList<string> ModifiedFindingIds);
 
         [Description("MUST: Use this tool to compile extracted flow JSON into a markdown report artifact for downstream analysis.")]
         public static string GenerateAnalysisReport(

--- a/Sarifintown.AgentEngine/SnippetCacheService.cs
+++ b/Sarifintown.AgentEngine/SnippetCacheService.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace Sarifintown.AgentEngine;
+
+internal sealed class SnippetCacheService
+{
+    private readonly ConcurrentDictionary<string, string> _cache = new(
+        OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+
+    internal bool TryGet(string key, out string snippet)
+    {
+        return _cache.TryGetValue(key, out snippet!);
+    }
+
+    internal void Set(string key, string snippet)
+    {
+        if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(snippet))
+        {
+            return;
+        }
+
+        _cache[key] = snippet;
+    }
+}

--- a/Sarifintown.AgentEngine/SnippetWarmupService.cs
+++ b/Sarifintown.AgentEngine/SnippetWarmupService.cs
@@ -1,0 +1,213 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Sarifintown.Core;
+using Sarifintown.Helpers;
+using Sarifintown.Models;
+
+namespace Sarifintown.AgentEngine;
+
+internal sealed class SnippetWarmupService : BackgroundService
+{
+    private readonly Channel<string> _findingQueue = Channel.CreateUnbounded<string>();
+    private readonly HashSet<string> _queuedFindingIds = new(StringComparer.Ordinal);
+    private readonly object _queueLock = new();
+
+    private readonly SarifStateService _stateService;
+    private readonly IFileReader _fileReader;
+    private readonly ITreeSitterEngine _treeSitterEngine;
+    private readonly SnippetCacheService _snippetCache;
+    private readonly string _workspaceRoot;
+    private readonly ILogger<SnippetWarmupService> _logger;
+
+    internal SnippetWarmupService(
+        SarifStateService stateService,
+        IFileReader fileReader,
+        ITreeSitterEngine treeSitterEngine,
+        SnippetCacheService snippetCache,
+        string workspaceRoot,
+        ILogger<SnippetWarmupService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(stateService);
+        ArgumentNullException.ThrowIfNull(fileReader);
+        ArgumentNullException.ThrowIfNull(treeSitterEngine);
+        ArgumentNullException.ThrowIfNull(snippetCache);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _stateService = stateService;
+        _fileReader = fileReader;
+        _treeSitterEngine = treeSitterEngine;
+        _snippetCache = snippetCache;
+        _workspaceRoot = workspaceRoot;
+        _logger = logger;
+    }
+
+    internal ValueTask QueueFindingsAsync(IEnumerable<string> findingIds, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(findingIds);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var findingId in findingIds)
+        {
+            if (string.IsNullOrWhiteSpace(findingId))
+            {
+                continue;
+            }
+
+            var shouldQueue = false;
+            lock (_queueLock)
+            {
+                shouldQueue = _queuedFindingIds.Add(findingId);
+            }
+
+            if (shouldQueue)
+            {
+                if (!_findingQueue.Writer.TryWrite(findingId))
+                {
+                    lock (_queueLock)
+                    {
+                        _queuedFindingIds.Remove(findingId);
+                    }
+                }
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    internal async Task PreloadSnippetsAsync(int maxFindings, CancellationToken cancellationToken)
+    {
+        if (maxFindings <= 0)
+        {
+            return;
+        }
+
+        var findings = await _stateService.GetFindingsAsync(cancellationToken).ConfigureAwait(false);
+        var candidates = findings
+            .OrderByDescending(finding => finding.PriorityScore)
+            .ThenBy(finding => finding.FindingId, StringComparer.Ordinal)
+            .Take(maxFindings)
+            .ToList();
+
+        foreach (var finding in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await WarmFindingAsync(finding, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var findingId in _findingQueue.Reader.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                await WarmFindingAsync(findingId, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (InvalidOperationException exception)
+            {
+                _logger.LogWarning(exception, "Snippet warmup skipped for finding {FindingId} due to invalid state.", findingId);
+            }
+            catch (IOException exception)
+            {
+                _logger.LogWarning(exception, "Snippet warmup skipped for finding {FindingId} due to I/O failure.", findingId);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                _logger.LogWarning(exception, "Snippet warmup skipped for finding {FindingId} due to access restrictions.", findingId);
+            }
+            finally
+            {
+                lock (_queueLock)
+                {
+                    _queuedFindingIds.Remove(findingId);
+                }
+            }
+        }
+    }
+
+    private async Task WarmFindingAsync(string findingId, CancellationToken cancellationToken)
+    {
+        var findings = await _stateService.GetFindingsAsync(cancellationToken).ConfigureAwait(false);
+        var finding = findings.FirstOrDefault(item => string.Equals(item.FindingId, findingId, StringComparison.Ordinal));
+        if (finding == null)
+        {
+            return;
+        }
+
+        await WarmFindingAsync(finding, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WarmFindingAsync(TriageFindingEnvelope finding, CancellationToken cancellationToken)
+    {
+
+        var flowLocations = finding.Result.CodeFlows?
+            .SelectMany(flow => flow.ThreadFlows ?? new List<ThreadFlow>())
+            .SelectMany(threadFlow => threadFlow.Locations ?? new List<ThreadFlowLocation>())
+            .ToList() ?? new List<ThreadFlowLocation>();
+
+        foreach (var flowLocation in flowLocations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var physicalLocation = flowLocation.Location?.PhysicalLocation;
+            if (physicalLocation == null)
+            {
+                continue;
+            }
+
+            var sourcePath = FileHelper.ResolvePathForWorkspace(physicalLocation.ArtifactLocation, finding.Run, _workspaceRoot);
+            if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+            {
+                continue;
+            }
+
+            var startLine = physicalLocation.Region?.StartLine ?? 1;
+            var endLine = physicalLocation.Region?.EndLine > 0 ? physicalLocation.Region.EndLine : startLine;
+            var cacheKey = TriageWorkflowService.BuildSnippetCacheKey(sourcePath, startLine, endLine, "tree-sitter-method");
+
+            if (_snippetCache.TryGet(cacheKey, out _))
+            {
+                continue;
+            }
+
+            var snippet = await ExtractSnippetAsync(sourcePath, physicalLocation.Region, cancellationToken).ConfigureAwait(false);
+            _snippetCache.Set(cacheKey, snippet);
+        }
+    }
+
+    private async Task<string> ExtractSnippetAsync(string sourcePath, Region? region, CancellationToken cancellationToken)
+    {
+        var sourceCode = await _fileReader.ReadFileAsync(sourcePath).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(sourceCode))
+        {
+            return string.Empty;
+        }
+
+        var windowStartLine = region?.StartLine ?? 1;
+        var windowEndLine = region?.EndLine > 0 ? region.EndLine : windowStartLine;
+        var startLine = Math.Max(0, windowStartLine - 1);
+        var endLine = Math.Max(startLine, windowEndLine - 1);
+        var language = CodeLanguageResolver.GetLanguageFromExtension(Path.GetExtension(sourcePath));
+
+        if (string.IsNullOrWhiteSpace(language))
+        {
+            return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var extractedMethod = await _treeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(extractedMethod)
+            && !extractedMethod.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
+        {
+            return extractedMethod.Trim();
+        }
+
+        return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+    }
+}

--- a/Sarifintown.AgentEngine/SpectreCliMenu.cs
+++ b/Sarifintown.AgentEngine/SpectreCliMenu.cs
@@ -48,7 +48,7 @@ internal static class SpectreCliMenu
             "Triage status" => await RenderStatusAsync(cancellationToken),
             "Triage list" => await RenderListAsync(cancellationToken),
             "Triage decision" => await RenderTriageAsync(cancellationToken),
-            "Triage inspect" or "Triage bulk" => JsonSerializer.Serialize(new { success = false, message = $"Action migrated to sarif.get/sarif.triage flow: {action}" }),
+            "Triage inspect" or "Triage bulk" => JsonSerializer.Serialize(new { success = false, message = $"Action migrated to sarif_get/sarif_triage flow: {action}" }),
             _ => JsonSerializer.Serialize(new { success = false, message = $"Unsupported action: {action}" })
         };
     }
@@ -82,7 +82,7 @@ internal static class SpectreCliMenu
                 .Title("Triage state")
                 .AddChoices("TP", "FP"));
         var reason = AnsiConsole.Ask<string>("Reason:");
-        var target = AnsiConsole.Ask<string>("Target (finding id, id1,id2, or scope):", "scope");
+        var target = AnsiConsole.Ask<string>("Target (alias like 1/@1/S-01, CSV aliases, raw ID, or scope):", "scope");
 
         cancellationToken.ThrowIfCancellationRequested();
         var result = await SarifTools.SarifTriage(state, reason, target);
@@ -115,15 +115,16 @@ internal static class SpectreCliMenu
         }
 
         var delimiter = SarifTools.StateContextDelimiter;
-        var marker = $"\n\n{delimiter}\n";
-        var delimiterIndex = text.IndexOf(marker, StringComparison.Ordinal);
+        var delimiterIndex = text.IndexOf(delimiter, StringComparison.Ordinal);
         if (delimiterIndex < 0)
         {
             return (text, string.Empty);
         }
 
         var displayMarkdown = text[..delimiterIndex].Trim();
-        var hiddenJsonState = text[(delimiterIndex + marker.Length)..].Trim();
+        var hiddenJsonState = text[(delimiterIndex + delimiter.Length)..]
+            .TrimStart('\r', '\n')
+            .Trim();
         return (displayMarkdown, hiddenJsonState);
     }
 

--- a/Sarifintown.AgentEngine/SpectreCliMenu.cs
+++ b/Sarifintown.AgentEngine/SpectreCliMenu.cs
@@ -1,4 +1,6 @@
 using Spectre.Console;
+using ModelContextProtocol.Protocol;
+using System.Linq;
 using System.Text.Json;
 
 namespace Sarifintown.AgentEngine;
@@ -38,129 +40,129 @@ internal static class SpectreCliMenu
     }
 
     public static async Task<string> ExecuteTriageActionAsync(
-        TriageWorkflowService workflow,
         string action,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(workflow);
-
         return action switch
         {
-            "Triage status" => await RenderStatusAsync(workflow, cancellationToken),
-            "Triage list" => await RenderListAsync(workflow, cancellationToken),
-            "Triage inspect" => await RenderInspectAsync(workflow, cancellationToken),
-            "Triage decision" => await RenderTriageAsync(workflow, cancellationToken),
-            "Triage bulk" => await RenderTriageBulkAsync(workflow, cancellationToken),
+            "Triage status" => await RenderStatusAsync(cancellationToken),
+            "Triage list" => await RenderListAsync(cancellationToken),
+            "Triage decision" => await RenderTriageAsync(cancellationToken),
+            "Triage inspect" or "Triage bulk" => JsonSerializer.Serialize(new { success = false, message = $"Action migrated to sarif.get/sarif.triage flow: {action}" }),
             _ => JsonSerializer.Serialize(new { success = false, message = $"Unsupported action: {action}" })
         };
     }
 
-    private static async Task<string> RenderStatusAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    private static async Task<string> RenderStatusAsync(CancellationToken cancellationToken)
     {
-        var status = await workflow.GetStatusAsync(cancellationToken);
-
-        AnsiConsole.MarkupLine($"[green]Total findings:[/] {status.TotalFindings}");
-        AnsiConsole.MarkupLine($"[yellow]Open:[/] {status.OpenCount}  [blue]Triaged:[/] {status.TriagedCount}  [green]TP:[/] {status.TruePositiveCount}  [red]FP:[/] {status.FalsePositiveCount}");
-
-        return JsonSerializer.Serialize(status);
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = await SarifTools.SarifGet(scope: "keep", filter: string.Empty, includeEvidence: false, limit: 10);
+        return RenderDualPurposeText(result);
     }
 
-    private static async Task<string> RenderListAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    private static async Task<string> RenderListAsync(CancellationToken cancellationToken)
     {
-        var severity = AnsiConsole.Ask<string>("Severity filter (optional, CSV):", string.Empty);
-        var rule = AnsiConsole.Ask<string>("Rule filter (optional, CSV):", string.Empty);
-        var file = AnsiConsole.Ask<string>("File filter (optional, wildcard supported):", string.Empty);
-        var state = AnsiConsole.Ask<string>("State filter (optional: Open/TP/FP):", string.Empty);
+        var scope = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Scope action")
+                .AddChoices("keep", "set", "refine", "clear"));
+        var filter = AnsiConsole.Ask<string>("Filter expression (e.g. severity:high, rule:SQLI):", string.Empty);
+        var includeEvidence = AnsiConsole.Confirm("Include evidence?", false);
         var limit = AnsiConsole.Ask<int>("Limit:", 10);
 
-        var results = await workflow.ListAsync(new TriageQueryOptions(severity, rule, file, state, limit), cancellationToken);
-        var table = new Table().Border(TableBorder.Rounded);
-        table.AddColumn("FindingId");
-        table.AddColumn("Rule");
-        table.AddColumn("File");
-        table.AddColumn("Line");
-        table.AddColumn("Severity");
-        table.AddColumn("State");
-        table.AddColumn("TPS");
-
-        foreach (var item in results)
-        {
-            table.AddRow(
-                item.FindingId,
-                item.RuleName,
-                item.FilePath,
-                item.LineNumber?.ToString() ?? "",
-                item.Severity,
-                item.State,
-                item.PriorityScore.ToString("0.##"));
-        }
-
-        AnsiConsole.Write(table);
-        return JsonSerializer.Serialize(results);
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = await SarifTools.SarifGet(scope, filter, includeEvidence, limit);
+        return RenderDualPurposeText(result);
     }
 
-    private static async Task<string> RenderInspectAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
-    {
-        var findingId = AnsiConsole.Ask<string>("Finding ID:");
-        var result = await workflow.InspectAsync(findingId, cancellationToken);
-
-        if (result == null)
-        {
-            var errorPayload = new { success = false, message = $"Finding not found: {findingId}" };
-            AnsiConsole.MarkupLine($"[red]{errorPayload.message}[/]");
-            return JsonSerializer.Serialize(errorPayload);
-        }
-
-        AnsiConsole.MarkupLine($"[green]Rule:[/] {result.RuleId} ({result.RuleName})");
-        AnsiConsole.MarkupLine($"[green]Severity:[/] {result.Severity}  [green]State:[/] {result.State}");
-        AnsiConsole.MarkupLine($"[green]Flow steps:[/] {result.DataFlowSteps.Count}");
-
-        return JsonSerializer.Serialize(result);
-    }
-
-    private static async Task<string> RenderTriageAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
-    {
-        var findingId = AnsiConsole.Ask<string>("Finding ID:");
-        var state = AnsiConsole.Prompt(
-            new SelectionPrompt<string>()
-                .Title("Triage state")
-                .AddChoices("TP", "FP"));
-        var reason = AnsiConsole.Ask<string>("Reason:");
-        var author = AnsiConsole.Ask<string>("Author:", "User");
-
-        var result = await workflow.TriageAsync(findingId, state, reason, author, cancellationToken);
-        AnsiConsole.MarkupLine(result.Success
-            ? $"[green]{result.Message}[/]"
-            : $"[red]{result.Message}[/]");
-
-        return JsonSerializer.Serialize(result);
-    }
-
-    private static async Task<string> RenderTriageBulkAsync(TriageWorkflowService workflow, CancellationToken cancellationToken)
+    private static async Task<string> RenderTriageAsync(CancellationToken cancellationToken)
     {
         var state = AnsiConsole.Prompt(
             new SelectionPrompt<string>()
                 .Title("Triage state")
                 .AddChoices("TP", "FP"));
         var reason = AnsiConsole.Ask<string>("Reason:");
-        var severity = AnsiConsole.Ask<string>("Severity filter (optional, CSV):", string.Empty);
-        var rule = AnsiConsole.Ask<string>("Rule filter (optional, CSV):", string.Empty);
-        var file = AnsiConsole.Ask<string>("File filter (optional, wildcard supported):", string.Empty);
-        var dryRun = AnsiConsole.Confirm("Dry run only?", true);
-        var author = AnsiConsole.Ask<string>("Author:", "User");
+        var target = AnsiConsole.Ask<string>("Target (finding id, id1,id2, or scope):", "scope");
 
-        var result = await workflow.TriageBulkAsync(
-            state,
-            reason,
-            new TriageQueryOptions(severity, rule, file, string.Empty, int.MaxValue),
-            dryRun,
-            author,
-            cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = await SarifTools.SarifTriage(state, reason, target);
+        return RenderDualPurposeText(result);
+    }
 
-        AnsiConsole.MarkupLine(result.Success
-            ? $"[green]{result.Message}[/]"
-            : $"[red]{result.Message}[/]");
+    private static string RenderDualPurposeText(CallToolResult result)
+    {
+        var text = (result.Content.FirstOrDefault() as TextContentBlock)?.Text ?? string.Empty;
+        var (displayMarkdown, hiddenJsonState) = SplitDualPurposeText(text);
 
-        return JsonSerializer.Serialize(result);
+        if (!string.IsNullOrWhiteSpace(hiddenJsonState))
+        {
+            RenderStatePanel(hiddenJsonState);
+        }
+
+        if (!string.IsNullOrWhiteSpace(displayMarkdown))
+        {
+            AnsiConsole.Write(new Text(displayMarkdown));
+        }
+
+        return text;
+    }
+
+    private static (string displayMarkdown, string hiddenJsonState) SplitDualPurposeText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var delimiter = SarifTools.StateContextDelimiter;
+        var marker = $"\n\n{delimiter}\n";
+        var delimiterIndex = text.IndexOf(marker, StringComparison.Ordinal);
+        if (delimiterIndex < 0)
+        {
+            return (text, string.Empty);
+        }
+
+        var displayMarkdown = text[..delimiterIndex].Trim();
+        var hiddenJsonState = text[(delimiterIndex + marker.Length)..].Trim();
+        return (displayMarkdown, hiddenJsonState);
+    }
+
+    private static void RenderStatePanel(string hiddenJsonState)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(hiddenJsonState);
+            if (!doc.RootElement.TryGetProperty("context", out var context))
+            {
+                return;
+            }
+
+            var scopeLabel = "global";
+            if (context.TryGetProperty("active_scope", out var activeScope)
+                && activeScope.ValueKind == JsonValueKind.Object
+                && activeScope.EnumerateObject().Any())
+            {
+                scopeLabel = string.Join(", ", activeScope.EnumerateObject().Select(p => $"{p.Name}={p.Value.ToString()}"));
+            }
+
+            var progressLabel = "n/a";
+            if (context.TryGetProperty("metrics", out var metrics)
+                && metrics.TryGetProperty("returned_in_batch", out var returned)
+                && metrics.TryGetProperty("remaining_in_scope", out var remaining))
+            {
+                progressLabel = $"{returned.GetInt32()} returned / {remaining.GetInt32()} remaining";
+            }
+
+            var panel = new Panel($"Scope: {scopeLabel}\nProgress: {progressLabel}")
+            {
+                Header = new PanelHeader("Active Triage Workspace")
+            };
+
+            AnsiConsole.Write(panel);
+        }
+        catch (JsonException)
+        {
+            // ignore malformed hidden context in CLI fallback path
+        }
     }
 }

--- a/Sarifintown.AgentEngine/TriageWorkflowModels.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowModels.cs
@@ -85,6 +85,21 @@ internal sealed record TriageBulkResult(
     IReadOnlyList<string> ModifiedFindingIds,
     bool DryRun);
 
+internal sealed record TriageFindingEnvelope(
+    string FindingId,
+    Sarifintown.Models.Result Result,
+    Sarifintown.Models.Run Run,
+    string SarifPath,
+    string Severity,
+    TriageFindingState State,
+    string RuleName,
+    string FilePath,
+    int? LineNumber,
+    double PriorityScore,
+    string RuleCategory,
+    string RuleDescription,
+    string Remediation);
+
 internal sealed record TriageStateDocument
 {
     public int SchemaVersion { get; init; } = 1;

--- a/Sarifintown.AgentEngine/TriageWorkflowModels.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowModels.cs
@@ -85,6 +85,60 @@ internal sealed record TriageBulkResult(
     IReadOnlyList<string> ModifiedFindingIds,
     bool DryRun);
 
+internal enum ScopeAction
+{
+    Keep = 0,
+    Set = 1,
+    Refine = 2,
+    Clear = 3
+}
+
+internal sealed record ActiveScopeFilter(
+    string Severity = "",
+    string Rule = "",
+    string File = "",
+    string State = "")
+{
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Severity)
+        && string.IsNullOrWhiteSpace(Rule)
+        && string.IsNullOrWhiteSpace(File)
+        && string.IsNullOrWhiteSpace(State);
+
+    public TriageQueryOptions ToQueryOptions(int limit)
+    {
+        return new TriageQueryOptions(
+            Severity,
+            Rule,
+            File,
+            State,
+            limit);
+    }
+}
+
+internal sealed record SarifGetMetrics(
+    int TotalInScope,
+    int ReturnedInBatch,
+    int RemainingInScope);
+
+internal sealed record SarifGetContext(
+    string Notice,
+    IReadOnlyDictionary<string, string> ActiveScope,
+    SarifGetMetrics Metrics);
+
+internal sealed record SarifGetFinding(
+    string FindingId,
+    string RuleName,
+    string FilePath,
+    int? LineNumber,
+    string Severity,
+    double PriorityScore,
+    string State,
+    TriageInspectResult? Evidence);
+
+internal sealed record SarifGetResponse(
+    SarifGetContext Context,
+    IReadOnlyList<SarifGetFinding> Findings);
+
 internal sealed record TriageFindingEnvelope(
     string FindingId,
     Sarifintown.Models.Result Result,

--- a/Sarifintown.AgentEngine/TriageWorkflowService.cs
+++ b/Sarifintown.AgentEngine/TriageWorkflowService.cs
@@ -1,44 +1,38 @@
 using Sarifintown.Core;
 using Sarifintown.Helpers;
 using Sarifintown.Models;
-using System.Globalization;
 using System.Text.RegularExpressions;
-using System.Text.Json;
 
 namespace Sarifintown.AgentEngine;
 
 internal sealed class TriageWorkflowService
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     private readonly IFileReader _fileReader;
     private readonly ITreeSitterEngine _treeSitterEngine;
+    private readonly SarifStateService _stateService;
+    private readonly SnippetCacheService? _snippetCache;
+    private readonly SnippetWarmupService? _snippetWarmupService;
     private readonly string _workspaceRoot;
-    private readonly IReadOnlyList<string> _sarifFiles;
 
     public TriageWorkflowService(
         IFileReader fileReader,
         ITreeSitterEngine treeSitterEngine,
+        SarifStateService stateService,
         string workspaceRoot,
-        IEnumerable<string> sarifFiles)
+        SnippetCacheService? snippetCache = null,
+        SnippetWarmupService? snippetWarmupService = null)
     {
         ArgumentNullException.ThrowIfNull(fileReader);
         ArgumentNullException.ThrowIfNull(treeSitterEngine);
+        ArgumentNullException.ThrowIfNull(stateService);
         ArgumentNullException.ThrowIfNull(workspaceRoot);
-        ArgumentNullException.ThrowIfNull(sarifFiles);
 
         _fileReader = fileReader;
         _treeSitterEngine = treeSitterEngine;
+        _stateService = stateService;
+        _snippetCache = snippetCache;
+        _snippetWarmupService = snippetWarmupService;
         _workspaceRoot = workspaceRoot;
-        _sarifFiles = sarifFiles
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Select(Path.GetFullPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
     }
 
     public async Task<TriageStatusResult> GetStatusAsync(CancellationToken cancellationToken = default)
@@ -83,6 +77,16 @@ internal sealed class TriageWorkflowService
             .OrderByDescending(finding => finding.PriorityScore)
             .ThenBy(finding => finding.FindingId, StringComparer.Ordinal)
             .Take(options.Limit <= 0 ? 10 : options.Limit)
+            .ToList();
+
+        if (_snippetWarmupService != null)
+        {
+            await _snippetWarmupService.QueueFindingsAsync(
+                ordered.Select(finding => finding.FindingId),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return ordered
             .Select(finding => new TriageListItem(
                 finding.FindingId,
                 finding.RuleName,
@@ -92,8 +96,6 @@ internal sealed class TriageWorkflowService
                 finding.PriorityScore,
                 finding.State.ToString()))
             .ToList();
-
-        return ordered;
     }
 
     public async Task<TriageInspectResult?> InspectAsync(
@@ -512,83 +514,8 @@ internal sealed class TriageWorkflowService
 
     private async Task<List<TriageFindingEnvelope>> LoadFindingsAsync(CancellationToken cancellationToken)
     {
-        var triageState = await LoadTriageStateDocumentAsync(cancellationToken);
-        var triageMap = triageState.Entries
-            .Where(entry => !string.IsNullOrWhiteSpace(entry.FindingId))
-            .GroupBy(entry => entry.FindingId, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.OrderByDescending(item => item.UpdatedUtc).First(), StringComparer.Ordinal);
-
-        var findings = new List<TriageFindingEnvelope>();
-
-        foreach (var sarifFile in _sarifFiles)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!File.Exists(sarifFile))
-            {
-                continue;
-            }
-
-            var content = await _fileReader.ReadFileAsync(sarifFile);
-            var sarifLog = JsonSerializer.Deserialize<SarifLog>(content, JsonOptions);
-            if (sarifLog?.Runs == null)
-            {
-                continue;
-            }
-
-            foreach (var run in sarifLog.Runs)
-            {
-                var rules = (run.Tool?.Driver?.Rule ?? new List<Rule>())
-                    .Where(rule => !string.IsNullOrWhiteSpace(rule.Id))
-                    .GroupBy(rule => rule.Id, StringComparer.OrdinalIgnoreCase)
-                    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
-
-                foreach (var result in run.Results ?? new List<Result>())
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    if (string.IsNullOrWhiteSpace(result.ResultIdentity))
-                    {
-                        result.ResultIdentity = SarifTriageIdentityHelper.BuildIdentity(result);
-                    }
-
-                    var findingId = result.ResultIdentity;
-                    if (string.IsNullOrWhiteSpace(findingId))
-                    {
-                        continue;
-                    }
-
-                    var rule = ResolveRule(rules, run, result);
-                    var severity = ResolveSeverity(result, rule);
-                    var state = ResolveState(triageMap, findingId);
-                    var filePath = ResolveResultFilePath(run, result);
-                    var lineNumber = result.Locations?.FirstOrDefault()?.PhysicalLocation?.Region?.StartLine;
-                    var priority = CalculatePriorityScore(severity, result);
-                    var ruleName = !string.IsNullOrWhiteSpace(rule?.Name)
-                        ? rule!.Name
-                        : result.RuleId ?? "UnknownRule";
-                    var ruleCategory = ResolveRuleCategory(rule, result);
-                    var ruleDescription = rule?.ShortDescription?.Text ?? string.Empty;
-                    var remediation = ResolveRemediation(rule, result);
-
-                    findings.Add(new TriageFindingEnvelope(
-                        findingId,
-                        result,
-                        run,
-                        sarifFile,
-                        severity,
-                        state,
-                        ruleName,
-                        filePath,
-                        lineNumber,
-                        priority,
-                        ruleCategory,
-                        ruleDescription,
-                        remediation));
-                }
-            }
-        }
-
-        return findings;
+        var findings = await _stateService.GetFindingsAsync(cancellationToken);
+        return findings.ToList();
     }
 
     private static IEnumerable<TriageFindingEnvelope> ApplyFilters(IEnumerable<TriageFindingEnvelope> findings, TriageQueryOptions options)
@@ -658,137 +585,6 @@ internal sealed class TriageWorkflowService
             .Where(item => !string.IsNullOrWhiteSpace(item));
     }
 
-    private static Rule? ResolveRule(
-        IReadOnlyDictionary<string, Rule> rules,
-        Run run,
-        Result result)
-    {
-        if (!string.IsNullOrWhiteSpace(result.RuleId)
-            && rules.TryGetValue(result.RuleId, out var byRuleId))
-        {
-            return byRuleId;
-        }
-
-        if (result.RuleIndex >= 0
-            && run.Tool?.Driver?.Rule != null
-            && result.RuleIndex < run.Tool.Driver.Rule.Count)
-        {
-            return run.Tool.Driver.Rule[result.RuleIndex];
-        }
-
-        return result.Rule;
-    }
-
-    private static string ResolveSeverity(Result result, Rule? rule)
-    {
-        if (TryResolveSecuritySeverity(result.Properties, out var fromResultProperties))
-        {
-            return fromResultProperties;
-        }
-
-        if (TryResolveSecuritySeverity(rule?.Properties, out var fromRuleProperties))
-        {
-            return fromRuleProperties;
-        }
-
-        var level = result.Level;
-        if (string.IsNullOrWhiteSpace(level))
-        {
-            level = rule?.DefaultConfiguration?.Level;
-        }
-
-        return NormalizeSeverity(level);
-    }
-
-    private static bool TryResolveSecuritySeverity(Dictionary<string, object>? properties, out string severity)
-    {
-        severity = string.Empty;
-
-        if (properties == null || properties.Count == 0)
-        {
-            return false;
-        }
-
-        if (!properties.TryGetValue("security-severity", out var rawValue) || rawValue == null)
-        {
-            return false;
-        }
-
-        if (!TryConvertToDouble(rawValue, out var score))
-        {
-            return false;
-        }
-
-        severity = score switch
-        {
-            >= 9.0 => "Critical",
-            >= 7.0 => "High",
-            >= 4.0 => "Medium",
-            _ => "Low"
-        };
-
-        return true;
-    }
-
-    private static bool TryResolveSecuritySeverity(Dictionary<string, JsonElement>? properties, out string severity)
-    {
-        severity = string.Empty;
-
-        if (properties == null || properties.Count == 0)
-        {
-            return false;
-        }
-
-        if (!properties.TryGetValue("security-severity", out var rawValue))
-        {
-            return false;
-        }
-
-        if (!TryConvertToDouble(rawValue, out var score))
-        {
-            return false;
-        }
-
-        severity = score switch
-        {
-            >= 9.0 => "Critical",
-            >= 7.0 => "High",
-            >= 4.0 => "Medium",
-            _ => "Low"
-        };
-
-        return true;
-    }
-
-    private static bool TryConvertToDouble(object value, out double parsed)
-    {
-        parsed = 0;
-
-        return value switch
-        {
-            double doubleValue => (parsed = doubleValue) >= 0,
-            float floatValue => (parsed = floatValue) >= 0,
-            decimal decimalValue => (parsed = (double)decimalValue) >= 0,
-            int intValue => (parsed = intValue) >= 0,
-            long longValue => (parsed = longValue) >= 0,
-            JsonElement element => TryConvertToDouble(element, out parsed),
-            string text => double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
-            _ => false
-        };
-    }
-
-    private static bool TryConvertToDouble(JsonElement element, out double parsed)
-    {
-        parsed = 0;
-
-        return element.ValueKind switch
-        {
-            JsonValueKind.Number => element.TryGetDouble(out parsed),
-            JsonValueKind.String => double.TryParse(element.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out parsed),
-            _ => false
-        };
-    }
-
     private static string NormalizeSeverity(string? rawSeverity)
     {
         if (string.IsNullOrWhiteSpace(rawSeverity))
@@ -809,125 +605,6 @@ internal sealed class TriageWorkflowService
             "low" => "Low",
             _ => "Medium"
         };
-    }
-
-    private static string ResolveRuleCategory(Rule? rule, Result result)
-    {
-        if (!string.IsNullOrWhiteSpace(result.RuleId))
-        {
-            return result.RuleId;
-        }
-
-        if (!string.IsNullOrWhiteSpace(rule?.Id))
-        {
-            return rule.Id;
-        }
-
-        return "UnknownRule";
-    }
-
-    private static string ResolveRemediation(Rule? rule, Result result)
-    {
-        if (TryResolvePropertyText(result.Properties, "remediation", out var remediationFromResult))
-        {
-            return remediationFromResult;
-        }
-
-        if (TryResolvePropertyText(rule?.Properties, "help", out var remediationFromRuleHelp))
-        {
-            return remediationFromRuleHelp;
-        }
-
-        if (TryResolvePropertyText(rule?.Properties, "recommendation", out var recommendationFromRule))
-        {
-            return recommendationFromRule;
-        }
-
-        return string.Empty;
-    }
-
-    private static bool TryResolvePropertyText(Dictionary<string, object>? properties, string key, out string text)
-    {
-        text = string.Empty;
-
-        if (properties == null || !properties.TryGetValue(key, out var rawValue) || rawValue == null)
-        {
-            return false;
-        }
-
-        text = rawValue switch
-        {
-            JsonElement element when element.ValueKind == JsonValueKind.String => element.GetString() ?? string.Empty,
-            JsonElement element => element.ToString(),
-            _ => rawValue.ToString() ?? string.Empty
-        };
-
-        return !string.IsNullOrWhiteSpace(text);
-    }
-
-    private static bool TryResolvePropertyText(Dictionary<string, JsonElement>? properties, string key, out string text)
-    {
-        text = string.Empty;
-
-        if (properties == null || !properties.TryGetValue(key, out var element))
-        {
-            return false;
-        }
-
-        text = element.ValueKind == JsonValueKind.String
-            ? element.GetString() ?? string.Empty
-            : element.ToString();
-
-        return !string.IsNullOrWhiteSpace(text);
-    }
-
-    private static TriageFindingState ResolveState(
-        IReadOnlyDictionary<string, TriageStateEntry> triageMap,
-        string findingId)
-    {
-        if (!triageMap.TryGetValue(findingId, out var triageEntry)
-            || string.IsNullOrWhiteSpace(triageEntry.State))
-        {
-            return TriageFindingState.Open;
-        }
-
-        if (Enum.TryParse<TriageFindingState>(triageEntry.State, true, out var parsedState))
-        {
-            return parsedState;
-        }
-
-        return TriageFindingState.Open;
-    }
-
-    private static string ResolveResultFilePath(Run run, Result result)
-    {
-        var firstLocation = result.Locations?.FirstOrDefault()?.PhysicalLocation?.ArtifactLocation;
-        var resolved = FileHelper.ResolveArtifactPath(firstLocation, run);
-
-        if (!string.IsNullOrWhiteSpace(resolved))
-        {
-            return resolved;
-        }
-
-        return firstLocation?.Uri ?? string.Empty;
-    }
-
-    private static double CalculatePriorityScore(string severity, Result result)
-    {
-        var severityWeight = severity switch
-        {
-            "Critical" => 100,
-            "High" => 80,
-            "Medium" => 50,
-            "Low" => 20,
-            _ => 40
-        };
-
-        var flowComplexity = result.CodeFlows?
-            .SelectMany(codeFlow => codeFlow.ThreadFlows ?? new List<ThreadFlow>())
-            .Sum(threadFlow => threadFlow.Locations?.Count ?? 0) ?? 0;
-
-        return severityWeight + (flowComplexity * 5);
     }
 
     private static void EnsureSeverityBuckets(IDictionary<string, int> severityCounts)
@@ -983,50 +660,13 @@ internal sealed class TriageWorkflowService
 
     private async Task<TriageStateDocument> LoadTriageStateDocumentAsync(CancellationToken cancellationToken)
     {
-        var triagePath = GetTriageFilePath();
-
-        if (!File.Exists(triagePath))
-        {
-            return new TriageStateDocument();
-        }
-
-        var json = await File.ReadAllTextAsync(triagePath, cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(json))
-        {
-            return new TriageStateDocument();
-        }
-
-        try
-        {
-            return JsonSerializer.Deserialize<TriageStateDocument>(json, JsonOptions) ?? new TriageStateDocument();
-        }
-        catch (JsonException jsonException)
-        {
-            throw new InvalidOperationException($"Invalid triage state file format at {triagePath}.", jsonException);
-        }
+        return await _stateService.GetTriageStateDocumentAsync(cancellationToken);
     }
 
     private async Task SaveTriageStateDocumentAsync(TriageStateDocument document, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(document);
-
-        var triagePath = GetTriageFilePath();
-        var triageDirectory = Path.GetDirectoryName(triagePath);
-
-        if (string.IsNullOrWhiteSpace(triageDirectory))
-        {
-            throw new InvalidOperationException("Unable to resolve triage state directory.");
-        }
-
-        Directory.CreateDirectory(triageDirectory);
-        var json = JsonSerializer.Serialize(document, JsonOptions);
-        await File.WriteAllTextAsync(triagePath, json, cancellationToken);
-    }
-
-    private string GetTriageFilePath()
-    {
-        return Path.Combine(_workspaceRoot, ".sarif", "triage.json");
+        await _stateService.SaveTriageStateDocumentAsync(document, cancellationToken);
     }
 
     private string ResolveFindingPath(TriageFindingEnvelope finding, PhysicalLocation.PhysicalLocationArtifactLocation? artifactLocation)
@@ -1060,18 +700,38 @@ internal sealed class TriageWorkflowService
         {
             var windowStart = region?.StartLine ?? 1;
             var windowEnd = region?.EndLine > 0 ? region.EndLine : windowStart;
-            return SnippetHelper.ExtractLineWindow(sourceCode, windowStart, windowEnd);
+            var windowCacheKey = BuildSnippetCacheKey(sourcePath, windowStart, windowEnd, ToEvidenceModeValue(evidenceMode));
+
+            if (_snippetCache != null && _snippetCache.TryGet(windowCacheKey, out var cachedWindowSnippet))
+            {
+                return cachedWindowSnippet;
+            }
+
+            var windowSnippet = SnippetHelper.ExtractLineWindow(sourceCode, windowStart, windowEnd);
+            _snippetCache?.Set(windowCacheKey, windowSnippet);
+
+            return windowSnippet;
         }
 
         var windowStartLine = region?.StartLine ?? 1;
         var windowEndLine = region?.EndLine > 0 ? region.EndLine : windowStartLine;
+        var cacheKey = BuildSnippetCacheKey(sourcePath, windowStartLine, windowEndLine, ToEvidenceModeValue(evidenceMode));
+
+        if (_snippetCache != null && _snippetCache.TryGet(cacheKey, out var cachedSnippet))
+        {
+            return cachedSnippet;
+        }
+
         var startLine = Math.Max(0, windowStartLine - 1);
         var endLine = Math.Max(startLine, windowEndLine - 1);
-        var language = GetLanguageFromExtension(Path.GetExtension(sourcePath));
+        var language = CodeLanguageResolver.GetLanguageFromExtension(Path.GetExtension(sourcePath));
 
+        string finalSnippet;
         if (string.IsNullOrWhiteSpace(language))
         {
-            return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+            finalSnippet = SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+            _snippetCache?.Set(cacheKey, finalSnippet);
+            return finalSnippet;
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -1079,53 +739,29 @@ internal sealed class TriageWorkflowService
         var extractedMethod = await _treeSitterEngine.ExtractMethodAsync(sourceCode, language, startLine, endLine);
         if (!string.IsNullOrWhiteSpace(extractedMethod) && !extractedMethod.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase))
         {
-            return extractedMethod.Trim();
+            finalSnippet = extractedMethod.Trim();
+            _snippetCache?.Set(cacheKey, finalSnippet);
+            return finalSnippet;
         }
 
-        return SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+        finalSnippet = SnippetHelper.ExtractLineWindow(sourceCode, windowStartLine, windowEndLine);
+        _snippetCache?.Set(cacheKey, finalSnippet);
+        return finalSnippet;
     }
 
-    private static string GetLanguageFromExtension(string extension)
+    internal static string BuildSnippetCacheKey(string sourcePath, int startLine, int endLine, string mode)
     {
-        return extension.ToLowerInvariant() switch
+        var normalizedMode = string.IsNullOrWhiteSpace(mode)
+            ? "tree-sitter-method"
+            : mode.Trim().ToLowerInvariant();
+
+        var normalizedPath = Path.GetFullPath(sourcePath).Replace('\\', '/');
+        if (OperatingSystem.IsWindows())
         {
-            ".cs" => "csharp",
-            ".js" => "javascript",
-            ".ts" => "typescript",
-            ".py" => "python",
-            ".java" => "java",
-            ".cpp" => "cpp",
-            ".c" => "c",
-            ".go" => "go",
-            ".rs" => "rust",
-            ".rb" => "ruby",
-            ".php" => "php",
-            ".html" => "html",
-            ".css" => "css",
-            ".json" => "json",
-            ".xml" => "xml",
-            ".yaml" => "yaml",
-            ".yml" => "yaml",
-            ".md" => "markdown",
-            ".sh" => "bash",
-            ".ps1" => "powershell",
-            ".sql" => "sql",
-            _ => string.Empty
-        };
+            normalizedPath = normalizedPath.ToLowerInvariant();
+        }
+
+        return string.Join("|", normalizedMode, normalizedPath, startLine, endLine);
     }
 
-    private sealed record TriageFindingEnvelope(
-        string FindingId,
-        Result Result,
-        Run Run,
-        string SarifPath,
-        string Severity,
-        TriageFindingState State,
-        string RuleName,
-        string FilePath,
-        int? LineNumber,
-        double PriorityScore,
-        string RuleCategory,
-        string RuleDescription,
-        string Remediation);
 }

--- a/Sarifintown.Core.Tests/SarifTriageIdentityHelperTests.cs
+++ b/Sarifintown.Core.Tests/SarifTriageIdentityHelperTests.cs
@@ -59,5 +59,24 @@ namespace Sarifintown.Core.Tests
             Assert.That(identity, Is.Not.Empty);
             Assert.That(identity.Length, Is.EqualTo(64));
         }
+
+        [Test]
+        public void BuildIdentity_WithDifferentToolNames_ReturnsDifferentIdentities()
+        {
+            var result = new Result
+            {
+                RuleId = "RULE001",
+                Message = new Result.ResultMessage { Text = "message" },
+                PartialFingerprints = new Dictionary<string, string>
+                {
+                    ["primaryLocationLineHash"] = "abc"
+                }
+            };
+
+            var codeQlIdentity = SarifTriageIdentityHelper.BuildIdentity(result, "CodeQL");
+            var eslintIdentity = SarifTriageIdentityHelper.BuildIdentity(result, "ESLint");
+
+            Assert.That(codeQlIdentity, Is.Not.EqualTo(eslintIdentity));
+        }
     }
 }

--- a/Sarifintown.Core/Helpers/SarifTriageIdentityHelper.cs
+++ b/Sarifintown.Core/Helpers/SarifTriageIdentityHelper.cs
@@ -9,11 +9,12 @@ namespace Sarifintown.Helpers
         /// <summary>
         /// Builds a stable identity for a SARIF result by preferring SARIF fingerprints and falling back to location and message attributes.
         /// </summary>
-        public static string BuildIdentity(Result result)
+        public static string BuildIdentity(Result result, string toolName = "")
         {
             ArgumentNullException.ThrowIfNull(result);
+            var normalizedToolName = NormalizeToolName(toolName);
 
-            var fingerprintSource = BuildFingerprintSource(result);
+            var fingerprintSource = BuildFingerprintSource(result, normalizedToolName);
             if (string.IsNullOrWhiteSpace(fingerprintSource))
             {
                 var location = result.Locations?.FirstOrDefault()?.PhysicalLocation;
@@ -23,6 +24,7 @@ namespace Sarifintown.Helpers
 
                 var region = location?.Region;
                 fingerprintSource = string.Join('|',
+                    normalizedToolName,
                     result.RuleId ?? string.Empty,
                     FileHelper.NormalizePath(fallbackPath),
                     region?.StartLine ?? 0,
@@ -35,23 +37,30 @@ namespace Sarifintown.Helpers
             return ComputeSha256Hex(fingerprintSource);
         }
 
-        private static string BuildFingerprintSource(Result result)
+        private static string BuildFingerprintSource(Result result, string normalizedToolName)
         {
             if (result.PartialFingerprints != null && result.PartialFingerprints.Count > 0)
             {
-                return "partial|" + string.Join('|', result.PartialFingerprints
+                return normalizedToolName + "|partial|" + string.Join('|', result.PartialFingerprints
                     .OrderBy(pair => pair.Key, StringComparer.Ordinal)
                     .Select(pair => $"{pair.Key}={pair.Value}"));
             }
 
             if (result.Fingerprints != null && result.Fingerprints.Count > 0)
             {
-                return "full|" + string.Join('|', result.Fingerprints
+                return normalizedToolName + "|full|" + string.Join('|', result.Fingerprints
                     .OrderBy(pair => pair.Key, StringComparer.Ordinal)
                     .Select(pair => $"{pair.Key}={pair.Value}"));
             }
 
             return string.Empty;
+        }
+
+        private static string NormalizeToolName(string toolName)
+        {
+            return string.IsNullOrWhiteSpace(toolName)
+                ? "unknown-tool"
+                : toolName.Trim().ToLowerInvariant();
         }
 
         private static string ComputeSha256Hex(string value)

--- a/Sarifintown/Services/BlazorTreeSitterEngineService.cs
+++ b/Sarifintown/Services/BlazorTreeSitterEngineService.cs
@@ -14,7 +14,6 @@ namespace Sarifintown.Services
 
         public async Task InitializeAsync()
         {
-            await _jsRuntime.InvokeVoidAsync("scriptLoader.ensure", "/js/tree-sitter-interop.js");
             await _jsRuntime.InvokeVoidAsync("TreeSitterInterop.initializeWorker");
         }
 

--- a/Sarifintown/wwwroot/index.html
+++ b/Sarifintown/wwwroot/index.html
@@ -31,6 +31,7 @@
 
 
 
+    <script src="/js/tree-sitter-interop.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script>
         function scrollToBottom(element) {


### PR DESCRIPTION
Add two facade MCP tools (manage_triage and analyze_sarif) to centralize triage and SARIF analysis workflows. Update SarifPrompts to instruct callers to use these facade actions instead of older individual tool names. Replace direct nextTool references in guided responses to point to manage_triage and adjust tool behaviors to return pass-through markdown and metadata via CreateDualPurposeResult. Introduce ParseFacadeFilters, BuildUiResourceUri/BuildUiCsp, BuildPassThroughMarkdown, GetWorkspaceRoot helpers and a FacadeFilterOptions type; adjust SARIF result type imports. Update tests (add new tests for facade behavior, UI URI building, list_files analysis, and MCP exposure) and set a local UI base URL in tests. Also update repository instructions (.github/copilot-instructions.md) to enforce using manage_triage/analyze_sarif and forbid generic tools when MCP actions exist.