### PR TITLE
Refactor SARIF triage flow and prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,34 +6,19 @@
 - User prefers standard NUnit assertions over FluentAssertions because FluentAssertions is not free.
 - When documenting MCP setup for this project, do not require DOTNET_ENVIRONMENT in configuration unless explicitly needed by project behavior.
 
-## MCP Enforcement Baseline
-- For SARIF/SAST/Secret triaging and reviewing workflows, use only `Sarifintown.Engine` MCP tools. Do not substitute with generic shell/terminal commands.
-- Do not guess repository state, scan results, triage state, or code-flow evidence. Retrieve data through MCP tools first.
-- If a required domain action has an MCP tool, call the tool before proposing conclusions.
-- Keep responses aligned with tool outputs; do not invent findings, IDs, or file paths.
-- Never use generic tools (custom scripts, terminal commands, or external summarization) to process SARIF triage or SARIF analysis data when MCP actions are available.
+## Sarifintown MCP Tools
 
-## SARIF Tool Workflow
+For SARIF/SAST/Secret triaging workflows, always use the sarifintown MCP tools (`sarif_filter`, `sarif_get`, `sarif_review`, `sarif_update`, `sarif_sync`). Do not substitute with generic shell commands, do not guess findings or IDs — retrieve data through tools first.
 
-### Reading findings: `sarif_get`
-- Use `sarif_get` to retrieve the current posture summary and prioritized findings.
-- Output the `<vulnerability_report>` block VERBATIM. Do NOT summarize, interpret, or duplicate.
-- STOP after output and wait for the user's explicit instruction.
-- Use `sarif_filter` to change the active scope before calling `sarif_get`.
+### Workflow: reviewing findings
+1. `sarif_get` → retrieve paginated findings index. Output the `<vulnerability_report>` block verbatim, then stop.
+2. `sarif_review(target)` → load code-flow evidence and triage rules for a displayid. Proceed with analysis immediately.
+3. `sarif_update(target, state, reason, llmReasoning)` → record the triage decision. For AI triage, always provide `llmReasoning`. For human manual overrides, omit it.
 
-### Autotriaging findings: `sarif_review`
-- Use `sarif_review` for AI-driven autotriage of findings.
-- Always call `sarif_get` first to load findings with evidence before calling `sarif_review`.
-- Analyze the evidence (code flow, snippets, rule description, severity) and determine a decision state (`confirmed`, `false_positive`, `test_code`, `wont_fix`, `mitigated`) and reason.
-- Pass your full chain-of-thought as `llmReasoning` and the evidence as `inputMarkdown`.
-- Output the result VERBATIM and STOP.
+### Workflow: filtering
+- `sarif_filter(query)` → set scope (e.g. `severity:high rule:SQLI`). Call `sarif_get` after.
+- `sarif_filter("clear")` → remove all filters.
+- `sarif_filter()` with no arguments → list available filter values.
 
-### Filtering findings: `sarif_filter`
-- Use `sarif_filter` to set or clear the active scope (severity, rule, path, status).
-- Call with no arguments to list available filter values.
-- After applying a filter, call `sarif_get` to view the filtered results.
-
-### Manual override: `sarif_update`
-- Use `sarif_update` only when the user explicitly asks to manually set or override a triage decision.
-- Requires explicit `state`, `reason`, and `target` from the user.
-- Sets `human_reviewed=true` in the audit ledger.
+### Workflow: syncing
+- `sarif_sync` → push pending triage decisions to upstream vendor APIs.

--- a/.sarif/sarifintown-prompts/base/output-format.md
+++ b/.sarif/sarifintown-prompts/base/output-format.md
@@ -3,7 +3,7 @@
 ## Conclude and Recommend
 Make a clear determination based on your focused analysis.
 
-* **Determine Validity:** State if the finding is a true or false positive for the specific rule that was triggered.
+* **Determine Validity:** True of False positive finding for the specific rule that was triggered.
 * **Provide Recommendation:** If a finding is a false positive due to a recurring pattern, provide a concise recommendation.
 
 Your analysis should be in very concise statements, and the final lines of your response must use the following format strictly:

--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -1,41 +1,22 @@
-# MCP Setup Guide for `Sarifintown.Engine`
+# MCP Setup Guide
 
-This guide explains how to configure the `Sarifintown.Engine` as an MCP server in AI IDEs.
-
-## Portable enforcement architecture (recommended)
-
-Use these layers together to enforce consistent MCP behavior across GitHub Copilot, Visual Studio, JetBrains, and terminal clients without custom IDE extensions.
-
-1. Workspace-level instruction files in repo root:
-   - `.github/copilot-instructions.md` (create a similar "global" instruction for other IDEs)
-2. Server-side MCP primitives:
-   - aggressive `[Description]` text on guided MCP tools
-   - native `[McpServerPrompt]` prompts for slash-command style workflow triggers
-3. Chained tool payloads:
-   - guided tools return explicit `next_step` metadata
-4. Markdown pass-through payloads:
-   - guided tools include an `llm_directive` requiring verbatim markdown render and user-input pause
+This guide explains how to configure `sarifintown` as an MCP server in AI IDEs and terminal clients.
 
 ## What the server does at startup
 
-When the server starts, it:
-
-1. Resolves workspace root from:
-   - `PROJECT_ROOT`
-   - `WORKSPACE_FOLDER`
-   - `WORKSPACE_ROOT`
-   - `MCP_WORKSPACE_ROOT`
-   - `PWD`
-   - otherwise current working directory
-   - ignores unresolved placeholders such as `{workspaceFolder}` or `${workspaceFolder}`
-2. Scans `<workspace>/.sarif/` recursively
-3. Registers all `*.sarif` files for tool-based parsing
+1. Resolves workspace root from environment variables (in order):
+   - `PROJECT_ROOT`, `WORKSPACE_FOLDER`, `WORKSPACE_ROOT`, `MCP_WORKSPACE_ROOT`, `PWD`
+   - Falls back to current working directory
+   - Ignores unresolved placeholders such as `${workspaceFolder}` or `{workspaceFolder}`
+2. Scans `<workspace>/.sarif/` recursively for `*.sarif` files
+3. Initializes Tree-sitter, SARIF state, and snippet preload
+4. Starts local web host and waits for MCP traffic
 
 In most IDEs this works automatically from the open folder/workspace context.
 
 ---
 
-## Workspace layout expected by the server
+## Workspace layout
 
 ```text
 <your-repo>/
@@ -46,17 +27,15 @@ In most IDEs this works automatically from the open folder/workspace context.
 
 ---
 
-## Build/Run options
+## Running the server
 
-Preferred: use the .NET global tool command `sarifintown`.
-
-## Option A (preferred): run via global tool
+**Option A (preferred):** global tool
 
 ```bash
 sarifintown
 ```
 
-## Option B: run from source
+**Option B:** from source
 
 ```bash
 dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
@@ -64,35 +43,11 @@ dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
 
 ---
 
-## MCP stdio configuration (IDE schemas)
+## MCP configuration
 
-Different MCP clients use different top-level keys for server registration.
+Different clients use different top-level keys: `"servers"` (Visual Studio, VS Code) or `"mcpServers"` (Cursor, Claude Code). The server body is the same.
 
-- Visual Studio / VS Code style: `"servers"`
-- Cursor / Claude Code style: `"mcpServers"`
-
-The server payload is the same in both styles (`transport`, `command`, `args`, optional `cwd`, optional `env`).
-
-If your IDE already injects workspace context, you usually do not need to add `env` values manually.
-
-### Visual Studio / VS Code style (`"servers"`)
-
-```json
-{
-  "servers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "env": {
-        "PROJECT_ROOT": "C:/path/to/your/workspace"
-      }
-    }
-  }
-}
-```
-
-macOS/Linux path variant:
+### Minimal config
 
 ```json
 {
@@ -109,172 +64,19 @@ macOS/Linux path variant:
 }
 ```
 
-### Cursor / Claude Code style (`"mcpServers"`)
+> For Cursor or Claude Code, replace `"servers"` with `"mcpServers"`.
 
-```json
-{
-  "mcpServers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "env": {
-        "PROJECT_ROOT": "/path/to/your/workspace"
-      }
-    }
-  }
-}
-```
+### Field reference
 
-> Different IDEs may use different top-level keys, but the important values are the same: `transport`, `command`, `args`, and `env.PROJECT_ROOT`.
+| Field | Required | Notes |
+|---|---|---|
+| `transport` | Yes | Must be `stdio`. |
+| `command` | Yes | `sarifintown` (global tool) or `dotnet` with `args: ["run", "--project", "..."]`. |
+| `env.PROJECT_ROOT` | Recommended | Absolute path. Ensures deterministic `.sarif` discovery. |
+| `env.MCP_CLIENT_NAME` | Optional | Improves host detection (e.g. `"Cursor"`, `"Claude Code"`). Also recognized: `MCP_HOST`, `MCP_CLIENT`. |
+| `cwd` | Optional | Useful for predictable relative paths. |
 
-Common workspace placeholders in IDE configs include `${workspaceFolder}`, `{workspaceFolder}`, and `${workspaceRoot}`.
-If a placeholder is passed through literally (not expanded), `sarifintown` ignores it and falls back to the next available workspace source.
-
-If you cannot use the global tool in your IDE, use `dotnet run --project ...` as fallback.
-
-### Client-specific examples
-
-#### Cursor (`mcp.json`)
-
-```json
-{
-  "mcpServers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "env": {
-        "PROJECT_ROOT": "C:/path/to/your/workspace",
-        "MCP_CLIENT_NAME": "Cursor"
-      }
-    }
-  }
-}
-```
-
-#### Claude Code (`mcp.json`)
-
-```json
-{
-  "mcpServers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "env": {
-        "PROJECT_ROOT": "/path/to/your/workspace",
-        "MCP_CLIENT_NAME": "Claude Code"
-      }
-    }
-  }
-}
-```
-
----
-
-## Terminal MCP configuration (CLI clients)
-
-If you use MCP from terminal-first clients (for example Claude Code, Codex CLI, Aider, or custom MCP CLI runners), use stdio transport and pass workspace via environment variables.
-
-Minimum terminal launch pattern:
-
-### Windows PowerShell
-
-```powershell
-$env:PROJECT_ROOT = "C:/path/to/your/workspace"
-$env:MCP_CLIENT_NAME = "Claude Code"
-sarifintown
-```
-
-### macOS/Linux
-
-```bash
-export PROJECT_ROOT="/path/to/your/workspace"
-export MCP_CLIENT_NAME="Claude Code"
-sarifintown
-```
-
-Notes:
-
-- `PROJECT_ROOT` is strongly recommended so `.sarif` discovery is deterministic.
-- `MCP_CLIENT_NAME` is optional but recommended; it improves host detection/routing.
-- If your client sets `MCP_HOST` or `MCP_CLIENT`, those are also recognized.
-
-### Example terminal client config (`mcp.json` style)
-
-Most terminal-first MCP clients use `"mcpServers"`; if your client expects `"servers"`, keep the same server object and only switch the top-level key.
-
-```json
-{
-  "mcpServers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "env": {
-        "PROJECT_ROOT": "/absolute/path/to/workspace",
-        "MCP_CLIENT_NAME": "Claude Code"
-      }
-    }
-  }
-}
-```
-
-### Fallback command for terminal clients
-
-If `sarifintown` is not installed as a global tool:
-
-```bash
-dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
-```
-
----
-
-## Detailed sample for a typical `mcp.json`
-
-Use the same server body for both schema styles:
-
-- wrap with `"servers"` for Visual Studio / VS Code style
-- wrap with `"mcpServers"` for Cursor / Claude Code style
-
-### Windows (preferred global tool)
-
-```json
-{
-  "servers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "cwd": "C:/dev/sarifintown",
-      "env": {
-        "PROJECT_ROOT": "C:/dev/my-app"
-      }
-    }
-  }
-}
-```
-
-### macOS/Linux (preferred global tool)
-
-```json
-{
-  "servers": {
-    "sarifintown": {
-      "transport": "stdio",
-      "command": "sarifintown",
-      "args": [],
-      "cwd": "/Users/me/dev/sarifintown",
-      "env": {
-        "PROJECT_ROOT": "/Users/me/dev/my-app"
-      }
-    }
-  }
-}
-```
-
-### Fallback sample (`dotnet run`)
+### Fallback config (dotnet run)
 
 ```json
 {
@@ -285,45 +87,53 @@ Use the same server body for both schema styles:
       "args": [
         "run",
         "--project",
-        "C:/dev/sarifintown/Sarifintown.AgentEngine/Sarifintown.Engine.csproj"
+        "/path/to/Sarifintown.AgentEngine/Sarifintown.Engine.csproj"
       ],
-      "cwd": "C:/dev/sarifintown",
       "env": {
-        "PROJECT_ROOT": "C:/dev/my-app"
+        "PROJECT_ROOT": "/path/to/your/workspace"
       }
     }
   }
 }
 ```
 
-### Why each field matters
-
-- `transport`: must be `stdio` for this server mode.
-- `command` + `args`: starts the MCP server process.
-- `cwd`: optional but useful for predictable relative paths.
-- `env.PROJECT_ROOT`: recommended for deterministic `.sarif` discovery in multi-root or custom launch environments.
-- `DOTNET_ENVIRONMENT`: optional; this project does not require it for MCP behavior.
-
 ### Path guidance
 
-- Windows paths: `C:/...` (or escaped `C:\\...` depending on parser).
-- macOS/Linux paths: `/...`.
-- Prefer absolute paths for `cwd` and `PROJECT_ROOT`.
+- Windows: `C:/...` (or escaped `C:\\...` depending on JSON parser).
+- macOS/Linux: `/...`.
+- Prefer absolute paths for `PROJECT_ROOT` and `cwd`.
+- Common IDE placeholders (`${workspaceFolder}`, `${workspaceRoot}`) are ignored if passed literally.
 
-### Optional preload and warmup tuning
+---
 
-You can tune SARIF preload behavior and startup snippet warmup directly from MCP client env vars:
+## Terminal usage
 
-- `SARIFINTOWN_Sarif__Strategy`: `None`, `LatestPerTool`, or `All`
-- `SARIFINTOWN_Sarif__EnableSnippetPreload`: `true`/`false`
-- `SARIFINTOWN_Sarif__EnableDebugPrompt`: `true`/`false` (default `false`)
-- `SARIFINTOWN_Sarif__IncludeEvidenceByDefault`: `true`/`false` (default `true`)
+For terminal-first clients (Claude Code, Codex CLI, Aider):
 
-`SARIFINTOWN_Sarif__EnableDebugPrompt` and `SARIFINTOWN_Sarif__IncludeEvidenceByDefault` are evaluated only at MCP server startup. They cannot be changed from MCP prompts or slash-command arguments.
+```bash
+# macOS/Linux
+export PROJECT_ROOT="/path/to/your/workspace"
+sarifintown
+```
 
-Snippet preload bootstrap is fixed to the first 10 findings during startup. Remaining findings are preloaded in the background.
+```powershell
+# Windows PowerShell
+$env:PROJECT_ROOT = "C:/path/to/your/workspace"
+sarifintown
+```
 
-Example (global tool invocation preserved):
+---
+
+## Optional environment variables
+
+Tune SARIF preload behavior via env vars:
+
+| Variable | Values | Default |
+|---|---|---|
+| `SARIFINTOWN_Sarif__Strategy` | `None`, `LatestPerTool`, `All` | `LatestPerTool` |
+| `SARIFINTOWN_Sarif__EnableSnippetPreload` | `true` / `false` | `true` |
+
+Example:
 
 ```json
 {
@@ -332,13 +142,10 @@ Example (global tool invocation preserved):
       "transport": "stdio",
       "command": "sarifintown",
       "args": [],
-      "cwd": "C:/dev/sarifintown",
       "env": {
-        "PROJECT_ROOT": "C:/dev/my-app",
+        "PROJECT_ROOT": "/path/to/workspace",
         "SARIFINTOWN_Sarif__Strategy": "LatestPerTool",
-        "SARIFINTOWN_Sarif__EnableSnippetPreload": "true",
-        "SARIFINTOWN_Sarif__EnableDebugPrompt": "false",
-        "SARIFINTOWN_Sarif__IncludeEvidenceByDefault": "true"
+        "SARIFINTOWN_Sarif__EnableSnippetPreload": "true"
       }
     }
   }
@@ -349,156 +156,71 @@ Example (global tool invocation preserved):
 
 ## Quick validation checklist
 
-1. Ensure `PROJECT_ROOT/.sarif` exists.
-2. Ensure at least one `*.sarif` file is present.
-3. Restart IDE MCP servers.
-4. Call `ListWorkspaceSarifFiles` from your MCP client.
-5. Confirm files are returned.
-6. Call `LoadAndFilterSarif` using either:
-   - full SARIF path, or
-   - filename discovered at startup (for example: `scan1.sarif`).
-7. Call `TriageStatus` to confirm triage state aggregation from `.sarif/triage.json`.
-8. Call `TriageList` and `TriageInspect` for finding prioritization and evidence retrieval.
+1. Ensure `PROJECT_ROOT/.sarif/` exists with at least one `*.sarif` file.
+2. Restart IDE MCP servers.
+3. Call `sarif_get` to view findings.
+4. Call `sarif_filter` to set scope if needed.
+5. Call `sarif_review` with a target displayid to load evidence.
+6. Call `sarif_update` to record a triage decision.
+7. Call `sarif_sync` to push decisions to upstream vendors.
 
 ---
 
-## MCP tools currently exposed by `Sarifintown.Engine`
+## MCP tools and prompts
 
-### Discovery and routing
+### Tools
 
-- `ListWorkspaceSarifFiles`
-- `ResolveInteractiveSurface`
+- `sarif_get` — retrieve paginated findings index
+- `sarif_filter` — set or clear active scope filters
+- `sarif_review` — load code-flow evidence and triage rules for a finding
+- `sarif_update` — record a triage decision (AI or human)
+- `sarif_sync` — push pending decisions to upstream vendor APIs
 
-### Analysis and extraction
+Tool responses include embedded `next_step` metadata for workflow chaining.
 
-- `LoadAndFilterSarif`
-- `ExtractCodeFlow`
-- `GenerateAnalysisReport`
+### Prompts
 
-### Triage workflow
+Slash-command prompts mirror each tool: `sarif_filter`, `sarif_get`, `sarif_review`, `sarif_update`, `sarif_sync`.
 
-- `TriageStatus`
-- `TriageList`
-- `TriageQuery` (alias of `TriageList`)
-- `TriageInspect`
-- `Triage`
-- `TriageBulk`
+### Persistence
 
-### Guided triage workflow (recommended for autonomous agents)
-
-- `TriageStatusGuided`
-- `TriageListGuided`
-- `TriageInspectGuided`
-
-Guided tool responses include:
-
-- `llm_directive` for markdown pass-through behavior
-- `next_step` metadata for deterministic tool chaining
-- `pause` metadata to force user-input checkpoints
-
-### MCP prompts
-
-- `SarifintownForceCheck`
-- `SarifintownInspectFinding`
-
-Triage decisions are persisted to `<workspace>/.sarif/triage.json`.
-
-Note: Tool responses are JSON serialized from .NET types and therefore use `PascalCase` property names unless otherwise noted.
-
----
-
-## IDE UI surface contract (MCP `ui://`)
-
-`ResolveInteractiveSurface` returns:
-
-- `uri`: `ui://sarifintown/mcp/dashboard`
-- `bridge.transport`: `postMessage`
-- `bridge.channel`: `sarifintown.mcp.v1`
-
-Recommended message envelope for host ↔ UI:
-
-```json
-{
-  "channel": "sarifintown.mcp.v1",
-  "type": "host.ping",
-  "requestId": "optional-correlation-id",
-  "payload": {}
-}
-```
-
-Common events:
-
-- Host -> UI: `host.ping`, `host.getState`
-- Host -> UI: `host.openFinding` (payload: `resultIdentity`)
-- UI -> Host: `ui.ready`, `ui.pong`, `ui.state`, `ui.request.chatPrompt`
-
-`ui.request.chatPrompt` payload:
-
-```json
-{
-  "channel": "sarifintown.mcp.v1",
-  "type": "ui.request.chatPrompt",
-  "requestId": "optional-correlation-id",
-  "payload": {
-    "prompt": "Explain SQL injection at line 42 in auth.cs",
-    "context": {
-      "source": "Sarifintown.McpDashboard",
-      "route": "/mcp/dashboard"
-    }
-  }
-}
-```
-
-Recommended host response:
-
-```json
-{
-  "channel": "sarifintown.mcp.v1",
-  "type": "host.chatPrompt.ack",
-  "requestId": "same-request-id",
-  "payload": {
-    "accepted": true
-  }
-}
-```
+- Triage state: `<workspace>/.sarif/triage.json`
+- Audit ledger: `<workspace>/.sarif/triage-ledger.json`
+- Execution log: `<workspace>/.sarif/agent-execution.log`
 
 ---
 
 ## Troubleshooting
 
-## No SARIF files returned
+### No SARIF files returned
 
 - Check `PROJECT_ROOT` points to the correct workspace.
-- Confirm files are inside `.sarif/`.
-- Confirm extension is `.sarif`.
+- Confirm files are inside `.sarif/` with `.sarif` extension.
 
-## File not found from tool call
+### Server fails to start
 
-- Use `ListWorkspaceSarifFiles` first to verify discovered names.
-- Pass exact filename or full path.
-
-## Server fails to start
-
-- Test the command manually in terminal.
-- Verify .NET SDK is installed.
+- Test the command manually in a terminal.
+- Verify .NET 10 SDK is installed.
 - Verify project path is correct.
 
-## Server starts but MCP `initialize` appears stuck
+### Server starts but MCP `initialize` appears stuck
 
-`Sarifintown.Engine` now emits startup diagnostics to **stderr** (MCP console output) so stdio protocol messages on stdout are not polluted.
+The server emits startup diagnostics to **stderr** so stdio protocol messages on stdout are not polluted.
 
 Typical startup sequence:
 
-1. Workspace discovery (`PROJECT_ROOT` and fallbacks)
+1. Workspace discovery
 2. Tree-sitter initialization
 3. SARIF state initialization
-4. Optional snippet preload
-5. Web host start + local UI URL resolution
+4. Snippet preload
+5. Web host start
 6. Wait for MCP traffic
 
-If `initialize` stalls, inspect MCP console logs for lines prefixed with `sarifintown-mcp` and look for a `failed after ... ms` message to identify the blocking stage.
+If `initialize` stalls, inspect MCP console logs for lines prefixed with `sarifintown-mcp` and look for a `failed after ... ms` message.
 
-If the process crashes before your MCP client can render console output, run the same command directly in a terminal to capture stderr:
+To capture stderr directly:
 
-- Global tool: `sarifintown`
-- Fallback: `dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj`
+```bash
+sarifintown
+# or: dotnet run --project Sarifintown.AgentEngine/Sarifintown.Engine.csproj
+```

--- a/README.md
+++ b/README.md
@@ -2,40 +2,37 @@
 
 Sarifintown is a Blazor WebAssembly solution for analyzing SARIF (Static Analysis Results Interchange Format) files and extracting code snippets from source code.
 
-MCP server support is available via `Sarifintown.Engine`; see the concise setup guide in [`MCP_SETUP.md`](MCP_SETUP.md).
+MCP server support is available via the `sarifintown` global tool; see [`MCP_SETUP.md`](MCP_SETUP.md) for configuration.
 
 ## Projects
 
-- **Sarifintown.UI**: Blazor WebAssembly app for SARIF analysis, triage, and code snippet extraction.
+- **Sarifintown.UI** (`Sarifintown/`): Blazor WebAssembly app for SARIF analysis, triage, and code snippet extraction.
 - **Sarifintown.Core**: Shared models, helpers, and SARIF processing logic.
-- **Sarifintown.Engine**: MCP server and CLI/TUI entrypoint for agent and terminal workflows.
-- **Sarifintown.Tests**, **Sarifintown.Core.Tests**, **Sarifintown.Engine.Tests**: NUnit test projects.
+- **Sarifintown.Engine** (`Sarifintown.AgentEngine/`): MCP server and CLI/TUI entrypoint for agent and terminal workflows.
+- **Sarifintown.UI.Tests**, **Sarifintown.Core.Tests**, **Sarifintown.Engine.Tests**: NUnit test projects.
 
 ## Features
 
 - WASM Standalone application that works in your browser (Chromium-based browsers).
-- Uses Browser File System API to read source code files (read-only access)
+- Uses Browser File System API to read source code files (read-only access).
 - Import SARIF files via drag-and-drop or file picker.
 - Extract and highlight code snippets for each finding with PrismJS.
 - Show full code flows.
 - Extract whole methods with Tree-sitter WASM grammars to improve code flow analysis.
 - Responsive UI built with MudBlazor.
 - Group and filter results by severity, rule and file path.
-- MCP tools for SARIF discovery, filtering, flow extraction, analysis report generation, and triage workflows.
-- Shared triage state persisted in `.sarif/triage.json` for MCP/CLI triage commands.
-- In-memory SARIF findings cache with configurable preload strategy for low-latency triage commands.
-- JIT snippet warmup queue that anticipates `TriageInspect` after `TriageList`/`TriageListGuided` responses.
+- MCP tools for SARIF filtering, triage review, and upstream sync workflows.
+- Triage state persisted in `.sarif/triage.json` and `.sarif/triage-ledger.json`.
 
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - Chromium-based browsers (Edge, Chrome) for File System API support. Sorry Firefox.
 
-
 ## Usage
 
 1. **Select Source Code Folder**  
-   Use the "Select Source Code" button to grant read-only access to your source code directory. SARIF files in the root and `.sarif` subfolder are detected automatically.
+   Use the "Select Source Code" button to grant read-only access to your source code directory. SARIF files in the `.sarif` subfolder are detected automatically.
 
 2. **Import SARIF Files**  
    Drag and drop SARIF files or use the file picker to import additional analysis results.
@@ -46,30 +43,17 @@ MCP server support is available via `Sarifintown.Engine`; see the concise setup 
 4. **Full Details Analysis**  
    If a SARIF file contains the code flow, you can view code threads and highlights using Tree-sitter grammars.
 
-## MCP triage workflow commands
+## MCP triage workflow
 
-`Sarifintown.Engine` exposes a shared triage workflow through MCP tools:
+The `sarifintown` MCP server exposes these tools:
 
-- `TriageStatus`
-- `TriageList` (and alias `TriageQuery`)
-- `TriageInspect`
-- `Triage`
-- `TriageBulk`
+- `sarif_get` — retrieve paginated findings index
+- `sarif_filter` — set or clear active scope filters
+- `sarif_review` — load code-flow evidence and triage rules for a finding
+- `sarif_update` — record a triage decision (AI or human)
+- `sarif_sync` — push pending decisions to upstream vendor APIs
 
-Guided/chained variants for autonomous clients:
-
-- `TriageStatusGuided`
-- `TriageListGuided`
-- `TriageInspectGuided`
-
-Guided responses include a strict markdown rendering directive, explicit `next_step` tool metadata, and a required user-input pause.
-
-MCP prompt primitives are also exposed:
-
-- `SarifintownForceCheck`
-- `SarifintownInspectFinding`
-
-These commands use loaded SARIF findings and persist decision state to `.sarif/triage.json`.
+MCP slash-command prompts mirror each tool for IDE prompt-based invocation.
 
 ## License
 

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -414,7 +414,7 @@ namespace Sarifintown.AgentEngine.Tests
                 Assert.That(setMeta.GetProperty("context").GetProperty("metrics").GetProperty("total_in_scope").GetInt32(), Is.EqualTo(1));
                 Assert.That(setMeta.GetProperty("pause").GetBoolean(), Is.True);
                 Assert.That(setMeta.GetProperty("next_step").GetString(), Is.EqualTo("sarif_review"));
-                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## ??? SARIF Findings (Page 1 of 1)"));
+                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## SARIF Findings (Page 1 of 1)"));
                 Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring(SarifTools.StateContextDelimiter));
 
                 await SarifTools.SarifFilter("severity:high rule:RULE-HIGH");
@@ -719,7 +719,7 @@ namespace Sarifintown.AgentEngine.Tests
                 Assert.That(text, Contains.Substring("## Evidence for Review"));
                 Assert.That(text, Contains.Substring("<system_directive>"));
                 Assert.That(text, Contains.Substring("# Test Core Directive"));
-                Assert.That(text, Contains.Substring("sarif_update"));
+                Assert.That(text, Contains.Substring("Analyze the evidence above using the rules in the system directive."));
             }
             finally
             {
@@ -772,7 +772,7 @@ namespace Sarifintown.AgentEngine.Tests
                 Assert.That(text, Does.Not.Contain("DEBUG: Assembled Triage Prompt"));
                 Assert.That(text, Does.Not.Contain("Triage Analysis Instructions"));
                 Assert.That(text, Does.Not.Contain("# Test Core Directive"));
-                Assert.That(text, Contains.Substring("## SARIF Findings Index"));
+                Assert.That(text, Contains.Substring("## SARIF Findings (Page 1 of 1)"));
                 Assert.That(text, Contains.Substring("sarif_review"));
             }
             finally
@@ -867,7 +867,7 @@ namespace Sarifintown.AgentEngine.Tests
                 var text = ((TextContentBlock)reviewResult.Content[0]).Text;
 
                 Assert.That(text, Contains.Substring("## Evidence for Review"));
-                Assert.That(text, Contains.Substring("sarif_update"));
+                Assert.That(text, Contains.Substring("Analyze the evidence above using the rules in the system directive."));
                 Assert.That(text, Does.Not.Contain("DEBUG: Assembled Triage Prompt"));
             }
             finally
@@ -1112,6 +1112,124 @@ namespace Sarifintown.AgentEngine.Tests
             {
                 Directory.Delete(workspace, true);
             }
+        }
+
+        [Test]
+        public async Task SarifUpdate_WithRangeTarget_UpdatesEachFindingInRange()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var resultsJson = string.Join(",", Enumerable.Range(1, 4).Select(index =>
+                $$"""
+                  {
+                    "ruleId": "RULE-RANGE-{{index}}",
+                    "level": "error",
+                    "message": { "text": "range finding {{index}}" }
+                  }
+                """));
+
+            var sarifPath = Path.Combine(sarifDirectory, "range-update.sarif");
+            File.WriteAllText(sarifPath, $$"""
+            {
+              "runs": [
+                {
+                  "results": [
+            {{resultsJson}}
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                _ = await SarifTools.SarifGet(limit: 10);
+
+                var triageResult = await SarifTools.SarifUpdate(
+                    target: "1-2",
+                    state: "false_positive",
+                    reason: "range state update");
+
+                var triageText = ((TextContentBlock)triageResult.Content[0]).Text;
+                Assert.That(triageText, Contains.Substring("`1` → `FP`"));
+                Assert.That(triageText, Contains.Substring("`2` → `FP`"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task SarifReview_WithRangeTarget_IncludesEvidenceForEachExpandedDisplayId()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var resultsJson = string.Join(",", Enumerable.Range(1, 3).Select(index =>
+                $$"""
+                  {
+                    "ruleId": "RULE-REVIEW-{{index}}",
+                    "level": "error",
+                    "message": { "text": "review finding {{index}}" }
+                  }
+                """));
+
+            var sarifPath = Path.Combine(sarifDirectory, "range-review.sarif");
+            File.WriteAllText(sarifPath, $$"""
+            {
+              "runs": [
+                {
+                  "results": [
+            {{resultsJson}}
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                _ = await SarifTools.SarifGet(limit: 10);
+                var reviewResult = await SarifTools.SarifReview(target: "1-2");
+
+                var reviewText = ((TextContentBlock)reviewResult.Content[0]).Text;
+                Assert.That(reviewText, Contains.Substring("### Finding `1`"));
+                Assert.That(reviewText, Contains.Substring("### Finding `2`"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public void SarifTargetDescriptions_IncludeRangeSyntax()
+        {
+            var reviewParameter = typeof(SarifTools)
+                .GetMethod(nameof(SarifTools.SarifReview))!
+                .GetParameters()
+                .Single(p => p.Name == "target");
+
+            var updateParameter = typeof(SarifTools)
+                .GetMethod(nameof(SarifTools.SarifUpdate))!
+                .GetParameters()
+                .Single(p => p.Name == "target");
+
+            var reviewDescription = reviewParameter.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
+            var updateDescription = updateParameter.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()?.Description;
+
+            Assert.That(reviewDescription, Does.Contain("a range (e.g. '1-5')"));
+            Assert.That(updateDescription, Does.Contain("a range (e.g. '1-5')"));
         }
 
         private static void SetInternalSarifToolsProperty(string propertyName, object? value)

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -414,7 +414,7 @@ namespace Sarifintown.AgentEngine.Tests
                 Assert.That(setMeta.GetProperty("context").GetProperty("metrics").GetProperty("total_in_scope").GetInt32(), Is.EqualTo(1));
                 Assert.That(setMeta.GetProperty("pause").GetBoolean(), Is.True);
                 Assert.That(setMeta.GetProperty("next_step").GetString(), Is.EqualTo("sarif_review"));
-                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## SARIF Findings Index"));
+                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## ??? SARIF Findings (Page 1 of 1)"));
                 Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring(SarifTools.StateContextDelimiter));
 
                 await SarifTools.SarifFilter("severity:high rule:RULE-HIGH");

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -351,8 +351,6 @@ namespace Sarifintown.AgentEngine.Tests
             SetInternalSarifToolsProperty("SnippetCache", null);
             SetInternalSarifToolsProperty("SnippetWarmupService", null);
             SetInternalSarifToolsProperty("PromptAssembly", null);
-            SarifTools.SetDebugPromptEnabled(false);
-            SarifTools.SetIncludeEvidenceByDefault(true);
             SarifTools.SetDiscoveredSarifFiles(Array.Empty<string>());
             SarifTools.SetLocalUiBaseUrl(string.Empty);
             SarifTools.SetWorkspaceRoot(Directory.GetCurrentDirectory());
@@ -416,7 +414,7 @@ namespace Sarifintown.AgentEngine.Tests
                 Assert.That(setMeta.GetProperty("context").GetProperty("metrics").GetProperty("total_in_scope").GetInt32(), Is.EqualTo(1));
                 Assert.That(setMeta.GetProperty("pause").GetBoolean(), Is.True);
                 Assert.That(setMeta.GetProperty("next_step").GetString(), Is.EqualTo("sarif_review"));
-                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## SARIF Scoped Query"));
+                Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring("## SARIF Findings Index"));
                 Assert.That(((TextContentBlock)setResult.Content[0]).Text, Contains.Substring(SarifTools.StateContextDelimiter));
 
                 await SarifTools.SarifFilter("severity:high rule:RULE-HIGH");
@@ -515,7 +513,6 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetIncludeEvidenceByDefault(false);
                 var result = await SarifTools.SarifGet(limit: 100);
                 var meta = JsonSerializer.SerializeToElement(result.Meta);
 
@@ -707,7 +704,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifGet_WithDebugPromptTrue_IncludesDebugSection()
+        public async Task SarifReview_WithPromptAssembly_ReturnsSystemDirectiveAndEvidence()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
@@ -721,16 +718,16 @@ namespace Sarifintown.AgentEngine.Tests
             Directory.CreateDirectory(categoriesDir);
             File.WriteAllText(Path.Combine(categoriesDir, "default-sast.md"), "# Test Default SAST");
 
-            var sarifPath = Path.Combine(sarifDirectory, "debug-prompt.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "review-directive.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
                 {
                   "results": [
                     {
-                      "ruleId": "RULE-DEBUG",
+                      "ruleId": "RULE-REVIEW-DIRECTIVE",
                       "level": "error",
-                      "message": { "text": "debug test finding" }
+                      "message": { "text": "review directive finding" }
                     }
                   ]
                 }
@@ -745,14 +742,17 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetDebugPromptEnabled(true);
+                var getResult = await SarifTools.SarifGet(limit: 10);
+                var meta = JsonSerializer.SerializeToElement(getResult.Meta);
+                var displayId = meta.GetProperty("context").GetProperty("aliases")[0].GetProperty("displayid").GetString();
 
-                SarifTools.SetIncludeEvidenceByDefault(true);
-                var result = await SarifTools.SarifGet();
-                var text = ((TextContentBlock)result.Content[0]).Text;
+                var reviewResult = await SarifTools.SarifReview(target: displayId!);
+                var text = ((TextContentBlock)reviewResult.Content[0]).Text;
 
-                Assert.That(text, Contains.Substring("DEBUG: Assembled Triage Prompt"));
+                Assert.That(text, Contains.Substring("## Evidence for Review"));
+                Assert.That(text, Contains.Substring("<system_directive>"));
                 Assert.That(text, Contains.Substring("# Test Core Directive"));
+                Assert.That(text, Contains.Substring("sarif_update"));
             }
             finally
             {
@@ -761,7 +761,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifGet_WithDebugPromptFalse_OmitsDebugSection()
+        public async Task SarifGet_DoesNotIncludePromptOrEvidenceInResponse()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
@@ -775,16 +775,16 @@ namespace Sarifintown.AgentEngine.Tests
             Directory.CreateDirectory(categoriesDir);
             File.WriteAllText(Path.Combine(categoriesDir, "default-sast.md"), "# Test Default SAST");
 
-            var sarifPath = Path.Combine(sarifDirectory, "no-debug.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "no-prompt-in-get.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
                 {
                   "results": [
                     {
-                      "ruleId": "RULE-NODEBUG",
+                      "ruleId": "RULE-NOPROMPTGET",
                       "level": "error",
-                      "message": { "text": "no debug" }
+                      "message": { "text": "no prompt in get" }
                     }
                   ]
                 }
@@ -799,15 +799,14 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetDebugPromptEnabled(false);
-
-                SarifTools.SetIncludeEvidenceByDefault(false);
                 var result = await SarifTools.SarifGet();
                 var text = ((TextContentBlock)result.Content[0]).Text;
 
                 Assert.That(text, Does.Not.Contain("DEBUG: Assembled Triage Prompt"));
-                Assert.That(text, Contains.Substring("Triage Analysis Instructions"));
-                Assert.That(text, Contains.Substring("# Test Core Directive"));
+                Assert.That(text, Does.Not.Contain("Triage Analysis Instructions"));
+                Assert.That(text, Does.Not.Contain("# Test Core Directive"));
+                Assert.That(text, Contains.Substring("## SARIF Findings Index"));
+                Assert.That(text, Contains.Substring("sarif_review"));
             }
             finally
             {
@@ -816,30 +815,22 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifReview_WithDebugPromptTrue_IncludesDebugSection()
+        public async Task SarifUpdate_WithLlmReasoning_RecordsAsAiDecision()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
             Directory.CreateDirectory(sarifDirectory);
 
-            var promptsDir = Path.Combine(workspace, ".sarif", "sarifintown-prompts", "base");
-            Directory.CreateDirectory(promptsDir);
-            File.WriteAllText(Path.Combine(promptsDir, "core-directive.md"), "# Review Core Directive");
-            File.WriteAllText(Path.Combine(promptsDir, "output-format.md"), "# Review Output Format");
-            var categoriesDir = Path.Combine(workspace, ".sarif", "sarifintown-prompts", "categories");
-            Directory.CreateDirectory(categoriesDir);
-            File.WriteAllText(Path.Combine(categoriesDir, "default-sast.md"), "# Review Default SAST");
-
-            var sarifPath = Path.Combine(sarifDirectory, "review-debug.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "ai-triage.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
                 {
                   "results": [
                     {
-                      "ruleId": "RULE-REVIEW-DEBUG",
+                      "ruleId": "RULE-AI-TRIAGE",
                       "level": "error",
-                      "message": { "text": "review debug finding" }
+                      "message": { "text": "ai triage finding" }
                     }
                   ]
                 }
@@ -849,28 +840,22 @@ namespace Sarifintown.AgentEngine.Tests
 
             SarifTools.SetWorkspaceRoot(workspace);
             SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
-            SetInternalSarifToolsProperty("PromptAssembly", new PromptAssemblyService(
-                Path.Combine(workspace, ".sarif", "sarifintown-prompts")));
 
             try
             {
-                SarifTools.SetDebugPromptEnabled(true);
-                SarifTools.SetIncludeEvidenceByDefault(true);
-
                 var getResult = await SarifTools.SarifGet(limit: 10);
                 var meta = JsonSerializer.SerializeToElement(getResult.Meta);
                 var displayId = meta.GetProperty("context").GetProperty("aliases")[0].GetProperty("displayid").GetString();
 
-                var reviewResult = await SarifTools.SarifReview(
+                var updateResult = await SarifTools.SarifUpdate(
                     target: displayId!,
                     state: "false_positive",
                     reason: "Test code pattern",
-                    llmReasoning: "Analyzed the code flow",
-                    inputMarkdown: "evidence markdown");
-                var text = ((TextContentBlock)reviewResult.Content[0]).Text;
+                    llmReasoning: "I analyzed the code flow and determined this is not exploitable.");
+                var text = ((TextContentBlock)updateResult.Content[0]).Text;
 
-                Assert.That(text, Contains.Substring("DEBUG: Assembled Triage Prompt"));
-                Assert.That(text, Contains.Substring("# Review Core Directive"));
+                Assert.That(text, Contains.Substring("## SARIF Scoped Review"));
+                Assert.That(text, Contains.Substring("Ledger entries written:"));
             }
             finally
             {
@@ -879,22 +864,22 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifReview_WithDebugPromptFalse_OmitsDebugSection()
+        public async Task SarifReview_WithoutPromptAssembly_StillReturnsEvidenceStructure()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
             Directory.CreateDirectory(sarifDirectory);
 
-            var sarifPath = Path.Combine(sarifDirectory, "review-nodebug.sarif");
+            var sarifPath = Path.Combine(sarifDirectory, "review-no-assembly.sarif");
             File.WriteAllText(sarifPath, """
             {
               "runs": [
                 {
                   "results": [
                     {
-                      "ruleId": "RULE-REVIEW-NODEBUG",
+                      "ruleId": "RULE-REVIEW-NOASSEMBLY",
                       "level": "error",
-                      "message": { "text": "review no debug" }
+                      "message": { "text": "review no assembly" }
                     }
                   ]
                 }
@@ -907,21 +892,15 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetDebugPromptEnabled(false);
-                SarifTools.SetIncludeEvidenceByDefault(true);
-
                 var getResult = await SarifTools.SarifGet(limit: 10);
                 var meta = JsonSerializer.SerializeToElement(getResult.Meta);
                 var displayId = meta.GetProperty("context").GetProperty("aliases")[0].GetProperty("displayid").GetString();
 
-                var reviewResult = await SarifTools.SarifReview(
-                    target: displayId!,
-                    state: "confirmed",
-                    reason: "Real vulnerability",
-                    llmReasoning: "Code is reachable",
-                    inputMarkdown: "evidence markdown");
+                var reviewResult = await SarifTools.SarifReview(target: displayId!);
                 var text = ((TextContentBlock)reviewResult.Content[0]).Text;
 
+                Assert.That(text, Contains.Substring("## Evidence for Review"));
+                Assert.That(text, Contains.Substring("sarif_update"));
                 Assert.That(text, Does.Not.Contain("DEBUG: Assembled Triage Prompt"));
             }
             finally
@@ -1076,7 +1055,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifGet_WithIncludeEvidence_IncludesTriageInstructionsByDefault()
+        public async Task SarifGet_WithPromptAssembly_DoesNotIncludePromptContent()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
@@ -1114,13 +1093,13 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetIncludeEvidenceByDefault(true);
                 var result = await SarifTools.SarifGet();
                 var text = ((TextContentBlock)result.Content[0]).Text;
 
-                Assert.That(text, Contains.Substring("### Triage Analysis Instructions"));
-                Assert.That(text, Contains.Substring("# Core Directive"));
+                Assert.That(text, Does.Not.Contain("### Triage Analysis Instructions"));
+                Assert.That(text, Does.Not.Contain("# Core Directive"));
                 Assert.That(text, Does.Not.Contain("DEBUG: Assembled Triage Prompt"));
+                Assert.That(text, Contains.Substring("sarif_review"));
             }
             finally
             {
@@ -1157,7 +1136,6 @@ namespace Sarifintown.AgentEngine.Tests
 
             try
             {
-                SarifTools.SetIncludeEvidenceByDefault(true);
                 var result = await SarifTools.SarifGet();
                 var text = ((TextContentBlock)result.Content[0]).Text;
 

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -602,39 +602,6 @@ namespace Sarifintown.AgentEngine.Tests
             Assert.That(payload.GetProperty("bridge").GetProperty("channel").GetString(), Is.EqualTo("sarifintown.mcp.v1"));
         }
 
-        [Test]
-        public void GenerateAnalysisReport_WithValidData_CreatesMarkdownFile()
-        {
-            var resultId = "0";
-            var extractedFlowData = @"{
-                ""rule_id"": ""RULE001"",
-                ""flow_steps"": [
-                    {
-                        ""file_path"": ""test.cs"",
-                        ""start_line"": 10,
-                        ""message"": ""Step 1"",
-                        ""code_snippet"": ""var x = 1;""
-                    }
-                ]
-            }";
-            var outputPath = Path.GetTempFileName();
-
-            try
-            {
-                var result = SarifTools.GenerateAnalysisReport(resultId, extractedFlowData, outputPath);
-
-                Assert.That(result, Contains.Substring("Report generated successfully"));
-                var fileContent = File.ReadAllText(outputPath);
-                Assert.That(fileContent, Contains.Substring("# Vulnerability Analysis Report"));
-                Assert.That(fileContent, Contains.Substring("**Rule ID:** RULE001"));
-                Assert.That(fileContent, Contains.Substring("test.cs (Line 10)"));
-                Assert.That(fileContent, Contains.Substring("var x = 1;"));
-            }
-            finally
-            {
-                File.Delete(outputPath);
-            }
-        }
 
         [Test]
         public void McpToolExposure_ContainsStatefulTools()

--- a/Sarifintown.AgentEngine.Tests/V8TreeSitterEngineTests.cs
+++ b/Sarifintown.AgentEngine.Tests/V8TreeSitterEngineTests.cs
@@ -150,8 +150,6 @@ namespace Sarifintown.AgentEngine.Tests
                     await SarifTools.SarifFilter(config.Filter);
                 }
 
-                SarifTools.SetIncludeEvidenceByDefault(config.IncludeEvidence);
-
                 var result = await SarifTools.SarifGet(
                     limit: config.Limit);
 

--- a/Sarifintown.AgentEngine/Configuration/SarifPreloadOptions.cs
+++ b/Sarifintown.AgentEngine/Configuration/SarifPreloadOptions.cs
@@ -14,8 +14,4 @@ internal sealed class SarifOptions
     public PreloadStrategy Strategy { get; set; } = PreloadStrategy.LatestPerTool;
 
     public bool EnableSnippetPreload { get; set; } = true;
-
-    public bool EnableDebugPrompt { get; set; }
-
-    public bool IncludeEvidenceByDefault { get; set; } = true;
 }

--- a/Sarifintown.AgentEngine/InteractiveSurfaceResolver.cs
+++ b/Sarifintown.AgentEngine/InteractiveSurfaceResolver.cs
@@ -1,0 +1,320 @@
+using ModelContextProtocol.Server;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Sarifintown.AgentEngine
+{
+    internal static class InteractiveSurfaceResolver
+    {
+        private static readonly string[] IdeHostTokens =
+        [
+            "vscode",
+            "visualstudiocode",
+            "visualstudio",
+            "cursor",
+            "windsurf",
+            "jetbrains",
+            "rider",
+            "zed",
+            "eclipse",
+            "intellij",
+            "xcode"
+        ];
+
+        private static readonly string[] CliHostTokens =
+        [
+            "claudecode",
+            "claude",
+            "codex",
+            "aider",
+            "geminicli",
+            "opencode",
+            "terminal",
+            "bash",
+            "zsh",
+            "fish",
+            "powershell",
+            "pwsh",
+            "cmd",
+            "windowsterminal",
+            "iterm",
+            "tmux",
+            "kitty",
+            "alacritty"
+        ];
+
+        private static readonly string[] VsCodeFamilyTokens =
+        [
+            "vscode",
+            "visualstudiocode",
+            "cursor",
+            "windsurf"
+        ];
+
+        private static readonly string[] JetBrainsFamilyTokens =
+        [
+            "jetbrains",
+            "rider",
+            "intellij",
+            "pycharm",
+            "webstorm",
+            "clion",
+            "goland",
+            "rubymine"
+        ];
+
+        /// <summary>
+        /// Resolves host capabilities and returns the UI/TUI launch payload for the caller.
+        /// </summary>
+        public static string ResolveInteractiveSurface(
+            McpServer thisServer,
+            string hostHint,
+            bool startCliMenu,
+            Func<object> localHttpUiPayloadFactory)
+        {
+            ArgumentNullException.ThrowIfNull(localHttpUiPayloadFactory);
+
+            var host = DetectHost(thisServer, hostHint);
+            var mode = ResolveHostMode(host);
+            var hostFamily = ResolveHostFamily(host);
+            var usedFallback = string.Equals(host, "unknown", StringComparison.OrdinalIgnoreCase);
+
+            if (mode == "ide-ui")
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    host,
+                    mode,
+                    host_family = hostFamily,
+                    uri = "ui://sarifintown/mcp/dashboard",
+                    local_http_ui = localHttpUiPayloadFactory(),
+                    bridge = new
+                    {
+                        transport = "postMessage",
+                        channel = "sarifintown.mcp.v1"
+                    },
+                    fallback = new
+                    {
+                        mode = "cli-tui",
+                        library = "Spectre.Console"
+                    }
+                });
+            }
+
+            string selectedAction = string.Empty;
+            string commandResult = string.Empty;
+            if (startCliMenu)
+            {
+                selectedAction = SpectreCliMenu.Start();
+                if (selectedAction.StartsWith("Triage ", StringComparison.Ordinal))
+                {
+                    commandResult = SpectreCliMenu
+                        .ExecuteTriageActionAsync(selectedAction)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                host,
+                mode,
+                host_family = hostFamily,
+                fallback_used = usedFallback,
+                local_http_ui = localHttpUiPayloadFactory(),
+                tui = new
+                {
+                    library = "Spectre.Console",
+                    action = selectedAction,
+                    action_result = commandResult,
+                    menu = "interactive"
+                }
+            });
+        }
+
+        private static string DetectHost(McpServer thisServer, string hostHint)
+        {
+            if (!string.IsNullOrWhiteSpace(hostHint))
+            {
+                return hostHint.Trim();
+            }
+
+            if (thisServer != null)
+            {
+                var hostFromServer = TryGetHostNameFromServer(thisServer);
+                if (!string.IsNullOrWhiteSpace(hostFromServer))
+                {
+                    return hostFromServer;
+                }
+            }
+
+            var hostFromEnvironment = TryGetHostNameFromEnvironment();
+            if (!string.IsNullOrWhiteSpace(hostFromEnvironment))
+            {
+                return hostFromEnvironment;
+            }
+
+            return "unknown";
+        }
+
+        private static string ResolveHostMode(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                return "cli-tui";
+            }
+
+            var normalizedHost = NormalizeHost(host);
+
+            if (ContainsAnyToken(normalizedHost, IdeHostTokens))
+            {
+                return "ide-ui";
+            }
+
+            if (ContainsAnyToken(normalizedHost, CliHostTokens))
+            {
+                return "cli-tui";
+            }
+
+            return "cli-tui";
+        }
+
+        private static string ResolveHostFamily(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                return "terminal-family";
+            }
+
+            var normalizedHost = NormalizeHost(host);
+
+            if (ContainsAnyToken(normalizedHost, VsCodeFamilyTokens))
+            {
+                return "vscode-family";
+            }
+
+            if (ContainsAnyToken(normalizedHost, JetBrainsFamilyTokens))
+            {
+                return "jetbrains-family";
+            }
+
+            if (normalizedHost.Contains("visualstudio", StringComparison.Ordinal))
+            {
+                return "visualstudio-family";
+            }
+
+            if (normalizedHost.Contains("zed", StringComparison.Ordinal))
+            {
+                return "zed-family";
+            }
+
+            if (ContainsAnyToken(normalizedHost, CliHostTokens))
+            {
+                return "terminal-family";
+            }
+
+            return "unknown-family";
+        }
+
+        private static string TryGetHostNameFromEnvironment()
+        {
+            var directValueVariables = new[]
+            {
+                "MCP_CLIENT_NAME",
+                "MCP_HOST",
+                "MCP_CLIENT",
+                "TERM_PROGRAM",
+                "TERM",
+                "TERMINAL_EMULATOR",
+                "PROMPT_TOOLKIT_SHELL",
+                "VSCODE_CWD",
+                "ELECTRON_RUN_AS_NODE"
+            };
+
+            foreach (var variable in directValueVariables)
+            {
+                var value = Environment.GetEnvironmentVariable(variable);
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value.Trim();
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("CLAUDECODE")))
+            {
+                return "Claude Code";
+            }
+
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("CURSOR_TRACE_ID")))
+            {
+                return "Cursor";
+            }
+
+            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("VSCODE_GIT_IPC_HANDLE")))
+            {
+                return "Visual Studio Code";
+            }
+
+            return string.Empty;
+        }
+
+        private static string NormalizeHost(string host)
+        {
+            var lowered = host.Trim().ToLowerInvariant();
+
+            return string.Concat(lowered.Where(char.IsLetterOrDigit));
+        }
+
+        private static bool ContainsAnyToken(string normalizedHost, IEnumerable<string> tokens)
+        {
+            return tokens.Any(token => normalizedHost.Contains(token, StringComparison.Ordinal));
+        }
+
+        private static string TryGetHostNameFromServer(McpServer server)
+        {
+            var directClientInfo = GetPropertyValue(server, "ClientInfo");
+            var directName = GetPropertyValue(directClientInfo, "Name")?.ToString();
+
+            if (!string.IsNullOrWhiteSpace(directName))
+            {
+                return directName.Trim();
+            }
+
+            var initializeRequest = GetPropertyValue(server, "InitializeRequest");
+            var requestClientInfo = GetPropertyValue(initializeRequest, "ClientInfo");
+            var requestClientName = GetPropertyValue(requestClientInfo, "Name")?.ToString();
+
+            if (!string.IsNullOrWhiteSpace(requestClientName))
+            {
+                return requestClientName.Trim();
+            }
+
+            var session = GetPropertyValue(server, "Session");
+            var sessionClientInfo = GetPropertyValue(session, "ClientInfo");
+            var sessionClientName = GetPropertyValue(sessionClientInfo, "Name")?.ToString();
+
+            return string.IsNullOrWhiteSpace(sessionClientName)
+                ? string.Empty
+                : sessionClientName.Trim();
+        }
+
+        private static object? GetPropertyValue(object? instance, string propertyName)
+        {
+            if (instance == null)
+            {
+                return null;
+            }
+
+            var property = instance
+                .GetType()
+                .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+
+            if (property == null)
+            {
+                return null;
+            }
+
+            return property.GetValue(instance);
+        }
+    }
+}

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -104,7 +104,6 @@ await RunStartupStageAsync("SARIF state initialization", () => sarifStateService
 
 var snippetCacheService = app.Services.GetRequiredService<SnippetCacheService>();
 var snippetWarmupService = app.Services.GetRequiredService<SnippetWarmupService>();
-var sarifOptions = app.Services.GetRequiredService<IOptions<SarifOptions>>().Value;
 
 // Inject dependencies into SarifTools
 SarifTools.FileReader = app.Services.GetRequiredService<IFileReader>();
@@ -116,27 +115,22 @@ SarifTools.PromptAssembly = app.Services.GetRequiredService<IPromptAssemblyServi
 SarifTools.SetDiscoveredSarifFiles(discovery.SarifFiles);
 SarifTools.SetLocalUiBaseUrl(string.Empty);
 SarifTools.SetWorkspaceRoot(discovery.WorkspaceRoot);
-SarifTools.SetDebugPromptEnabled(sarifOptions.EnableDebugPrompt);
-SarifTools.SetIncludeEvidenceByDefault(sarifOptions.IncludeEvidenceByDefault);
 await RunStartupStageAsync("Available facets initialization", () => SarifTools.InitializeAvailableFacetsAsync());
 WriteStartupInfo("MCP tool dependencies configured.");
 
 await RunStartupStageAsync("Web host start", () => app.StartAsync());
 
-if (sarifOptions.EnableSnippetPreload)
-{
-    await RunStartupStageAsync(
-        $"Snippet preload bootstrap ({InitialSnippetPreloadCount})",
-        () => snippetWarmupService.PreloadSnippetsAsync(InitialSnippetPreloadCount, app.Lifetime.ApplicationStopping));
-    var bootstrapPreloadStatus = snippetWarmupService.GetPreloadStatus();
-    WriteStartupInfo($"Snippet preload bootstrap status: '{bootstrapPreloadStatus.Message}'");
+await RunStartupStageAsync(
+    $"Snippet preload bootstrap ({InitialSnippetPreloadCount})",
+    () => snippetWarmupService.PreloadSnippetsAsync(InitialSnippetPreloadCount, app.Lifetime.ApplicationStopping));
+var bootstrapPreloadStatus = snippetWarmupService.GetPreloadStatus();
+WriteStartupInfo($"Snippet preload bootstrap status: '{bootstrapPreloadStatus.Message}'");
 
-    _ = RunSnippetPreloadInBackgroundAsync(
-        snippetWarmupService,
-        InitialSnippetPreloadCount,
-        app.Lifetime.ApplicationStopping);
-    WriteStartupInfo($"Snippet preload bootstrap ({InitialSnippetPreloadCount}) completed; remaining preload scheduled in background");
-}
+_ = RunSnippetPreloadInBackgroundAsync(
+    snippetWarmupService,
+    InitialSnippetPreloadCount,
+    app.Lifetime.ApplicationStopping);
+WriteStartupInfo($"Snippet preload bootstrap ({InitialSnippetPreloadCount}) completed; remaining preload scheduled in background");
 
 static async ValueTask<CompleteResult> HandleCompletionRequestAsync(
     CompleteRequestParams request,

--- a/Sarifintown.AgentEngine/PromptAssemblyService.cs
+++ b/Sarifintown.AgentEngine/PromptAssemblyService.cs
@@ -15,7 +15,6 @@ public sealed class PromptAssemblyService : IPromptAssemblyService
     private const string CoreDirectiveFileName = "core-directive.md";
     private const string OutputFormatFileName = "output-format.md";
     private const string SastCategoryFileName = "sast.md";
-    private const string SastLegacyCategoryFileName = "sast"; // Not strictly needed, we can just use "sast.md"
     private const string SecretCategoryFileName = "secret.md";
     private const string ScaCategoryFileName = "sca.md";
 

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -37,7 +37,7 @@ public static class SarifPrompts
     /// Builds a slash-command prompt for reading SARIF findings with current filters.
     /// </summary>
     [McpServerPrompt(Name = "sarif_get", Title = "Get Triage Posture")]
-    [Description("Retrieve posture summary and prioritized findings using the active filter.")]
+    [Description("Load a lightweight paginated findings index (ID, Rule, Severity, File Path). Call this FIRST in the sequential flow before sarif_review and sarif_update.")]
     public static string TriageQueryPrompt(
         [Description("Maximum finding count to return.")]
         int limit = 10,
@@ -57,46 +57,49 @@ public static class SarifPrompts
     }
 
     /// <summary>
-    /// Builds a slash-command prompt for autotriaging findings using LLM analysis.
-    /// The LLM loads evidence, analyzes each finding, and autonomously determines the triage decision.
+    /// Builds a slash-command prompt for loading code evidence and organizational rules before triage.
+    /// The LLM receives deep code flows and the assembled organizational rules, then calls sarif_update.
     /// </summary>
     [McpServerPrompt(Name = "sarif_review", Title = "Review Findings")]
-    [Description("Autotriage the currently scoped findings. Loads evidence, analyzes each finding, determines a decision, and records it with full LLM reasoning into the local audit ledger.")]
+    [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability.")]
     public static string ReviewPrompt(
         [Description("Target displayid, CSV displayid list, or 'scope' (max 25).")]
         string target = "scope")
     {
         return $"""
             EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_get` to load findings with evidence for target='{target}'.
-            2. For each finding in the result, analyze the evidence: code flow, snippets, rule description, severity.
-            3. Determine the appropriate decision state (confirmed, false_positive, test_code, wont_fix, mitigated) and formulate a 1-2 sentence reason from the evidence.
-            4. Call `sarif_review` with target='{target}', state=<your decision>, reason=<your reason>,
-               llmReasoning=<your full chain-of-thought analysis>, inputMarkdown=<the evidence you analyzed>.
-            5. Output exactly one <vulnerability_report> block VERBATIM from the result. Do NOT summarize, interpret, or add commentary.
+            1. Call `sarif_get` to obtain the list of findings and their displayids.
+            2. Call `sarif_review` with target='{target}' to load code evidence and organizational rules.
+            3. Analyze the evidence using the rules in the <system_directive> block returned by sarif_review.
+            4. Call `sarif_update` with target='{target}', state=<your decision>, reason=<your reason>, llmReasoning=<your full chain-of-thought>.
+            5. Output exactly one <vulnerability_report> block VERBATIM from the sarif_update result. Do NOT summarize, interpret, or add commentary.
             6. STOP and wait for user instruction.
             """;
     }
 
     /// <summary>
-    /// Builds a slash-command prompt for manually overriding a triage decision.
-    /// Sets human_reviewed=true in the audit ledger.
+    /// Builds a slash-command prompt for recording a triage decision.
+    /// Handles both AI-driven triage (with llmReasoning) and human manual overrides (without llmReasoning).
     /// </summary>
     [McpServerPrompt(Name = "sarif_update", Title = "Update Triage Decision")]
-    [Description("Manually override a triage decision for one or many findings. Marks the decision as human-reviewed in the audit ledger.")]
+    [Description("Record a triage decision. Call this AFTER analyzing the output of sarif_review.")]
     public static string UpdatePrompt(
         [Description("Decision state (confirmed, false_positive, test_code, wont_fix, mitigated).")]
         string state,
         [Description("Required decision reason.")]
         string reason,
         [Description("Target displayid, CSV displayid list, or 'scope'.")]
-        string target = "scope")
+        string target = "scope",
+        [Description("Optional AI chain-of-thought. Provide for AI triage. Omit for explicit human manual overrides.")]
+        string llmReasoning = "")
     {
         return $"""
             EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_update` with state='{state}', reason='{reason}', target='{target}'.
-            2. Output the result block VERBATIM. Do NOT add commentary.
-            3. Call `sarif_get` to verify remaining findings.
+            1. Call `sarif_get` to identify the exact target displayid if needed.
+            2. Call `sarif_review` with target='{target}' if analysis evidence has not been loaded yet.
+            3. Call `sarif_update` with target='{target}', state='{state}', reason='{reason}', and llmReasoning='{llmReasoning}'.
+            4. Output the result block VERBATIM. Do NOT add commentary.
+            5. Call `sarif_get` to verify remaining findings.
             """;
     }
 

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -46,7 +46,7 @@ public static class SarifPrompts
     /// Loads deep code-flow evidence and organizational triage rules.
     /// </summary>
     [McpServerPrompt(Name = "sarif_review", Title = "Review Findings/Issues/Vulnerabilities (SAST/Secret/SCA)")]
-    [Description("READ-ONLY tool. Loads deep code-flow evidence and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability so you can decide if it is a true or false positive.")]
+    [Description("Provides deep code-flow evidence and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability so you can review/triage/decide if it is a true or false positive.")]
     public static string ReviewPrompt(
         [Description("Target DisplayId (e.g. 1), CSV displayid list (e.g. 1,2,3), or 'scope' to review all open findings/issues (max 25).")]
         string target = "scope")

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -57,13 +57,13 @@ public static class SarifPrompts
     }
 
     /// <summary>
-    /// Builds a slash-command prompt for loading code evidence and organizational rules before triage.
-    /// The LLM receives deep code flows and the assembled organizational rules, then calls sarif_update.
+    /// Slash-command prompt for reviewing, analyzing, inspecting, or triaging SARIF findings.
+    /// Loads deep code-flow evidence and organizational triage rules, then records a decision via sarif_update.
     /// </summary>
     [McpServerPrompt(Name = "sarif_review", Title = "Review Findings")]
-    [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability.")]
+    [Description("Review, analyze, inspect, or triage SARIF findings. Loads code-flow evidence and organizational rules so you can decide true/false positive.")]
     public static string ReviewPrompt(
-        [Description("Target displayid, CSV displayid list, or 'scope' (max 25).")]
+        [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or 'scope' to review all open findings (max 25).")]
         string target = "scope")
     {
         return $"""

--- a/Sarifintown.AgentEngine/SarifPrompts.cs
+++ b/Sarifintown.AgentEngine/SarifPrompts.cs
@@ -10,34 +10,24 @@ public static class SarifPrompts
     /// Builds a slash-command prompt for setting SARIF finding filters.
     /// </summary>
     [McpServerPrompt(Name = "sarif_filter", Title = "Filter Findings")]
-    [Description("Set or clear filters for SARIF findings. Call with no query to list available filter values.")]
+    [Description("Set or clear filters for SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities. Call with no query to list available filter values.")]
     public static string FilterPrompt(
         [Description("Space-separated filter query (e.g. 'severity:high rule:SQLI status:open path:controllers'). Omit to list available filters.")]
         string query = "")
     {
         if (string.IsNullOrWhiteSpace(query))
         {
-            return """
-                EXECUTION PROTOCOL — follow these steps exactly:
-                1. Call `sarif_filter` with no arguments to list available filter values.
-                2. Output the result VERBATIM.
-                3. STOP and wait for the user to choose filters.
-                """;
+            return "List available filter values. Stop and wait for the user to choose.";
         }
 
-        return $"""
-            EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_filter` with query='{query}'.
-            2. Output the confirmation VERBATIM.
-            3. Call `sarif_get` to view filtered results.
-            """;
+        return $"Filter applied: query='{query}'. Proceed to call sarif_get to view the results.";
     }
 
     /// <summary>
     /// Builds a slash-command prompt for reading SARIF findings with current filters.
     /// </summary>
-    [McpServerPrompt(Name = "sarif_get", Title = "Get Triage Posture")]
-    [Description("Load a lightweight paginated findings index (ID, Rule, Severity, File Path). Call this FIRST in the sequential flow before sarif_review and sarif_update.")]
+    [McpServerPrompt(Name = "sarif_get", Title = "Get Security Findings")]
+    [Description("Load a lightweight SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities index (ID, Rule, Severity, File Path). Call this to see what needs review.")]
     public static string TriageQueryPrompt(
         [Description("Maximum finding count to return.")]
         int limit = 10,
@@ -48,33 +38,20 @@ public static class SarifPrompts
     {
         var safeLimit = limit <= 0 ? 10 : Math.Min(limit, 25);
 
-        return $"""
-            EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_get` with limit={safeLimit}, page={page}, pageToken='{pageToken}'.
-            2. Output exactly one <vulnerability_report> block VERBATIM. Do NOT summarize, interpret, duplicate, or append extra text.
-            3. STOP immediately and wait for explicit user instruction.
-            """;
+        return $"Fetch up to {safeLimit} findings (page={page}, token='{pageToken}'). Output exactly one <vulnerability_report> block. Do not add commentary.";
     }
 
     /// <summary>
     /// Slash-command prompt for reviewing, analyzing, inspecting, or triaging SARIF findings.
-    /// Loads deep code-flow evidence and organizational triage rules, then records a decision via sarif_update.
+    /// Loads deep code-flow evidence and organizational triage rules.
     /// </summary>
-    [McpServerPrompt(Name = "sarif_review", Title = "Review Findings")]
-    [Description("Review, analyze, inspect, or triage SARIF findings. Loads code-flow evidence and organizational rules so you can decide true/false positive.")]
+    [McpServerPrompt(Name = "sarif_review", Title = "Review Findings/Issues/Vulnerabilities (SAST/Secret/SCA)")]
+    [Description("READ-ONLY tool. Loads deep code-flow evidence and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability so you can decide if it is a true or false positive.")]
     public static string ReviewPrompt(
-        [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or 'scope' to review all open findings (max 25).")]
+        [Description("Target DisplayId (e.g. 1), CSV displayid list (e.g. 1,2,3), or 'scope' to review all open findings/issues (max 25).")]
         string target = "scope")
     {
-        return $"""
-            EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_get` to obtain the list of findings and their displayids.
-            2. Call `sarif_review` with target='{target}' to load code evidence and organizational rules.
-            3. Analyze the evidence using the rules in the <system_directive> block returned by sarif_review.
-            4. Call `sarif_update` with target='{target}', state=<your decision>, reason=<your reason>, llmReasoning=<your full chain-of-thought>.
-            5. Output exactly one <vulnerability_report> block VERBATIM from the sarif_update result. Do NOT summarize, interpret, or add commentary.
-            6. STOP and wait for user instruction.
-            """;
+        return $"Analyze the code evidence and rules for target='{target}'. Return your findings in a <system_directive> block. Wait for further instructions or proceed to record your decision.";
     }
 
     /// <summary>
@@ -82,7 +59,7 @@ public static class SarifPrompts
     /// Handles both AI-driven triage (with llmReasoning) and human manual overrides (without llmReasoning).
     /// </summary>
     [McpServerPrompt(Name = "sarif_update", Title = "Update Triage Decision")]
-    [Description("Record a triage decision. Call this AFTER analyzing the output of sarif_review.")]
+    [Description("Record a triage decision for a SARIF (SAST/Secret/SCA) finding/issue/vulnerability. Call this AFTER analyzing the output of sarif_review.")]
     public static string UpdatePrompt(
         [Description("Decision state (confirmed, false_positive, test_code, wont_fix, mitigated).")]
         string state,
@@ -93,30 +70,18 @@ public static class SarifPrompts
         [Description("Optional AI chain-of-thought. Provide for AI triage. Omit for explicit human manual overrides.")]
         string llmReasoning = "")
     {
-        return $"""
-            EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_get` to identify the exact target displayid if needed.
-            2. Call `sarif_review` with target='{target}' if analysis evidence has not been loaded yet.
-            3. Call `sarif_update` with target='{target}', state='{state}', reason='{reason}', and llmReasoning='{llmReasoning}'.
-            4. Output the result block VERBATIM. Do NOT add commentary.
-            5. Call `sarif_get` to verify remaining findings.
-            """;
+        return $"Record decision for target='{target}': state='{state}', reason='{reason}'. Output the result VERBATIM.";
     }
 
     /// <summary>
     /// Builds a slash-command prompt for syncing pending triage decisions to upstream vendor APIs.
     /// </summary>
     [McpServerPrompt(Name = "sarif_sync", Title = "Sync Triage Decisions")]
-    [Description("Push pending local review decisions to upstream vendor APIs (e.g., Snyk, GitHub Advanced Security).")]
+    [Description("Push pending local review decisions for SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities to upstream vendor APIs (e.g., Snyk, GitHub Advanced Security).")]
     public static string SyncPrompt(
         [Description("Target: 'pending' to sync all pending entries, or specific composite keys.")]
         string target = "pending")
     {
-        return $"""
-            EXECUTION PROTOCOL — follow these steps exactly:
-            1. Call `sarif_sync` with target='{target}'.
-            2. Output the result VERBATIM. Do NOT add commentary.
-            3. STOP and wait for user instruction.
-            """;
+        return $"Sync triage decisions for target='{target}'. Output result VERBATIM.";
     }
 }

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -35,8 +35,6 @@ namespace Sarifintown.AgentEngine
         private static readonly Dictionary<string, string> DisplayIdToFindingId = new(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, string> FindingIdToDisplayId = new(StringComparer.Ordinal);
         private static int _nextDisplayId = 1;
-        private static bool _debugPromptEnabled;
-        private static bool _includeEvidenceByDefault = true;
         private static HashSet<string> _availableSeverities = new(StringComparer.OrdinalIgnoreCase);
         private static HashSet<string> _availableRules = new(StringComparer.OrdinalIgnoreCase);
         private static HashSet<string> _availableStatuses = new(StringComparer.OrdinalIgnoreCase) { "Open", "TP", "FP" };
@@ -109,28 +107,6 @@ namespace Sarifintown.AgentEngine
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
                     .ToList();
-            }
-        }
-
-        /// <summary>
-        /// Enables or disables prompt debug mode for `sarif_get` at server startup.
-        /// </summary>
-        public static void SetDebugPromptEnabled(bool enabled)
-        {
-            lock (SyncRoot)
-            {
-                _debugPromptEnabled = enabled;
-            }
-        }
-
-        /// <summary>
-        /// Sets the default evidence inclusion behavior for `sarif_get` at server startup.
-        /// </summary>
-        public static void SetIncludeEvidenceByDefault(bool enabled)
-        {
-            lock (SyncRoot)
-            {
-                _includeEvidenceByDefault = enabled;
             }
         }
 
@@ -224,7 +200,7 @@ namespace Sarifintown.AgentEngine
         }
 
         [McpServerTool(Name = "sarif_get")]
-        [Description("Retrieve scoped SARIF findings using the active filter set by sarif_filter. Evidence inclusion and debug prompt output are controlled only by server startup settings. CRITICAL EXECUTION PROTOCOL: (1) Output exactly one vulnerability_report block VERBATIM from this tool result. (2) Do NOT summarize, interpret, restate, duplicate, or render additional tables. (3) STOP after output and wait for explicit user instruction. (4) Never call sarif_get again unless the user explicitly asks for another page. Use sarif_filter to change filters.")]
+        [Description("Retrieve scoped SARIF findings using the active filter set by sarif_filter. Returns a paginated index of findings. CRITICAL EXECUTION PROTOCOL: (1) Output the content inside the <vulnerability_report> block VERBATIM. (2) Do NOT summarize, interpret, restate, or duplicate. (3) STOP after output and wait for explicit user instruction. (4) Never call sarif_get again unless the user explicitly asks for another page. Use sarif_filter to change filters. To triage a finding, call sarif_review with the target displayid to load code evidence and organizational rules.")]
         public static async Task<CallToolResult> SarifGet(
             [Description("Maximum findings to return (1-25).")]
             int limit = 10,
@@ -234,15 +210,8 @@ namespace Sarifintown.AgentEngine
             string pageToken = "")
         {
             var safeLimit = limit <= 0 ? 10 : Math.Min(limit, 25);
-            bool debugPromptEnabled;
-            bool includeEvidenceByDefault;
-            lock (SyncRoot)
-            {
-                debugPromptEnabled = _debugPromptEnabled;
-                includeEvidenceByDefault = _includeEvidenceByDefault;
-            }
 
-            var payload = await ExecutePureGetAsync(includeEvidenceByDefault, safeLimit, page, debugPromptEnabled, pageToken);
+            var payload = await ExecutePureGetAsync(safeLimit, page, pageToken);
             var stateContext = new
             {
                 context = new
@@ -286,103 +255,98 @@ namespace Sarifintown.AgentEngine
         }
 
         /// <summary>
-        /// Autotriage: persists the LLM's triage decision and reasoning into the audit ledger.
-        /// The LLM must first call sarif_get to load evidence, analyze findings, then call this tool.
-        /// Does not make external API calls. Use sarif_sync to push decisions upstream.
+        /// Context injector: loads deep code evidence and organizational rules for the LLM to analyze.
+        /// After analyzing the output, the LLM should call sarif_update to record its decision.
         /// </summary>
         [McpServerTool(Name = "sarif_review")]
-        [Description("Record an AI triage decision for one or more SARIF findings into the local audit ledger. Requires prior evidence from sarif_get. CRITICAL EXECUTION PROTOCOL: (1) You MUST have already called sarif_get and received evidence for the target findings. (2) Analyze the evidence: code flow, snippets, rule description, severity. (3) Determine state and reason from your analysis. (4) Call this tool with target, state, reason, llmReasoning (your full chain-of-thought), and inputMarkdown (the evidence you analyzed). (5) Output exactly one <vulnerability_report> block VERBATIM from the result. (6) Do NOT summarize, interpret, or add commentary. (7) STOP and wait for user instruction. Use sarif_update instead for manual human overrides.")]
+        [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability before calling sarif_update. CRITICAL EXECUTION PROTOCOL: (1) Call sarif_get first to get target displayids. (2) Call sarif_review with the target displayid(s) to load code evidence and organizational rules. (3) Analyze the evidence using the rules in the system directive. (4) Call sarif_update with your target, state, reason, and llmReasoning. Do NOT stop after this tool; proceed with analysis immediately.")]
         public static async Task<CallToolResult> SarifReview(
-            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to autotriage all open findings in active scope (max 25).")]
-            string target = "scope",
-            [Description("Decision state determined by analysis: confirmed (true positive), false_positive (not a real issue), test_code (in test/non-production code), wont_fix (accepted risk), or mitigated (already addressed).")]
-            string state = "",
-            [Description("Decision reason derived from the evidence analysis.")]
-            string reason = "",
-            [Description("Verbose chain-of-thought reasoning from the LLM analysis.")]
-            string llmReasoning = "",
-            [Description("The exact evidence markdown that was fed to the LLM for this decision.")]
-            string inputMarkdown = "")
+            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to review all open findings in active scope (max 25).")]
+            string target)
         {
             if (string.IsNullOrWhiteSpace(target))
             {
                 return CreatePlainTextResult("❌ `target` is required (displayid, CSV list, or 'scope').");
             }
 
-            if (string.IsNullOrWhiteSpace(state))
+            var workflow = CreateTriageWorkflowService();
+            List<string> targetIds;
+
+            if (string.Equals(target, "scope", StringComparison.OrdinalIgnoreCase))
             {
-                return CreatePlainTextResult("❌ `state` is required. Analyze the evidence from sarif_get and provide a decision: confirmed, false_positive, test_code, wont_fix, or mitigated.");
+                var activeScope = GetActiveScope();
+                var scopedFindings = await workflow.ListAsync(activeScope.ToQueryOptions(MaxEvidenceInspectCount));
+                targetIds = scopedFindings
+                    .Where(item => string.Equals(item.State, TriageFindingState.Open.ToString(), StringComparison.OrdinalIgnoreCase))
+                    .Select(item => item.FindingId)
+                    .Distinct(StringComparer.Ordinal)
+                    .Take(MaxEvidenceInspectCount)
+                    .ToList();
+            }
+            else
+            {
+                targetIds = ResolveFindingIds(target)
+                    .Select(ResolveFindingIdFromAliasOrRaw)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
             }
 
-            if (string.IsNullOrWhiteSpace(reason))
-            {
-                return CreatePlainTextResult("❌ `reason` is required. Summarize your analysis of the evidence in 1-2 sentences.");
-            }
-
-            if (!TryParseTriageDecisionState(state, out var parsedDecision))
-            {
-                return CreatePlainTextResult("❌ `state` must be one of: confirmed, false_positive, test_code, wont_fix, mitigated.");
-            }
-
-            var ledger = GetOrCreateLedgerService();
-
-            // Persist via the existing triage machinery so local state stays consistent
-            var triagePayload = await ExecuteScopedTriageAsync(state, reason, target, "AI");
-            if (triagePayload.ModifiedFindingIds.Count == 0)
+            if (targetIds.Count == 0)
             {
                 return CreatePlainTextResult("⚠️ No findings matched the target. Verify the displayid or scope.");
             }
 
-            // Resolve tool name from findings for composite key generation
-            var now = DateTime.UtcNow;
-            var ledgerItems = await BuildLedgerItemsAsync(
-                triagePayload, parsedDecision, reason, "AI", humanReviewed: false,
-                llmReasoning, inputMarkdown, now);
+            var evidenceByFindingId = await workflow.InspectManyAsync(targetIds);
 
-            await ledger.UpsertAsync(ledgerItems);
-
-            var reviewStateContext = new
+            var promptAssembly = PromptAssembly;
+            string? systemDirective = null;
+            if (promptAssembly != null && evidenceByFindingId.Count > 0)
             {
-                review = new
-                {
-                    success = triagePayload.Success,
-                    state = triagePayload.State,
-                    workflow_state = triagePayload.WorkflowState,
-                    target = triagePayload.Target,
-                    affected_count = triagePayload.AffectedCount,
-                    modified_finding_ids = triagePayload.ModifiedFindingIds,
-                    ledger_entries_written = ledgerItems.Count,
-                    sync_status = "pending"
-                }
-            };
+                var findingsForPrompt = evidenceByFindingId.Values
+                    .Select(e => (e.RuleId, e.Message))
+                    .ToList();
+                systemDirective = await promptAssembly.BuildBatchTriagePromptAsync(findingsForPrompt).ConfigureAwait(false);
+            }
+
+            var reviewMarkdown = BuildReviewContextMarkdown(target, evidenceByFindingId, systemDirective);
+
+            await AppendToExecutionLogAsync("sarif_review",
+                $"Target: {target}\n\nEvidence:\n{reviewMarkdown}\n\nSystem Directive:\n{systemDirective ?? "(none)"}").ConfigureAwait(false);
 
             var reviewMeta = new JsonObject
             {
-                ["pause"] = true,
-                ["next_step"] = "sarif_get"
+                ["next_step"] = "sarif_update"
             };
 
-            return CreateDualPurposeResult(
-                markdown: BuildScopedReviewMarkdown(triagePayload, ledgerItems.Count, await BuildReviewDebugPromptsAsync(triagePayload)),
-                systemStateContext: reviewStateContext,
+            return CreateReviewContextResult(
+                reviewMarkdown,
                 resourceUri: BuildUiResourceUri("triage", "sarif_review", string.Empty),
                 additionalMeta: reviewMeta);
         }
 
         /// <summary>
-        /// Manual override: applies a human-provided triage decision to specific findings,
-        /// marking them as human-reviewed in the audit ledger.
+        /// Unified writer: records a triage decision into the audit ledger.
+        /// AI callers must supply llmReasoning after analyzing evidence from sarif_review.
+        /// Human callers omit llmReasoning to mark the decision as human-reviewed.
         /// </summary>
         [McpServerTool(Name = "sarif_update")]
-        [Description("Manually override a triage decision for one or more findings. Sets human_reviewed=true in the audit ledger. Use this to correct or confirm AI-generated decisions. CRITICAL EXECUTION PROTOCOL: (1) Call this tool with a displayid from sarif_get output. (2) Output the result block VERBATIM. (3) Run sarif_get again to verify remaining findings.")]
+        [Description("Record a triage decision. If you are the AI analyzing evidence, you MUST provide your 'llmReasoning'. If a human user explicitly tells you to update a finding, leave 'llmReasoning' empty. CRITICAL EXECUTION PROTOCOL: (1) Call this tool after analyzing sarif_review output. (2) Output the result block VERBATIM. (3) Run sarif_get to verify remaining findings.")]
         public static async Task<CallToolResult> SarifUpdate(
+            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to update all open findings in active scope.")]
+            string target,
             [Description("Decision state: confirmed (true positive), false_positive (not a real issue), test_code (in test/non-production code), wont_fix (accepted risk), or mitigated (already addressed).")]
             string state,
-            [Description("Required decision reason/audit note explaining why this decision was made.")]
+            [Description("Decision reason explaining why this decision was made.")]
             string reason,
-            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to update all open findings in active scope.")]
-            string target)
+            [Description("Verbose chain-of-thought analysis. REQUIRED for AI callers. OMIT for human manual overrides.")]
+            string llmReasoning = "")
         {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                return CreatePlainTextResult("❌ `target` is required (displayid, CSV list, or 'scope').");
+            }
+
             if (string.IsNullOrWhiteSpace(state))
             {
                 return CreatePlainTextResult("❌ `state` is required (confirmed, false_positive, test_code, wont_fix, mitigated).");
@@ -393,30 +357,79 @@ namespace Sarifintown.AgentEngine
                 return CreatePlainTextResult("❌ `reason` is required.");
             }
 
-            if (string.IsNullOrWhiteSpace(target))
-            {
-                return CreatePlainTextResult("❌ `target` is required (displayid, CSV list, or 'scope').");
-            }
-
             if (!TryParseTriageDecisionState(state, out var parsedDecision))
             {
                 return CreatePlainTextResult("❌ `state` must be one of: confirmed, false_positive, test_code, wont_fix, mitigated.");
             }
 
+            var isAiTriage = !string.IsNullOrWhiteSpace(llmReasoning);
+            var author = isAiTriage ? "AI" : "human_developer";
             var ledger = GetOrCreateLedgerService();
 
-            var triagePayload = await ExecuteScopedTriageAsync(state, reason, target, "human_developer");
+            var triagePayload = await ExecuteScopedTriageAsync(state, reason, target, author);
             if (triagePayload.ModifiedFindingIds.Count == 0)
             {
                 return CreatePlainTextResult("⚠️ No findings matched the target. Verify the displayid or scope.");
             }
 
+            // For AI triage: silently re-assemble the organizational rules prompt for the audit trail
+            string? systemPromptUsed = null;
+            if (isAiTriage)
+            {
+                var promptAssembly = PromptAssembly;
+                if (promptAssembly != null && triagePayload.Evidence.Count > 0)
+                {
+                    var findingsForPrompt = triagePayload.Evidence
+                        .Where(e => e.Evidence != null)
+                        .Select(e => (e.Evidence!.RuleId, e.Evidence!.Message))
+                        .ToList();
+                    if (findingsForPrompt.Count > 0)
+                    {
+                        systemPromptUsed = await promptAssembly.BuildBatchTriagePromptAsync(findingsForPrompt).ConfigureAwait(false);
+                    }
+                }
+            }
+
             var now = DateTime.UtcNow;
             var ledgerItems = await BuildLedgerItemsAsync(
-                triagePayload, parsedDecision, reason, "human_developer", humanReviewed: true,
-                llmReasoning: string.Empty, inputMarkdown: string.Empty, now);
+                triagePayload, parsedDecision, reason, author,
+                humanReviewed: !isAiTriage,
+                llmReasoning, now, systemPromptUsed);
 
             await ledger.UpsertAsync(ledgerItems);
+
+            await AppendToExecutionLogAsync("sarif_update",
+                $"Target: {target}\nState: {state}\nReason: {reason}\nllmReasoning: {llmReasoning}").ConfigureAwait(false);
+
+            if (isAiTriage)
+            {
+                var reviewStateContext = new
+                {
+                    review = new
+                    {
+                        success = triagePayload.Success,
+                        state = triagePayload.State,
+                        workflow_state = triagePayload.WorkflowState,
+                        target = triagePayload.Target,
+                        affected_count = triagePayload.AffectedCount,
+                        modified_finding_ids = triagePayload.ModifiedFindingIds,
+                        ledger_entries_written = ledgerItems.Count,
+                        sync_status = "pending"
+                    }
+                };
+
+                var aiMeta = new JsonObject
+                {
+                    ["pause"] = true,
+                    ["next_step"] = "sarif_get"
+                };
+
+                return CreateDualPurposeResult(
+                    markdown: BuildScopedReviewMarkdown(triagePayload, ledgerItems.Count),
+                    systemStateContext: reviewStateContext,
+                    resourceUri: BuildUiResourceUri("triage", "sarif_update", string.Empty),
+                    additionalMeta: aiMeta);
+            }
 
             return CreateDualPurposeResult(
                 markdown: BuildScopedTriageMarkdown(triagePayload),
@@ -426,7 +439,7 @@ namespace Sarifintown.AgentEngine
         }
 
         /// <summary>
-        /// Builds ledger entries from a completed triage payload. Shared by SarifReview and SarifUpdate.
+        /// Builds ledger entries from a completed triage payload. Shared by SarifUpdate AI and human paths.
         /// </summary>
         private static async Task<List<(string CompositeKey, LedgerEntry Entry)>> BuildLedgerItemsAsync(
             ScopedTriagePayload triagePayload,
@@ -435,8 +448,8 @@ namespace Sarifintown.AgentEngine
             string author,
             bool humanReviewed,
             string llmReasoning,
-            string inputMarkdown,
-            DateTime timestamp)
+            DateTime timestamp,
+            string? systemPromptUsed)
         {
             var ledgerItems = new List<(string CompositeKey, LedgerEntry Entry)>();
 
@@ -474,9 +487,9 @@ namespace Sarifintown.AgentEngine
                     },
                     AuditLog = new LedgerAuditLog
                     {
-                        InputMarkdown = inputMarkdown,
                         LlmReasoning = llmReasoning,
-                        HumanReviewed = humanReviewed
+                        HumanReviewed = humanReviewed,
+                        SystemPromptUsed = humanReviewed ? null : systemPromptUsed
                     },
                     UpstreamSync = new LedgerUpstreamSync
                     {
@@ -766,7 +779,7 @@ namespace Sarifintown.AgentEngine
             });
         }
 
-        private static async Task<ScopedGetPayload> ExecutePureGetAsync(bool includeEvidence, int limit, int page = 0, bool debugPrompt = false, string pageToken = "")
+        private static async Task<ScopedGetPayload> ExecutePureGetAsync(int limit, int page = 0, string pageToken = "")
         {
             if (page < 0)
             {
@@ -831,30 +844,10 @@ namespace Sarifintown.AgentEngine
                 _paginationNextOffset = hasMore ? nextOffset : effectiveOffset;
             }
 
-            IReadOnlyDictionary<string, TriageInspectResult>? evidenceByFindingId = null;
-            if (includeEvidence && executionFindings.Count > 0)
-            {
-                var evidenceTargetIds = executionFindings
-                    .Select(item => item.FindingId)
-                    .Take(MaxEvidenceInspectCount)
-                    .ToList();
-
-                evidenceByFindingId = await workflow.InspectManyAsync(evidenceTargetIds);
-            }
-
-            var promptAssembly = PromptAssembly;
             var findingRows = new List<ScopedFinding>(executionFindings.Count);
             foreach (var finding in executionFindings)
             {
                 var displayId = GetOrCreateDisplayId(finding.FindingId);
-                TriageInspectResult? evidence = null;
-                if (includeEvidence && evidenceByFindingId != null)
-                {
-                    evidenceByFindingId.TryGetValue(finding.FindingId, out evidence);
-                }
-
-                // We skip generating per-finding triage prompt to avoid massive duplication
-                string? triagePrompt = null;
 
                 findingRows.Add(new ScopedFinding(
                     displayId,
@@ -862,22 +855,10 @@ namespace Sarifintown.AgentEngine
                     finding.Severity,
                     finding.State,
                     finding.RuleName,
-                    evidence?.Message ?? finding.RuleName,
+                    finding.RuleName,
                     new ScopedLocation(finding.FilePath, finding.LineNumber),
-                    evidence,
-                    triagePrompt));
-            }
-
-            string? batchedTriagePrompt = null;
-            if (promptAssembly != null && executionFindings.Count > 0)
-            {
-                var inputFindings = findingRows.Select(f => (f.Evidence?.RuleId ?? f.Rule, f.Evidence?.Message ?? f.Message!));
-                batchedTriagePrompt = await promptAssembly.BuildBatchTriagePromptAsync(inputFindings).ConfigureAwait(false);
-                // Attach the batched prompt to the first finding only, to transport it to the markdown builder
-                if (findingRows.Count > 0)
-                {
-                    findingRows[0] = findingRows[0] with { TriagePrompt = batchedTriagePrompt };
-                }
+                    null,
+                    null));
             }
 
             var metrics = new SarifGetMetrics(
@@ -929,7 +910,6 @@ namespace Sarifintown.AgentEngine
                     snippetPreloadStatus,
                     pagination),
                 findingRows,
-                debugPrompt,
                 availableFacets);
         }
 
@@ -1591,69 +1571,14 @@ namespace Sarifintown.AgentEngine
         private static string BuildScopedGetMarkdown(ScopedGetPayload payload)
         {
             ArgumentNullException.ThrowIfNull(payload);
-            var metrics = payload.Context.Metrics;
             var findings = payload.Findings;
-            var currentPage = payload.Context.Pagination.PageNumber;
-            var totalPages = payload.Context.Pagination.TotalPages;
-            var nextPage = payload.Context.Pagination.NextPageNumber ?? currentPage;
+            var pagination = payload.Context.Pagination;
 
             var lines = new List<string>
             {
-                "## SARIF Scoped Query",
+                "## SARIF Findings Index",
                 string.Empty
             };
-
-            // Display active filters
-            var activeScope = payload.Context.ActiveScope;
-            if (activeScope.Count > 0)
-            {
-                lines.Add("### Active Filters");
-                foreach (var kvp in activeScope)
-                {
-                    lines.Add($"- **{kvp.Key}**: `{EscapeMarkdown(kvp.Value)}`");
-                }
-
-                lines.Add(string.Empty);
-            }
-            else
-            {
-                lines.Add("### Active Filters");
-                lines.Add("- *(none — showing all findings)*");
-                lines.Add(string.Empty);
-            }
-
-            lines.Add($"- Total in scope: **{metrics.TotalInScope}**");
-            lines.Add($"- Returned in batch: **{metrics.ReturnedInBatch}**");
-            lines.Add($"- Remaining in scope: **{metrics.RemainingInScope}**");
-            lines.Add($"- Snippet preload status: **{payload.Context.SnippetPreloadStatus}**");
-            lines.Add($"- Page: **{currentPage} of {totalPages}**");
-            lines.Add($"- Page size: **{payload.Context.Pagination.PageSize}**");
-            lines.Add($"- Has more: **{payload.Context.Pagination.HasMore}**");
-            lines.Add(string.Empty);
-
-            // Display top noisy directories
-            if (payload.AvailableFacets?.TopLeafDirectories is { Length: > 0 } dirs)
-            {
-                lines.Add("### Top Directories");
-                foreach (var dir in dirs)
-                {
-                    lines.Add($"- `{EscapeMarkdown(dir)}`");
-                }
-
-                lines.Add(string.Empty);
-            }
-
-            if (payload.Context.Pagination.HasMore)
-            {
-                lines.Add($"- Next page: **{nextPage} of {totalPages}**");
-                lines.Add(string.Empty);
-            }
-
-            if (payload.Context.Pagination.PreviousPageNumber.HasValue)
-            {
-                lines.Add($"- Previous page: **{payload.Context.Pagination.PreviousPageNumber.Value} of {totalPages}**");
-                lines.Add(string.Empty);
-            }
 
             if (findings.Count == 0)
             {
@@ -1661,61 +1586,24 @@ namespace Sarifintown.AgentEngine
             }
             else
             {
-                lines.Add("| Id | Severity | State | Rule | Location |\n|---|---|---|---|---|");
+                lines.Add("| Id | Rule | Severity | File Path |\n|---|---|---|---|");
                 foreach (var finding in findings)
                 {
-                    lines.Add($"| `{EscapeMarkdown(finding.DisplayId)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.State)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Location.File)}`:{finding.Location.Line?.ToString() ?? "?"} |");
+                    lines.Add($"| `{EscapeMarkdown(finding.DisplayId)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.Location.File)}` |");
                 }
 
             }
 
             lines.Add(string.Empty);
-            lines.Add("**STOP:** Wait for explicit user instruction.");
-            lines.Add("If the user asks to review/triage findings, call `sarif_review` with the target displayid. You must analyze the evidence above and provide your state, reason, and llmReasoning.");
-            lines.Add("If the user wants to manually override a decision, call `sarif_update` with state, reason, and target.");
-            lines.Add("To change filters, call `sarif_filter`.");
-            if (payload.Context.Pagination.HasMore)
+            lines.Add("To triage a finding, call `sarif_review` with the target displayid to load code evidence and organizational rules.");
+            if (pagination.HasMore)
             {
-                lines.Add($"Optional fetch: if the user explicitly asks for more findings, call `sarif_get` once with `page: {nextPage}` or with `context.pagination.next_page_token`.");
-                lines.Add("Do not auto-fetch another batch; wait for the user instruction.");
+                lines.Add($"More findings are available. Use `page` `{pagination.NextPageNumber}` or `context.pagination.next_page_token` to fetch the next batch.");
             }
 
-            if (payload.Context.Pagination.PreviousPageNumber.HasValue)
+            if (pagination.PreviousPageNumber.HasValue)
             {
-                lines.Add($"To go back, call `sarif_get` once with `page: {payload.Context.Pagination.PreviousPageNumber.Value}`.");
-            }
-
-            var consolidatedPrompt = findings.FirstOrDefault(f => !string.IsNullOrWhiteSpace(f.TriagePrompt))?.TriagePrompt;
-            if (!string.IsNullOrWhiteSpace(consolidatedPrompt))
-            {
-                lines.Add(string.Empty);
-                lines.Add("---");
-
-                if (payload.DebugPrompt)
-                {
-                    lines.Add("### DEBUG: Assembled Triage Prompt");
-                    lines.Add(string.Empty);
-                    lines.Add("<details><summary>Batched Triage System Prompt</summary>");
-                    lines.Add(string.Empty);
-                    lines.Add("```markdown");
-                    lines.Add(consolidatedPrompt);
-                    lines.Add("```");
-                    lines.Add(string.Empty);
-                    lines.Add("</details>");
-                    lines.Add(string.Empty);
-                }
-                else
-                {
-                    lines.Add("### Triage Analysis Instructions");
-                    lines.Add("Follow these instructions when analyzing the findings above for review.");
-                    lines.Add(string.Empty);
-                    lines.Add("<details><summary>View Execution Directives</summary>");
-                    lines.Add(string.Empty);
-                    lines.Add(consolidatedPrompt);
-                    lines.Add(string.Empty);
-                    lines.Add("</details>");
-                    lines.Add(string.Empty);
-                }
+                lines.Add($"To fetch the previous batch, use `page` `{pagination.PreviousPageNumber.Value}`.");
             }
 
             return string.Join(Environment.NewLine, lines);
@@ -1810,45 +1698,165 @@ namespace Sarifintown.AgentEngine
         }
 
         /// <summary>
-        /// Builds debug prompt entries for reviewed findings when debug prompt mode is enabled.
+        /// Builds the evidence markdown + embedded system directive + call-to-action for sarif_review responses.
         /// </summary>
-        private static async Task<string?> BuildReviewDebugPromptsAsync(
-            ScopedTriagePayload triagePayload)
+        private static string BuildReviewContextMarkdown(
+            string target,
+            IReadOnlyDictionary<string, TriageInspectResult> evidenceByFindingId,
+            string? systemDirective)
         {
-            bool debugEnabled;
-            lock (SyncRoot)
+            ArgumentNullException.ThrowIfNull(evidenceByFindingId);
+
+            var lines = new List<string>
             {
-                debugEnabled = _debugPromptEnabled;
+                "## Evidence for Review",
+                string.Empty,
+                $"Target: `{EscapeMarkdown(target)}`",
+                string.Empty
+            };
+
+            foreach (var (findingId, evidence) in evidenceByFindingId)
+            {
+                string displayId;
+                lock (SyncRoot)
+                {
+                    displayId = FindingIdToDisplayId.TryGetValue(findingId, out var did) ? did : findingId;
+                }
+
+                lines.Add($"### Finding `{EscapeMarkdown(displayId)}`");
+                lines.Add(string.Empty);
+                lines.Add($"- Rule: `{EscapeMarkdown(evidence.RuleId)}`");
+                lines.Add($"- Severity: `{EscapeMarkdown(evidence.Severity)}`");
+                lines.Add($"- State: `{EscapeMarkdown(evidence.State)}`");
+                lines.Add($"- Message: {EscapeMarkdown(evidence.Message)}");
+
+                if (!string.IsNullOrWhiteSpace(evidence.RuleDescription))
+                {
+                    lines.Add(string.Empty);
+                    lines.Add($"**Rule Description:** {EscapeMarkdown(evidence.RuleDescription)}");
+                }
+
+                lines.Add(string.Empty);
+                lines.Add("#### Data Flow");
+                if (evidence.DataFlowEvidenceBlocks.Count > 0)
+                {
+                    foreach (var block in evidence.DataFlowEvidenceBlocks)
+                    {
+                        lines.Add($"**Steps `{block.StartStepIndex}`-`{block.EndStepIndex}`** at `{EscapeMarkdown(block.FilePath)}`:{block.StartLine?.ToString() ?? "?"}-{block.EndLine?.ToString() ?? "?"}");
+                        lines.Add("```csharp");
+                        lines.Add(block.CodeSnippet);
+                        lines.Add("```");
+                    }
+                }
+                else if (evidence.DataFlowSteps.Count > 0)
+                {
+                    foreach (var step in evidence.DataFlowSteps)
+                    {
+                        lines.Add($"**Step `{step.Index}`** at `{EscapeMarkdown(step.FilePath)}`:{step.StartLine?.ToString() ?? "?"} — {EscapeMarkdown(step.Message)}");
+                        if (!string.IsNullOrWhiteSpace(step.CodeSnippet))
+                        {
+                            lines.Add("```csharp");
+                            lines.Add(step.CodeSnippet);
+                            lines.Add("```");
+                        }
+                    }
+                }
+                else
+                {
+                    lines.Add("- No data flow available for this finding.");
+                }
+
+                lines.Add(string.Empty);
             }
 
-            if (!debugEnabled)
+            if (!string.IsNullOrWhiteSpace(systemDirective))
             {
-                return null;
+                lines.Add("---");
+                lines.Add(string.Empty);
+                lines.Add("<system_directive>");
+                lines.Add(systemDirective);
+                lines.Add("</system_directive>");
+                lines.Add(string.Empty);
             }
 
-            var promptAssembly = PromptAssembly;
-            if (promptAssembly == null)
-            {
-                return null;
-            }
+            lines.Add("---");
+            lines.Add(string.Empty);
+            lines.Add("Analyze the evidence above using the rules in the system directive. Output your chain of thought, then immediately call `sarif_update` to record your final decision.");
 
-            var inputs = triagePayload.Evidence
-                .Where(e => !string.IsNullOrWhiteSpace(e.Evidence?.RuleId) || !string.IsNullOrWhiteSpace(e.Evidence?.Message))
-                .Select(e => (e.Evidence!.RuleId, e.Evidence!.Message))
-                .ToList();
-
-            if (inputs.Count == 0)
-            {
-                return null;
-            }
-
-            return await promptAssembly.BuildBatchTriagePromptAsync(inputs).ConfigureAwait(false);
+            return string.Join(Environment.NewLine, lines);
         }
+
+        /// <summary>
+        /// Builds a CallToolResult for sarif_review responses (no "output verbatim and stop" contract).
+        /// </summary>
+        private static CallToolResult CreateReviewContextResult(
+            string reviewMarkdown,
+            string resourceUri,
+            JsonObject? additionalMeta = null)
+        {
+            var meta = new JsonObject();
+            if (!string.IsNullOrWhiteSpace(resourceUri))
+            {
+                var csp = BuildUiCsp(resourceUri);
+                meta["ui"] = new JsonObject
+                {
+                    ["resourceUri"] = resourceUri,
+                    ["csp"] = csp
+                };
+            }
+
+            if (additionalMeta != null)
+            {
+                foreach (var property in additionalMeta)
+                {
+                    meta[property.Key] = property.Value?.DeepClone();
+                }
+            }
+
+            return new CallToolResult
+            {
+                Content = new List<ContentBlock>
+                {
+                    new TextContentBlock { Text = reviewMarkdown?.Trim() ?? string.Empty }
+                },
+                Meta = meta
+            };
+        }
+
+        /// <summary>
+        /// Appends a diagnostic entry to the agent execution log for developer observability.
+        /// Errors are silently swallowed so logging never disrupts the main flow.
+        /// </summary>
+        private static async Task AppendToExecutionLogAsync(string actionName, string rawContent)
+        {
+            try
+            {
+                string workspaceRoot;
+                lock (SyncRoot)
+                {
+                    workspaceRoot = _workspaceRoot;
+                }
+
+                var logPath = Path.Combine(workspaceRoot, ".sarif", "agent-execution.log");
+                var logDirectory = Path.GetDirectoryName(logPath)!;
+                if (!Directory.Exists(logDirectory))
+                {
+                    Directory.CreateDirectory(logDirectory);
+                }
+
+                var entry = $"[{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}] ACTION: {actionName}{Environment.NewLine}{rawContent}{Environment.NewLine}---{Environment.NewLine}";
+                await File.AppendAllTextAsync(logPath, entry).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Silently swallow — logging must never crash the main flow
+            }
+        }
+
 
         private static string BuildScopedReviewMarkdown(
             ScopedTriagePayload payload,
-            int ledgerEntriesWritten,
-            string? debugPrompt = null)
+            int ledgerEntriesWritten)
         {
             ArgumentNullException.ThrowIfNull(payload);
 
@@ -1931,22 +1939,6 @@ namespace Sarifintown.AgentEngine
                         lines.Add("- Evidence unavailable for this finding.");
                     }
                 }
-            }
-
-            if (!string.IsNullOrWhiteSpace(debugPrompt))
-            {
-                lines.Add(string.Empty);
-                lines.Add("---");
-                lines.Add("### DEBUG: Assembled Triage Prompt");
-                lines.Add(string.Empty);
-                lines.Add("<details><summary>Batched Triage System Prompt</summary>");
-                lines.Add(string.Empty);
-                lines.Add("```markdown");
-                lines.Add(debugPrompt);
-                lines.Add("```");
-                lines.Add(string.Empty);
-                lines.Add("</details>");
-                lines.Add(string.Empty);
             }
 
             lines.Add(string.Empty);
@@ -2047,7 +2039,7 @@ namespace Sarifintown.AgentEngine
                 Options.Create(new SarifOptions
                 {
                     Strategy = PreloadStrategy.LatestPerTool,
-                    EnableSnippetPreload = false
+                    EnableSnippetPreload = true
                 }),
                 workspaceRoot,
                 discoveredFiles);
@@ -2305,7 +2297,7 @@ namespace Sarifintown.AgentEngine
             TriageInspectResult? Evidence,
             string? TriagePrompt = null);
 
-        private sealed record ScopedGetPayload(ScopedContext Context, IReadOnlyList<ScopedFinding> Findings, bool DebugPrompt = false, ScopedAvailableFacets? AvailableFacets = null);
+        private sealed record ScopedGetPayload(ScopedContext Context, IReadOnlyList<ScopedFinding> Findings, ScopedAvailableFacets? AvailableFacets = null);
 
         private sealed record ScopedAvailableFacets(
             string[] Rules,

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -259,7 +259,7 @@ namespace Sarifintown.AgentEngine
         /// After analyzing the output, the LLM should call sarif_update to record its decision.
         /// </summary>
         [McpServerTool(Name = "sarif_review")]
-        [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability before calling sarif_update. CRITICAL EXECUTION PROTOCOL: (1) Call sarif_get first to get target displayids. (2) Call sarif_review with the target displayid(s) to load code evidence and organizational rules. (3) Analyze the evidence using the rules in the system directive. (4) Call sarif_update with your target, state, reason, and llmReasoning. Do NOT stop after this tool; proceed with analysis immediately.")]
+        [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability before calling sarif_update. CRITICAL EXECUTION PROTOCOL: (1) Call sarif_get first to get target displayids. (2) Call sarif_review with the target displayid(s) to load code evidence and organizational rules. IMPORTANT: This tool ONLY takes the 'target' parameter. Do NOT try to pass 'state' or 'reason' to this tool. (3) Analyze the evidence using the rules in the system directive. (4) AFTER analysis, call sarif_update to record the decision (which does require state and reason). Do NOT stop after this tool; proceed with analysis immediately.")]
         public static async Task<CallToolResult> SarifReview(
             [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to review all open findings in active scope (max 25).")]
             string target)
@@ -331,7 +331,7 @@ namespace Sarifintown.AgentEngine
         /// Human callers omit llmReasoning to mark the decision as human-reviewed.
         /// </summary>
         [McpServerTool(Name = "sarif_update")]
-        [Description("Record a triage decision. If you are the AI analyzing evidence, you MUST provide your 'llmReasoning'. If a human user explicitly tells you to update a finding, leave 'llmReasoning' empty. CRITICAL EXECUTION PROTOCOL: (1) Call this tool after analyzing sarif_review output. (2) Output the result block VERBATIM. (3) Run sarif_get to verify remaining findings.")]
+        [Description("Record a triage decision. If you are the AI analyzing evidence, you MUST provide your 'llmReasoning'. If a human user explicitly tells you to update a finding, leave 'llmReasoning' empty. CRITICAL EXECUTION PROTOCOL: (1) Call this tool after analyzing sarif_review output. (2) Output the result block VERBATIM. (3) Run sarif_get to verify remaining findings. IMPORTANT: This tool requires four parameters: 'target', 'state', 'reason', and 'llmReasoning'.")]
         public static async Task<CallToolResult> SarifUpdate(
             [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to update all open findings in active scope.")]
             string target,
@@ -820,6 +820,38 @@ namespace Sarifintown.AgentEngine
             var snippetPreloadStatus = await ResolveSnippetPreloadStatusAsync().ConfigureAwait(false);
 
             var activeScopeFindings = await workflow.ListAsync(activeScope.ToQueryOptions(int.MaxValue));
+            ArgumentNullException.ThrowIfNull(activeScopeFindings);
+
+            var severityCounts = activeScopeFindings
+                .GroupBy(item => string.IsNullOrWhiteSpace(item.Severity) ? "Unknown" : item.Severity.Trim(), StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+            var statusCounts = activeScopeFindings
+                .GroupBy(item => string.IsNullOrWhiteSpace(item.State) ? "Unknown" : item.State.Trim(), StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+            var ruleGroups = activeScopeFindings
+                .GroupBy(item => string.IsNullOrWhiteSpace(item.RuleName) ? "Unknown" : item.RuleName.Trim(), StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            const int TopRuleLimit = 10;
+            var topRules = ruleGroups
+                .Take(TopRuleLimit)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+            var remainingRuleGroups = ruleGroups.Skip(TopRuleLimit).ToList();
+            var scopedStats = new ScopedStats(
+                severityCounts,
+                statusCounts,
+                topRules,
+                remainingRuleGroups.Count,
+                remainingRuleGroups.Sum(group => group.Count()));
 
             var effectiveOffset = Math.Min(cursorOffset, activeScopeFindings.Count);
             var executionFindings = activeScopeFindings
@@ -910,6 +942,7 @@ namespace Sarifintown.AgentEngine
                     snippetPreloadStatus,
                     pagination),
                 findingRows,
+                scopedStats,
                 availableFacets);
         }
 
@@ -1573,12 +1606,55 @@ namespace Sarifintown.AgentEngine
             ArgumentNullException.ThrowIfNull(payload);
             var findings = payload.Findings;
             var pagination = payload.Context.Pagination;
+            var metrics = payload.Context.Metrics;
+            var activeScope = payload.Context.ActiveScope;
+            var stats = payload.Stats;
+
+            var activeFilters = activeScope.Count == 0
+                ? "None (Showing all findings)"
+                : string.Join(", ", activeScope.Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+
+            var severitySummary = stats.SeverityCounts.Count == 0
+                ? "None"
+                : string.Join(", ", stats.SeverityCounts.Select(kvp => $"{kvp.Key} ({kvp.Value})"));
+
+            var statusSummary = stats.StatusCounts.Count == 0
+                ? "None"
+                : string.Join(", ", stats.StatusCounts.Select(kvp => $"{kvp.Key} ({kvp.Value})"));
 
             var lines = new List<string>
             {
-                "## SARIF Findings Index",
+                $"## 🛡️ SARIF Findings (Page {pagination.PageNumber} of {pagination.TotalPages})",
+                string.Empty,
+                $"**Active Filters:** {EscapeMarkdown(activeFilters)}",
+                $"**Scope Summary:** {metrics.TotalInScope} total issues | Showing {metrics.ReturnedInBatch} in this batch",
+                string.Empty,
+                "### Statistics",
+                $"**Severities:** {EscapeMarkdown(severitySummary)}",
+                $"**Statuses:** {EscapeMarkdown(statusSummary)}",
+                "**Top Rules:**",
                 string.Empty
             };
+
+            if (stats.TopRules.Count == 0)
+            {
+                lines.Add("- None");
+            }
+            else
+            {
+                foreach (var (ruleName, count) in stats.TopRules)
+                {
+                    lines.Add($"- `{EscapeMarkdown(ruleName)}` ({count})");
+                }
+
+                if (stats.RemainingRulesCount > 0)
+                {
+                    lines.Add($"- *(...and {stats.RemainingRulesCount} more rules accounting for {stats.RemainingFindingsCount} more findings)*");
+                }
+            }
+
+            lines.Add(string.Empty);
+            lines.Add("### Findings in This Batch");
 
             if (findings.Count == 0)
             {
@@ -1586,10 +1662,11 @@ namespace Sarifintown.AgentEngine
             }
             else
             {
-                lines.Add("| Id | Rule | Severity | File Path |\n|---|---|---|---|");
+                lines.Add("| Id | Sev | Status | Rule | Path |");
+                lines.Add("|---|---|---|---|---|");
                 foreach (var finding in findings)
                 {
-                    lines.Add($"| `{EscapeMarkdown(finding.DisplayId)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.Location.File)}` |");
+                    lines.Add($"| `{EscapeMarkdown(finding.DisplayId)}` | `{EscapeMarkdown(finding.Severity)}` | `{EscapeMarkdown(finding.State)}` | `{EscapeMarkdown(finding.Rule)}` | `{EscapeMarkdown(finding.Location.File)}` |");
                 }
 
             }
@@ -2297,7 +2374,18 @@ namespace Sarifintown.AgentEngine
             TriageInspectResult? Evidence,
             string? TriagePrompt = null);
 
-        private sealed record ScopedGetPayload(ScopedContext Context, IReadOnlyList<ScopedFinding> Findings, ScopedAvailableFacets? AvailableFacets = null);
+        private sealed record ScopedGetPayload(
+            ScopedContext Context,
+            IReadOnlyList<ScopedFinding> Findings,
+            ScopedStats Stats,
+            ScopedAvailableFacets? AvailableFacets = null);
+
+        private sealed record ScopedStats(
+            IReadOnlyDictionary<string, int> SeverityCounts,
+            IReadOnlyDictionary<string, int> StatusCounts,
+            IReadOnlyDictionary<string, int> TopRules,
+            int RemainingRulesCount,
+            int RemainingFindingsCount);
 
         private sealed record ScopedAvailableFacets(
             string[] Rules,

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -169,7 +169,7 @@ namespace Sarifintown.AgentEngine
         }
 
         [McpServerTool(Name = "sarif_filter")]
-        [Description("Set or clear the active scope filter for SARIF findings. Uses a space-separated query string (e.g. 'severity:high rule:SQLI status:open path:controllers'). Supported keys: status, severity, rule, path. Call with no arguments to see available filter values. Call sarif_get after filtering to view results.")]
+        [Description("Set or clear the active scope filter for SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities. Uses a space-separated query string (e.g. 'severity:high rule:SQLI status:open path:controllers'). Supported keys: status, severity, rule, path. Call with no arguments to see available filter values.")]
         public static async Task<CallToolResult> SarifFilter(
             [Description("Space-separated filter query (e.g. 'severity:high rule:SQLI status:open path:controllers'). Omit or leave empty to list available filters.")]
             string query = "")
@@ -209,9 +209,9 @@ namespace Sarifintown.AgentEngine
         }
 
         [McpServerTool(Name = "sarif_get")]
-        [Description("Retrieve scoped SARIF findings using the active filter set by sarif_filter. Returns a paginated index of findings. CRITICAL EXECUTION PROTOCOL: (1) Output the content inside the <vulnerability_report> block VERBATIM. (2) Do NOT summarize, interpret, restate, or duplicate. (3) STOP after output and wait for explicit user instruction. (4) Never call sarif_get again unless the user explicitly asks for another page. Use sarif_filter to change filters. To triage a finding, call sarif_review with the target displayid to load code evidence and organizational rules.")]
+        [Description("Retrieve scoped SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities using the active filter. Returns a paginated index of results. Outputs exactly one <vulnerability_report> block VERBATIM without additional commentary.")]
         public static async Task<CallToolResult> SarifGet(
-            [Description("Maximum findings to return (1-25).")]
+            [Description("Maximum findings/issues to return (1-25).")]
             int limit = 10,
             [Description("Optional 1-based page number. When provided, this overrides automatic pagination and pageToken.")]
             int page = 0,
@@ -270,12 +270,11 @@ namespace Sarifintown.AgentEngine
 
         /// <summary>
         /// Context injector: loads deep code evidence and organizational rules for the LLM to analyze.
-        /// After analyzing the output, the LLM should call sarif_update to record its decision.
         /// </summary>
         [McpServerTool(Name = "sarif_review")]
-        [Description("Review, analyze, inspect, or triage a SARIF finding by its displayid. Loads deep code-flow evidence, source snippets, and organizational triage rules so you can determine whether the finding is a true positive or false positive. Accepts a single 'target' parameter (displayid, CSV list, or 'scope'). After reviewing the evidence, call sarif_update to record the decision.")]
+        [Description("Retrieves detailed code-flow evidence, execution context, and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability. Use this to analyze an issue's source code before making a triage decision.")]
         public static async Task<CallToolResult> SarifReview(
-            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to review all open findings in active scope (max 25).")]
+            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), or literal 'scope' to review all open findings/issues in active scope (max 25).")]
             string target)
         {
             if (string.IsNullOrWhiteSpace(target))
@@ -345,15 +344,15 @@ namespace Sarifintown.AgentEngine
         /// Human callers omit llmReasoning to mark the decision as human-reviewed.
         /// </summary>
         [McpServerTool(Name = "sarif_update")]
-        [Description("Record a triage decision. If you are the AI analyzing evidence, you MUST provide your 'llmReasoning'. If a human user explicitly tells you to update a finding, leave 'llmReasoning' empty. CRITICAL EXECUTION PROTOCOL: (1) Call this tool after analyzing sarif_review output. (2) Output the result block VERBATIM. (3) Run sarif_get to verify remaining findings. IMPORTANT: This tool requires four parameters: 'target', 'state', 'reason', and 'llmReasoning'.")]
+        [Description("Records a triage decision for a SARIF (SAST/Secret/SCA) finding/issue/vulnerability into the audit ledger. Requires a state and a reason.")]
         public static async Task<CallToolResult> SarifUpdate(
-            [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to update all open findings in active scope.")]
+            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), or literal 'scope' to update all open findings/issues in active scope.")]
             string target,
             [Description("Decision state: confirmed (true positive), false_positive (not a real issue), test_code (in test/non-production code), wont_fix (accepted risk), or mitigated (already addressed).")]
             string state,
-            [Description("Decision reason explaining why this decision was made.")]
+            [Description("Explicit decision reason explaining why this decision was made.")]
             string reason,
-            [Description("Verbose chain-of-thought analysis. REQUIRED for AI callers. OMIT for human manual overrides.")]
+            [Description("Optional chain-of-thought analysis detailing how the conclusion was reached. Leave empty for human manual overrides.")]
             string llmReasoning = "")
         {
             if (string.IsNullOrWhiteSpace(target))
@@ -529,7 +528,7 @@ namespace Sarifintown.AgentEngine
         /// Pushes pending local triage decisions from the audit ledger to upstream vendor APIs.
         /// </summary>
         [McpServerTool(Name = "sarif_sync")]
-        [Description("Push local review decisions to upstream vendor APIs. Only processes entries with 'pending' sync status. Call this after using sarif_review to record decisions.")]
+        [Description("Pushes pending local triage decisions for SARIF (SAST/Secret/SCA) findings/issues/vulnerabilities to upstream vendor APIs.")]
         public static async Task<CallToolResult> SarifSync(
             [Description("Target: 'pending' to sync all pending entries, or specific composite keys (comma-separated).")]
             string target = "pending")
@@ -1700,7 +1699,7 @@ namespace Sarifintown.AgentEngine
             }
 
             lines.Add(string.Empty);
-            lines.Add("To triage a finding, call `sarif_review` with the target displayid to load code evidence and organizational rules.");
+            lines.Add("To review/triage a finding, call `sarif_review` with the target displayid to load code evidence and organizational rules.");
             if (pagination.HasMore)
             {
                 lines.Add($"More findings are available. Use `page` `{pagination.NextPageNumber}` or `context.pagination.next_page_token` to fetch the next batch.");

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -1147,49 +1147,6 @@ namespace Sarifintown.AgentEngine
             };
         }
 
-        private static ActiveScopeFilter ParseScopeFilter(string filter)
-        {
-            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var token in SplitFilterTokens(filter))
-            {
-                var separatorIndex = token.IndexOf(':');
-                if (separatorIndex <= 0 || separatorIndex == token.Length - 1)
-                {
-                    continue;
-                }
-
-                var key = token[..separatorIndex].Trim();
-                var value = token[(separatorIndex + 1)..].Trim().Trim('"', '\'');
-
-                if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
-                {
-                    map[key] = value;
-                }
-            }
-
-            map.TryGetValue("severity", out var severity);
-            map.TryGetValue("rule", out var rule);
-
-            if (string.IsNullOrWhiteSpace(rule) && map.TryGetValue("ruleId", out var ruleId))
-            {
-                rule = ruleId;
-            }
-
-            map.TryGetValue("file", out var file);
-            if (string.IsNullOrWhiteSpace(file) && map.TryGetValue("path", out var path))
-            {
-                file = path;
-            }
-
-            map.TryGetValue("state", out var state);
-            if (string.IsNullOrWhiteSpace(state) && map.TryGetValue("status", out var status))
-            {
-                state = status;
-            }
-
-            return new ActiveScopeFilter(severity ?? string.Empty, rule ?? string.Empty, file ?? string.Empty, state ?? string.Empty);
-        }
-
         private static ActiveScopeFilter ParseSpaceSeparatedQuery(string query)
         {
             if (string.IsNullOrWhiteSpace(query))
@@ -1265,50 +1222,6 @@ namespace Sarifintown.AgentEngine
                     map[key] = value;
                 }
             }
-        }
-
-        private static IReadOnlyList<string> SplitFilterTokens(string filter)
-        {
-            if (string.IsNullOrWhiteSpace(filter))
-            {
-                return Array.Empty<string>();
-            }
-
-            var result = new List<string>();
-            var buffer = new System.Text.StringBuilder();
-            var inQuotes = false;
-
-            foreach (var ch in filter)
-            {
-                if (ch == '"')
-                {
-                    inQuotes = !inQuotes;
-                    buffer.Append(ch);
-                    continue;
-                }
-
-                if (ch == ',' && !inQuotes)
-                {
-                    var value = buffer.ToString().Trim();
-                    if (!string.IsNullOrWhiteSpace(value))
-                    {
-                        result.Add(value);
-                    }
-
-                    buffer.Clear();
-                    continue;
-                }
-
-                buffer.Append(ch);
-            }
-
-            var trailing = buffer.ToString().Trim();
-            if (!string.IsNullOrWhiteSpace(trailing))
-            {
-                result.Add(trailing);
-            }
-
-            return result;
         }
 
         private static ActiveScopeFilter GetActiveScope()
@@ -1504,13 +1417,6 @@ namespace Sarifintown.AgentEngine
                 scope.State.Trim()).ToLowerInvariant();
         }
 
-        private static string GetWorkspaceRoot()
-        {
-            lock (SyncRoot)
-            {
-                return _workspaceRoot;
-            }
-        }
 
         private static CallToolResult CreateDualPurposeResult(
             string markdown,
@@ -1885,7 +1791,7 @@ namespace Sarifintown.AgentEngine
 
             lines.Add("---");
             lines.Add(string.Empty);
-            lines.Add("Analyze the evidence above using the rules in the system directive. Output your chain of thought, then immediately call `sarif_update` to record your final decision.");
+            lines.Add("Analyze the evidence above using the rules in the system directive. Output your chain of thought, and your final decision.");
 
             return string.Join(Environment.NewLine, lines);
         }
@@ -2448,63 +2354,6 @@ namespace Sarifintown.AgentEngine
             string DisplayId,
             TriageInspectResult? Evidence);
 
-        [Description("MUST: Use this tool to compile extracted flow JSON into a markdown report artifact for downstream analysis.")]
-        public static string GenerateAnalysisReport(
-            [Description("Result identifier for report metadata.")]
-            string resultId,
-            [Description("Extracted flow JSON payload returned by ExtractCodeFlow.")]
-            string extractedFlowData,
-            [Description("Destination markdown file path.")]
-            string outputPath)
-        {
-            try
-            {
-                var flowData = JsonSerializer.Deserialize<JsonElement>(extractedFlowData);
-                string ruleId = flowData.TryGetProperty("rule_id", out var ruleElement) ? ruleElement.GetString() ?? "Unknown_Rule" : "Unknown_Rule";
-
-                var sb = new System.Text.StringBuilder();
-                sb.AppendLine($"# Vulnerability Analysis Report");
-                sb.AppendLine($"**Rule ID:** {ruleId}");
-                sb.AppendLine($"**Result Index:** {resultId}");
-                sb.AppendLine($"**Date Generated:** {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
-                sb.AppendLine("\n## Data Flow Context\n");
-
-                if (flowData.TryGetProperty("flow_steps", out var stepsElement) && stepsElement.ValueKind == JsonValueKind.Array)
-                {
-                    int stepNum = 1;
-                    foreach (var step in stepsElement.EnumerateArray())
-                    {
-                        string file = step.GetProperty("file_path").GetString() ?? "unknown_file";
-                        int line = step.TryGetProperty("start_line", out var lineElem) ? lineElem.GetInt32() : 0;
-                        string snippet = step.GetProperty("code_snippet").GetString() ?? "";
-                        string msg = step.TryGetProperty("message", out var msgElement) ? msgElement.GetString() ?? "" : "";
-
-                        sb.AppendLine($"### Step {stepNum}: {file} (Line {line})");
-                        if (!string.IsNullOrEmpty(msg)) sb.AppendLine($"*Context:* {msg}\n");
-                        sb.AppendLine("```csharp");
-                        sb.AppendLine(snippet);
-                        sb.AppendLine("```\n");
-                        stepNum++;
-                    }
-                }
-                else
-                {
-                    sb.AppendLine("*No valid data flow steps extracted.*");
-                }
-
-                File.WriteAllText(outputPath, sb.ToString());
-
-                return JsonSerializer.Serialize(new
-                {
-                    success = true,
-                    message = "Report generated successfully.",
-                    file_path = Path.GetFullPath(outputPath)
-                });
-            }
-            catch (Exception ex)
-            {
-                return JsonSerializer.Serialize(new { error = $"Failed to generate report: {ex.Message}" });
-            }
-        }
+        
     }
 }

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -38,63 +38,6 @@ namespace Sarifintown.AgentEngine
         private static HashSet<string> _availableSeverities = new(StringComparer.OrdinalIgnoreCase);
         private static HashSet<string> _availableRules = new(StringComparer.OrdinalIgnoreCase);
         private static HashSet<string> _availableStatuses = new(StringComparer.OrdinalIgnoreCase) { "Open", "TP", "FP" };
-        private static readonly string[] IdeHostTokens =
-        [
-            "vscode",
-            "visualstudiocode",
-            "visualstudio",
-            "cursor",
-            "windsurf",
-            "jetbrains",
-            "rider",
-            "zed",
-            "eclipse",
-            "intellij",
-            "xcode"
-        ];
-
-        private static readonly string[] CliHostTokens =
-        [
-            "claudecode",
-            "claude",
-            "codex",
-            "aider",
-            "geminicli",
-            "opencode",
-            "terminal",
-            "bash",
-            "zsh",
-            "fish",
-            "powershell",
-            "pwsh",
-            "cmd",
-            "windowsterminal",
-            "iterm",
-            "tmux",
-            "kitty",
-            "alacritty"
-        ];
-
-        private static readonly string[] VsCodeFamilyTokens =
-        [
-            "vscode",
-            "visualstudiocode",
-            "cursor",
-            "windsurf"
-        ];
-
-        private static readonly string[] JetBrainsFamilyTokens =
-        [
-            "jetbrains",
-            "rider",
-            "intellij",
-            "pycharm",
-            "webstorm",
-            "clion",
-            "goland",
-            "rubymine"
-        ];
-
         public static void SetDiscoveredSarifFiles(IEnumerable<string> discoveredSarifFiles)
         {
             ArgumentNullException.ThrowIfNull(discoveredSarifFiles);
@@ -272,7 +215,7 @@ namespace Sarifintown.AgentEngine
         /// Context injector: loads deep code evidence and organizational rules for the LLM to analyze.
         /// </summary>
         [McpServerTool(Name = "sarif_review")]
-        [Description("Retrieves detailed code-flow evidence, execution context, and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability. Use this to analyze an issue's source code before making a triage decision.")]
+        [Description("Retrieves detailed code-flow evidence, execution context, and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability. Use this to review/triage/analyze a finding/issue/vulnerability.")]
         public static async Task<CallToolResult> SarifReview(
             [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), or literal 'scope' to review all open findings/issues in active scope (max 25).")]
             string target)
@@ -748,62 +691,11 @@ namespace Sarifintown.AgentEngine
             [Description("When true for CLI mode, starts the Spectre.Console menu immediately.")]
             bool startCliMenu = false)
         {
-            var host = DetectHost(thisServer, hostHint);
-            var mode = ResolveHostMode(host);
-            var hostFamily = ResolveHostFamily(host);
-            var usedFallback = string.Equals(host, "unknown", StringComparison.OrdinalIgnoreCase);
-
-            if (mode == "ide-ui")
-            {
-                return JsonSerializer.Serialize(new
-                {
-                    host,
-                    mode,
-                    host_family = hostFamily,
-                    uri = "ui://sarifintown/mcp/dashboard",
-                    local_http_ui = CreateLocalHttpUiPayload(),
-                    bridge = new
-                    {
-                        transport = "postMessage",
-                        channel = "sarifintown.mcp.v1"
-                    },
-                    fallback = new
-                    {
-                        mode = "cli-tui",
-                        library = "Spectre.Console"
-                    }
-                });
-            }
-
-            string selectedAction = string.Empty;
-            string commandResult = string.Empty;
-            if (startCliMenu)
-            {
-                selectedAction = SpectreCliMenu.Start();
-                if (selectedAction.StartsWith("Triage ", StringComparison.Ordinal))
-                {
-                    commandResult = SpectreCliMenu
-                        .ExecuteTriageActionAsync(selectedAction)
-                        .GetAwaiter()
-                        .GetResult();
-                }
-            }
-
-            return JsonSerializer.Serialize(new
-            {
-                host,
-                mode,
-                host_family = hostFamily,
-                fallback_used = usedFallback,
-                local_http_ui = CreateLocalHttpUiPayload(),
-                tui = new
-                {
-                    library = "Spectre.Console",
-                    action = selectedAction,
-                    action_result = commandResult,
-                    menu = "interactive"
-                }
-            });
+            return InteractiveSurfaceResolver.ResolveInteractiveSurface(
+                thisServer,
+                hostHint,
+                startCliMenu,
+                CreateLocalHttpUiPayload);
         }
 
         private static async Task<ScopedGetPayload> ExecutePureGetAsync(int limit, int page = 0, string pageToken = "")
@@ -2076,172 +1968,6 @@ namespace Sarifintown.AgentEngine
                 workspaceRoot,
                 snippetCache,
                 snippetWarmupService);
-        }
-
-        private static string DetectHost(McpServer thisServer, string hostHint)
-        {
-            if (!string.IsNullOrWhiteSpace(hostHint))
-            {
-                return hostHint.Trim();
-            }
-
-            if (thisServer != null)
-            {
-                var hostFromServer = TryGetHostNameFromServer(thisServer);
-                if (!string.IsNullOrWhiteSpace(hostFromServer))
-                {
-                    return hostFromServer;
-                }
-            }
-
-            var hostFromEnvironment = TryGetHostNameFromEnvironment();
-            if (!string.IsNullOrWhiteSpace(hostFromEnvironment))
-            {
-                return hostFromEnvironment;
-            }
-
-            return "unknown";
-        }
-
-        private static string ResolveHostMode(string host)
-        {
-            if (string.IsNullOrWhiteSpace(host))
-            {
-                return "cli-tui";
-            }
-
-            var normalizedHost = NormalizeHost(host);
-
-            if (ContainsAnyToken(normalizedHost, IdeHostTokens))
-            {
-                return "ide-ui";
-            }
-
-            if (ContainsAnyToken(normalizedHost, CliHostTokens))
-            {
-                return "cli-tui";
-            }
-
-            return "cli-tui";
-        }
-
-        private static string ResolveHostFamily(string host)
-        {
-            if (string.IsNullOrWhiteSpace(host))
-            {
-                return "terminal-family";
-            }
-
-            var normalizedHost = NormalizeHost(host);
-
-            if (ContainsAnyToken(normalizedHost, VsCodeFamilyTokens))
-            {
-                return "vscode-family";
-            }
-
-            if (ContainsAnyToken(normalizedHost, JetBrainsFamilyTokens))
-            {
-                return "jetbrains-family";
-            }
-
-            if (normalizedHost.Contains("visualstudio", StringComparison.Ordinal))
-            {
-                return "visualstudio-family";
-            }
-
-            if (normalizedHost.Contains("zed", StringComparison.Ordinal))
-            {
-                return "zed-family";
-            }
-
-            if (ContainsAnyToken(normalizedHost, CliHostTokens))
-            {
-                return "terminal-family";
-            }
-
-            return "unknown-family";
-        }
-
-        private static string TryGetHostNameFromEnvironment()
-        {
-            var directValueVariables = new[]
-            {
-                "MCP_CLIENT_NAME",
-                "MCP_HOST",
-                "MCP_CLIENT",
-                "TERM_PROGRAM",
-                "TERM",
-                "TERMINAL_EMULATOR",
-                "PROMPT_TOOLKIT_SHELL",
-                "VSCODE_CWD",
-                "ELECTRON_RUN_AS_NODE"
-            };
-
-            foreach (var variable in directValueVariables)
-            {
-                var value = Environment.GetEnvironmentVariable(variable);
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    return value.Trim();
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("CLAUDECODE")))
-            {
-                return "Claude Code";
-            }
-
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("CURSOR_TRACE_ID")))
-            {
-                return "Cursor";
-            }
-
-            if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("VSCODE_GIT_IPC_HANDLE")))
-            {
-                return "Visual Studio Code";
-            }
-
-            return string.Empty;
-        }
-
-        private static string NormalizeHost(string host)
-        {
-            var lowered = host.Trim().ToLowerInvariant();
-
-            return string.Concat(lowered.Where(char.IsLetterOrDigit));
-        }
-
-        private static bool ContainsAnyToken(string normalizedHost, IEnumerable<string> tokens)
-        {
-            return tokens.Any(token => normalizedHost.Contains(token, StringComparison.Ordinal));
-        }
-
-        private static string TryGetHostNameFromServer(McpServer server)
-        {
-            var directClientInfo = GetPropertyValue(server, "ClientInfo");
-            var directName = GetPropertyValue(directClientInfo, "Name")?.ToString();
-
-            if (!string.IsNullOrWhiteSpace(directName))
-            {
-                return directName.Trim();
-            }
-
-            var initializeRequest = GetPropertyValue(server, "InitializeRequest");
-            var requestClientInfo = GetPropertyValue(initializeRequest, "ClientInfo");
-            var requestClientName = GetPropertyValue(requestClientInfo, "Name")?.ToString();
-
-            if (!string.IsNullOrWhiteSpace(requestClientName))
-            {
-                return requestClientName.Trim();
-            }
-
-            var session = GetPropertyValue(server, "Session");
-            var sessionClientInfo = GetPropertyValue(session, "ClientInfo");
-            var sessionClientName = GetPropertyValue(sessionClientInfo, "Name")?.ToString();
-
-            return string.IsNullOrWhiteSpace(sessionClientName)
-                ? string.Empty
-                : sessionClientName.Trim();
         }
 
         private static object CreateLocalHttpUiPayload()

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -217,7 +217,7 @@ namespace Sarifintown.AgentEngine
         [McpServerTool(Name = "sarif_review")]
         [Description("Retrieves detailed code-flow evidence, execution context, and organizational rules for a specific SARIF (SAST/Secret/SCA) finding/issue/vulnerability. Use this to review/triage/analyze a finding/issue/vulnerability.")]
         public static async Task<CallToolResult> SarifReview(
-            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), or literal 'scope' to review all open findings/issues in active scope (max 25).")]
+            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), a range (e.g. '1-5'), or literal 'scope' to review all open findings/issues in active scope (max 25).")]
             string target)
         {
             if (string.IsNullOrWhiteSpace(target))
@@ -289,7 +289,7 @@ namespace Sarifintown.AgentEngine
         [McpServerTool(Name = "sarif_update")]
         [Description("Records a triage decision for a SARIF (SAST/Secret/SCA) finding/issue/vulnerability into the audit ledger. Requires a state and a reason.")]
         public static async Task<CallToolResult> SarifUpdate(
-            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), or literal 'scope' to update all open findings/issues in active scope.")]
+            [Description("Target displayid (e.g. '1'), CSV displayid list (e.g. '1,2,3'), a range (e.g. '1-5'), or literal 'scope' to update all open findings/issues in active scope.")]
             string target,
             [Description("Decision state: confirmed (true positive), false_positive (not a real issue), test_code (in test/non-production code), wont_fix (accepted risk), or mitigated (already addressed).")]
             string state,
@@ -1872,9 +1872,38 @@ namespace Sarifintown.AgentEngine
                 return new List<string>();
             }
 
-            return findingIds
-                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                .Distinct(StringComparer.Ordinal)
+            var result = new List<string>();
+            var parts = findingIds.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var part in parts)
+            {
+                var dashIndex = part.IndexOf('-');
+
+                if (dashIndex > 0 && dashIndex < part.Length - 1)
+                {
+                    var left = part[..dashIndex].Trim();
+                    var right = part[(dashIndex + 1)..].Trim();
+
+                    if (int.TryParse(left, out var start) && int.TryParse(right, out var end))
+                    {
+                        var min = Math.Min(start, end);
+                        var max = Math.Max(start, end);
+                        var safeMax = Math.Min(max, min + 100);
+
+                        for (var i = min; i <= safeMax; i++)
+                        {
+                            result.Add(i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                        }
+
+                        continue;
+                    }
+                }
+
+                result.Add(part);
+            }
+
+            return result
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
 

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -170,13 +170,16 @@ namespace Sarifintown.AgentEngine
 
         [McpServerTool(Name = "sarif_filter")]
         [Description("Set or clear the active scope filter for SARIF findings. Uses a space-separated query string (e.g. 'severity:high rule:SQLI status:open path:controllers'). Supported keys: status, severity, rule, path. Call with no arguments to see available filter values. Call sarif_get after filtering to view results.")]
-        public static Task<CallToolResult> SarifFilter(
+        public static async Task<CallToolResult> SarifFilter(
             [Description("Space-separated filter query (e.g. 'severity:high rule:SQLI status:open path:controllers'). Omit or leave empty to list available filters.")]
             string query = "")
         {
             if (string.IsNullOrWhiteSpace(query))
             {
-                return Task.FromResult(BuildAvailableFiltersResult());
+                var result = BuildAvailableFiltersResult();
+                await AppendToExecutionLogAsync("sarif_filter",
+                    $"Input: (empty — list available filters)\n\nOutput:\n{ExtractTextContent(result)}").ConfigureAwait(false);
+                return result;
             }
 
             var normalizedQuery = query.Trim();
@@ -184,7 +187,10 @@ namespace Sarifintown.AgentEngine
             {
                 SetActiveScope(new ActiveScopeFilter());
                 ResetPagination();
-                return Task.FromResult(CreatePlainTextResult("✅ Scope cleared. All filters removed. Run `sarif_get` to view unfiltered results."));
+                var clearResult = CreatePlainTextResult("✅ Scope cleared. All filters removed. Run `sarif_get` to view unfiltered results.");
+                await AppendToExecutionLogAsync("sarif_filter",
+                    $"Input: clear\n\nOutput:\n{ExtractTextContent(clearResult)}").ConfigureAwait(false);
+                return clearResult;
             }
 
             var parsedFilter = ParseSpaceSeparatedQuery(normalizedQuery);
@@ -196,7 +202,10 @@ namespace Sarifintown.AgentEngine
                 ? "none"
                 : string.Join(", ", scopeDict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
 
-            return Task.FromResult(CreatePlainTextResult($"✅ Scope updated. Current filters: {filterDescription}. Run `sarif_get` to view results."));
+            var filterResult = CreatePlainTextResult($"✅ Scope updated. Current filters: {filterDescription}. Run `sarif_get` to view results.");
+            await AppendToExecutionLogAsync("sarif_filter",
+                $"Input: {normalizedQuery}\n\nOutput:\n{ExtractTextContent(filterResult)}").ConfigureAwait(false);
+            return filterResult;
         }
 
         [McpServerTool(Name = "sarif_get")]
@@ -247,8 +256,13 @@ namespace Sarifintown.AgentEngine
             metaObj["pause"] = true;
             metaObj["next_step"] = "sarif_review";
 
+            var getMarkdown = BuildScopedGetMarkdown(payload);
+
+            await AppendToExecutionLogAsync("sarif_get",
+                $"Input: limit={safeLimit}, page={page}, pageToken={pageToken}\n\nOutput:\n{getMarkdown}").ConfigureAwait(false);
+
             return CreateDualPurposeResult(
-                markdown: BuildScopedGetMarkdown(payload),
+                markdown: getMarkdown,
                 systemStateContext: stateContext,
                 resourceUri: BuildUiResourceUri("triage", "sarif_get", string.Empty),
                 additionalMeta: metaObj);
@@ -259,7 +273,7 @@ namespace Sarifintown.AgentEngine
         /// After analyzing the output, the LLM should call sarif_update to record its decision.
         /// </summary>
         [McpServerTool(Name = "sarif_review")]
-        [Description("Load deep code evidence and organizational rules for specific findings. Call this FIRST to analyze a vulnerability before calling sarif_update. CRITICAL EXECUTION PROTOCOL: (1) Call sarif_get first to get target displayids. (2) Call sarif_review with the target displayid(s) to load code evidence and organizational rules. IMPORTANT: This tool ONLY takes the 'target' parameter. Do NOT try to pass 'state' or 'reason' to this tool. (3) Analyze the evidence using the rules in the system directive. (4) AFTER analysis, call sarif_update to record the decision (which does require state and reason). Do NOT stop after this tool; proceed with analysis immediately.")]
+        [Description("Review, analyze, inspect, or triage a SARIF finding by its displayid. Loads deep code-flow evidence, source snippets, and organizational triage rules so you can determine whether the finding is a true positive or false positive. Accepts a single 'target' parameter (displayid, CSV list, or 'scope'). After reviewing the evidence, call sarif_update to record the decision.")]
         public static async Task<CallToolResult> SarifReview(
             [Description("Target displayid (e.g. 1), CSV displayid list (e.g. 1,2,3), or literal 'scope' to review all open findings in active scope (max 25).")]
             string target)
@@ -312,7 +326,7 @@ namespace Sarifintown.AgentEngine
             var reviewMarkdown = BuildReviewContextMarkdown(target, evidenceByFindingId, systemDirective);
 
             await AppendToExecutionLogAsync("sarif_review",
-                $"Target: {target}\n\nEvidence:\n{reviewMarkdown}\n\nSystem Directive:\n{systemDirective ?? "(none)"}").ConfigureAwait(false);
+                $"Input: target={target}\n\nOutput:\n{reviewMarkdown}").ConfigureAwait(false);
 
             var reviewMeta = new JsonObject
             {
@@ -398,9 +412,6 @@ namespace Sarifintown.AgentEngine
 
             await ledger.UpsertAsync(ledgerItems);
 
-            await AppendToExecutionLogAsync("sarif_update",
-                $"Target: {target}\nState: {state}\nReason: {reason}\nllmReasoning: {llmReasoning}").ConfigureAwait(false);
-
             if (isAiTriage)
             {
                 var reviewStateContext = new
@@ -424,15 +435,25 @@ namespace Sarifintown.AgentEngine
                     ["next_step"] = "sarif_get"
                 };
 
+                var aiOutputMarkdown = BuildScopedReviewMarkdown(triagePayload, ledgerItems.Count);
+
+                await AppendToExecutionLogAsync("sarif_update",
+                    $"Input: target={target}, state={state}, reason={reason}, llmReasoning={llmReasoning}\n\nOutput:\n{aiOutputMarkdown}").ConfigureAwait(false);
+
                 return CreateDualPurposeResult(
-                    markdown: BuildScopedReviewMarkdown(triagePayload, ledgerItems.Count),
+                    markdown: aiOutputMarkdown,
                     systemStateContext: reviewStateContext,
                     resourceUri: BuildUiResourceUri("triage", "sarif_update", string.Empty),
                     additionalMeta: aiMeta);
             }
 
+            var humanOutputMarkdown = BuildScopedTriageMarkdown(triagePayload);
+
+            await AppendToExecutionLogAsync("sarif_update",
+                $"Input: target={target}, state={state}, reason={reason}\n\nOutput:\n{humanOutputMarkdown}").ConfigureAwait(false);
+
             return CreateDualPurposeResult(
-                markdown: BuildScopedTriageMarkdown(triagePayload),
+                markdown: humanOutputMarkdown,
                 systemStateContext: null,
                 resourceUri: BuildUiResourceUri("triage", "sarif_update", string.Empty),
                 additionalMeta: null);
@@ -531,7 +552,10 @@ namespace Sarifintown.AgentEngine
 
             if (entriesToSync.Count == 0)
             {
-                return CreatePlainTextResult("ℹ️ No pending entries found in the triage ledger. Nothing to sync.");
+                var noOpResult = CreatePlainTextResult("ℹ️ No pending entries found in the triage ledger. Nothing to sync.");
+                await AppendToExecutionLogAsync("sarif_sync",
+                    $"Input: target={target}\n\nOutput: No pending entries found.").ConfigureAwait(false);
+                return noOpResult;
             }
 
             var now = DateTime.UtcNow;
@@ -597,7 +621,11 @@ namespace Sarifintown.AgentEngine
                 lines.Add("ℹ️ No entries were processed.");
             }
 
-            return CreatePlainTextResult(string.Join(Environment.NewLine, lines));
+            var syncOutput = string.Join(Environment.NewLine, lines);
+            await AppendToExecutionLogAsync("sarif_sync",
+                $"Input: target={target}, entries_to_sync={entriesToSync.Count}\n\nOutput:\n{syncOutput}").ConfigureAwait(false);
+
+            return CreatePlainTextResult(syncOutput);
         }
 
         /// <summary>
@@ -1624,7 +1652,7 @@ namespace Sarifintown.AgentEngine
 
             var lines = new List<string>
             {
-                $"## 🛡️ SARIF Findings (Page {pagination.PageNumber} of {pagination.TotalPages})",
+                $"## SARIF Findings (Page {pagination.PageNumber} of {pagination.TotalPages})",
                 string.Empty,
                 $"**Active Filters:** {EscapeMarkdown(activeFilters)}",
                 $"**Scope Summary:** {metrics.TotalInScope} total issues | Showing {metrics.ReturnedInBatch} in this batch",
@@ -1928,6 +1956,19 @@ namespace Sarifintown.AgentEngine
             {
                 // Silently swallow — logging must never crash the main flow
             }
+        }
+
+        /// <summary>
+        /// Extracts concatenated text from a <see cref="CallToolResult"/> for execution logging.
+        /// </summary>
+        private static string ExtractTextContent(CallToolResult result)
+        {
+            if (result?.Content == null || result.Content.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(Environment.NewLine, result.Content.OfType<TextContentBlock>().Select(b => b.Text));
         }
 
 

--- a/Sarifintown.AgentEngine/TriageLedger.cs
+++ b/Sarifintown.AgentEngine/TriageLedger.cs
@@ -88,6 +88,12 @@ internal sealed record LedgerAuditLog
 
     [JsonPropertyName("human_reviewed")]
     public bool HumanReviewed { get; init; }
+
+    /// <summary>
+    /// The assembled organizational rules prompt injected via sarif_review. Null for human overrides.
+    /// </summary>
+    [JsonPropertyName("system_prompt_used")]
+    public string? SystemPromptUsed { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
Restructure SARIF triage tools: sarif_get now returns a lightweight paginated findings index (no embedded evidence or debug prompt), sarif_review becomes a context injector that loads deep code evidence and an optional system directive, and sarif_update is unified to record decisions for both AI (with llmReasoning) and human callers. Removed startup flags controlling debug/evidence behavior and moved prompt/evidence assembly to runtime via IPromptAssemblyService; added execution logging and persisted SystemPromptUsed into ledger entries. Also updated markdown output (tables/UX), simplified preload options and startup snippet preload to always run, adjusted tests and prompt descriptions accordingly.