### PR TITLE
Add upstream sync providers and sarif_sync logic

### DIFF
--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -57,7 +57,8 @@ Different clients use different top-level keys: `"servers"` (Visual Studio, VS C
       "command": "sarifintown",
       "args": [],
       "env": {
-        "PROJECT_ROOT": "/path/to/your/workspace"
+        "PROJECT_ROOT": "/path/to/your/workspace",
+        "SNYK_ORG_ID": "your-snyk-org-id"
       }
     }
   }
@@ -73,6 +74,7 @@ Different clients use different top-level keys: `"servers"` (Visual Studio, VS C
 | `transport` | Yes | Must be `stdio`. |
 | `command` | Yes | `sarifintown` (global tool) or `dotnet` with `args: ["run", "--project", "..."]`. |
 | `env.PROJECT_ROOT` | Recommended | Absolute path. Ensures deterministic `.sarif` discovery. |
+| `env.SNYK_ORG_ID` | Recommended for `sarif_sync` with Snyk findings | Snyk organization ID used during upstream sync; read from environment, not as a `sarif_sync` command argument. |
 | `env.MCP_CLIENT_NAME` | Optional | Improves host detection (e.g. `"Cursor"`, `"Claude Code"`). Also recognized: `MCP_HOST`, `MCP_CLIENT`. |
 | `cwd` | Optional | Useful for predictable relative paths. |
 
@@ -132,6 +134,14 @@ Tune SARIF preload behavior via env vars:
 |---|---|---|
 | `SARIFINTOWN_Sarif__Strategy` | `None`, `LatestPerTool`, `All` | `LatestPerTool` |
 | `SARIFINTOWN_Sarif__EnableSnippetPreload` | `true` / `false` | `true` |
+
+Sync credentials/context for upstream push operations:
+
+| Variable | Used by | Notes |
+|---|---|---|
+| `SNYK_TOKEN` | `sarif_sync` (Snyk) | Required when syncing Snyk ignore states. |
+| `SNYK_ORG_ID` | `sarif_sync` (Snyk) | Required org identifier for Snyk sync. Provide via MCP `env`; do not pass as a `sarif_sync` command parameter. |
+| `GHAS_TOKEN` / `GITHUB_TOKEN` | `sarif_sync` (GitHub Advanced Security) | Token used for GHAS sync adapters. |
 
 Example:
 

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -33,6 +33,19 @@ namespace Sarifintown.AgentEngine.Tests
             }
         }
 
+        private sealed class StubSnykSuccessHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(System.Net.HttpStatusCode.Created)
+                {
+                    Content = new StringContent("{\"data\":{\"id\":\"ignore-1\"}}")
+                };
+
+                return Task.FromResult(response);
+            }
+        }
+
         [Test]
         public async Task SarifGet_WithKeepAndNoPageToken_AutoAdvancesWithinSameScope()
         {
@@ -1216,7 +1229,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifSync_WithAcceptedSarifSuppression_MarksEntrySyncedWithoutProviderCall()
+        public async Task SarifSync_WithAcceptedSarifSuppression_MarksEntrySkippedWithoutProviderCall()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
@@ -1261,14 +1274,14 @@ namespace Sarifintown.AgentEngine.Tests
                 var syncResult = await SarifTools.SarifSync();
                 var syncText = ((TextContentBlock)syncResult.Content[0]).Text;
 
-                Assert.That(syncText, Contains.Substring("already had accepted SARIF suppressions"));
+                Assert.That(syncText, Contains.Substring("🚫 **1** entries skipped"));
 
                 var ledgerPath = Path.Combine(workspace, ".sarif", "triage-ledger.json");
                 var ledgerJson = await File.ReadAllTextAsync(ledgerPath);
                 using var ledgerDoc = JsonDocument.Parse(ledgerJson);
                 var entry = ledgerDoc.RootElement.GetProperty("entries").EnumerateObject().Single().Value;
-                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("synced"));
-                Assert.That(entry.GetProperty("upstream_state").GetString(), Is.EqualTo("accepted"));
+                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("skipped"));
+                Assert.That(entry.GetProperty("upstream_state").GetString(), Is.EqualTo("not-vulnerable"));
             }
             finally
             {
@@ -1277,7 +1290,7 @@ namespace Sarifintown.AgentEngine.Tests
         }
 
         [Test]
-        public async Task SarifSync_WithConfirmedState_SkipsUpstreamCallAndMarksSyncedWithoutTokens()
+        public async Task SarifSync_WithConfirmedState_SkipsUpstreamCallAndMarksSkippedWithoutTokens()
         {
             var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             var sarifDirectory = Path.Combine(workspace, ".sarif");
@@ -1316,14 +1329,80 @@ namespace Sarifintown.AgentEngine.Tests
                 var syncResult = await SarifTools.SarifSync();
                 var syncText = ((TextContentBlock)syncResult.Content[0]).Text;
 
-                Assert.That(syncText, Contains.Substring("entries synced successfully"));
+                Assert.That(syncText, Contains.Substring("🚫 **1** entries skipped"));
 
                 var ledgerPath = Path.Combine(workspace, ".sarif", "triage-ledger.json");
                 var ledgerJson = await File.ReadAllTextAsync(ledgerPath);
                 using var ledgerDoc = JsonDocument.Parse(ledgerJson);
                 var entry = ledgerDoc.RootElement.GetProperty("entries").EnumerateObject().Single().Value;
-                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("synced"));
+                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("skipped"));
                 Assert.That(entry.GetProperty("upstream_state").GetString(), Is.EqualTo("local-only"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task SarifSync_WithHttpSync_RedactsAuthorizationHeaderInSyncLog()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "sync-http-log.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "tool": {
+                    "driver": {
+                      "name": "SnykCode"
+                    }
+                  },
+                  "results": [
+                    {
+                      "ruleId": "RULE-SYNC-HTTP-LOG",
+                      "level": "error",
+                      "message": { "text": "sync with logging" },
+                      "fingerprints": {
+                        "snyk/asset/finding/v1": "issue-123"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+            SarifTools.SetSyncOptions(new Sarifintown.AgentEngine.Configuration.SyncOptions
+            {
+                SnykToken = "token-secret-value",
+                SnykOrgId = "org-123"
+            });
+
+            SetInternalSarifToolsProperty(
+                "SyncHttpClientFactory",
+                (Func<HttpClient>)(() => CreateSyncHttpClientWithRedactingLogging(workspace, new StubSnykSuccessHandler())));
+
+            try
+            {
+                _ = await SarifTools.SarifGet(limit: 10);
+                _ = await SarifTools.SarifUpdate(target: "1", state: "false_positive", reason: "redaction-check");
+
+                var syncResult = await SarifTools.SarifSync();
+                var syncText = ((TextContentBlock)syncResult.Content[0]).Text;
+                Assert.That(syncText, Contains.Substring("✅ **1** entries synced successfully."));
+
+                var logPath = Path.Combine(workspace, ".sarif", "sarif_sync_http.log");
+                Assert.That(File.Exists(logPath), Is.True);
+
+                var logText = await File.ReadAllTextAsync(logPath);
+                Assert.That(logText, Contains.Substring("Authorization: [REDACTED]"));
+                Assert.That(logText, Does.Not.Contain("token-secret-value"));
             }
             finally
             {
@@ -1355,6 +1434,25 @@ namespace Sarifintown.AgentEngine.Tests
         {
             var property = typeof(SarifTools).GetProperty(propertyName, BindingFlags.Static | BindingFlags.NonPublic);
             property!.SetValue(null, value);
+        }
+
+        private static HttpClient CreateSyncHttpClientWithRedactingLogging(string workspaceRoot, HttpMessageHandler terminalHandler)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+            ArgumentNullException.ThrowIfNull(terminalHandler);
+
+            var assembly = typeof(SarifTools).Assembly;
+            var optionsType = assembly.GetType("Sarifintown.AgentEngine.Sync.SyncHttpLoggingOptions", throwOnError: true)!;
+            var handlerType = assembly.GetType("Sarifintown.AgentEngine.Sync.RedactingHttpLoggingHandler", throwOnError: true)!;
+
+            var options = Activator.CreateInstance(optionsType, workspaceRoot)
+                ?? throw new InvalidOperationException("Unable to create SyncHttpLoggingOptions instance.");
+
+            var loggingHandler = (DelegatingHandler?)(Activator.CreateInstance(handlerType, options)
+                ?? throw new InvalidOperationException("Unable to create RedactingHttpLoggingHandler instance."));
+
+            loggingHandler.InnerHandler = terminalHandler;
+            return new HttpClient(loggingHandler, disposeHandler: true);
         }
     }
 }

--- a/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
+++ b/Sarifintown.AgentEngine.Tests/SarifToolsTests.cs
@@ -351,6 +351,9 @@ namespace Sarifintown.AgentEngine.Tests
             SetInternalSarifToolsProperty("SnippetCache", null);
             SetInternalSarifToolsProperty("SnippetWarmupService", null);
             SetInternalSarifToolsProperty("PromptAssembly", null);
+            SetInternalSarifToolsProperty("LedgerService", null);
+            SetInternalSarifToolsProperty("SyncProvidersOverride", null);
+            SetInternalSarifToolsProperty("SyncHttpClientFactory", null);
             SarifTools.SetDiscoveredSarifFiles(Array.Empty<string>());
             SarifTools.SetLocalUiBaseUrl(string.Empty);
             SarifTools.SetWorkspaceRoot(Directory.GetCurrentDirectory());
@@ -1205,6 +1208,122 @@ namespace Sarifintown.AgentEngine.Tests
                 var reviewText = ((TextContentBlock)reviewResult.Content[0]).Text;
                 Assert.That(reviewText, Contains.Substring("### Finding `1`"));
                 Assert.That(reviewText, Contains.Substring("### Finding `2`"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task SarifSync_WithAcceptedSarifSuppression_MarksEntrySyncedWithoutProviderCall()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "sync-suppression.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "tool": {
+                    "driver": {
+                      "name": "SnykCode"
+                    }
+                  },
+                  "results": [
+                    {
+                      "ruleId": "RULE-SYNC-SUPPRESS",
+                      "level": "error",
+                      "message": { "text": "already suppressed" },
+                      "suppressions": [
+                        {
+                          "kind": "external",
+                          "status": "accepted"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                _ = await SarifTools.SarifGet(limit: 10);
+                _ = await SarifTools.SarifUpdate(target: "1", state: "false_positive", reason: "sync-check");
+
+                var syncResult = await SarifTools.SarifSync();
+                var syncText = ((TextContentBlock)syncResult.Content[0]).Text;
+
+                Assert.That(syncText, Contains.Substring("already had accepted SARIF suppressions"));
+
+                var ledgerPath = Path.Combine(workspace, ".sarif", "triage-ledger.json");
+                var ledgerJson = await File.ReadAllTextAsync(ledgerPath);
+                using var ledgerDoc = JsonDocument.Parse(ledgerJson);
+                var entry = ledgerDoc.RootElement.GetProperty("entries").EnumerateObject().Single().Value;
+                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("synced"));
+                Assert.That(entry.GetProperty("upstream_state").GetString(), Is.EqualTo("accepted"));
+            }
+            finally
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+
+        [Test]
+        public async Task SarifSync_WithConfirmedState_SkipsUpstreamCallAndMarksSyncedWithoutTokens()
+        {
+            var workspace = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            var sarifDirectory = Path.Combine(workspace, ".sarif");
+            Directory.CreateDirectory(sarifDirectory);
+
+            var sarifPath = Path.Combine(sarifDirectory, "sync-confirmed-local.sarif");
+            File.WriteAllText(sarifPath, """
+            {
+              "runs": [
+                {
+                  "tool": {
+                    "driver": {
+                      "name": "SnykCode"
+                    }
+                  },
+                  "results": [
+                    {
+                      "ruleId": "RULE-SYNC-CONFIRMED",
+                      "level": "error",
+                      "message": { "text": "confirmed local state" }
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            SarifTools.SetWorkspaceRoot(workspace);
+            SarifTools.SetDiscoveredSarifFiles(new[] { sarifPath });
+
+            try
+            {
+                _ = await SarifTools.SarifGet(limit: 10);
+                _ = await SarifTools.SarifUpdate(target: "1", state: "confirmed", reason: "confirmed-local");
+
+                var syncResult = await SarifTools.SarifSync();
+                var syncText = ((TextContentBlock)syncResult.Content[0]).Text;
+
+                Assert.That(syncText, Contains.Substring("entries synced successfully"));
+
+                var ledgerPath = Path.Combine(workspace, ".sarif", "triage-ledger.json");
+                var ledgerJson = await File.ReadAllTextAsync(ledgerPath);
+                using var ledgerDoc = JsonDocument.Parse(ledgerJson);
+                var entry = ledgerDoc.RootElement.GetProperty("entries").EnumerateObject().Single().Value;
+                Assert.That(entry.GetProperty("upstream_sync").GetProperty("status").GetString(), Is.EqualTo("synced"));
+                Assert.That(entry.GetProperty("upstream_state").GetString(), Is.EqualTo("local-only"));
             }
             finally
             {

--- a/Sarifintown.AgentEngine/Configuration/SyncOptions.cs
+++ b/Sarifintown.AgentEngine/Configuration/SyncOptions.cs
@@ -1,6 +1,6 @@
 namespace Sarifintown.AgentEngine.Configuration;
 
-public sealed class SyncOptions
+public sealed record SyncOptions
 {
     public const string SectionName = "Sync";
 
@@ -8,7 +8,7 @@ public sealed class SyncOptions
     
     public string? SnykOrgId { get; init; }
     
-    public string? GhasToken { get; init; }
-    
-    public string? GithubToken { get; init; }
+    public string? GitHubToken { get; init; }
+
+    public string? GitHubRepo { get; init; }
 }

--- a/Sarifintown.AgentEngine/Configuration/SyncOptions.cs
+++ b/Sarifintown.AgentEngine/Configuration/SyncOptions.cs
@@ -1,0 +1,14 @@
+namespace Sarifintown.AgentEngine.Configuration;
+
+public sealed class SyncOptions
+{
+    public const string SectionName = "Sync";
+
+    public string? SnykToken { get; init; }
+    
+    public string? SnykOrgId { get; init; }
+    
+    public string? GhasToken { get; init; }
+    
+    public string? GithubToken { get; init; }
+}

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using ModelContextProtocol.Protocol;
 using Sarifintown.AgentEngine;
 using Sarifintown.AgentEngine.Configuration;
+using Sarifintown.AgentEngine.Sync;
 using Sarifintown.Core;
 
 AppDomain.CurrentDomain.UnhandledException += (_, eventArgs) =>
@@ -61,6 +62,12 @@ builder.Services.Configure<PromptAssemblyOptions>(
 builder.Services.Configure<SyncOptions>(
     builder.Configuration.GetSection(SyncOptions.SectionName));
 
+builder.Services.AddSingleton(new SyncHttpLoggingOptions(discovery.WorkspaceRoot));
+builder.Services.AddTransient<RedactingHttpLoggingHandler>();
+builder.Services
+    .AddHttpClient("SyncProviders")
+    .AddHttpMessageHandler<RedactingHttpLoggingHandler>();
+
 // Register Headless Implementations
 builder.Services.AddSingleton<IFileReader>(new NativeFileReader(discovery.WorkspaceRoot));
 builder.Services.AddSingleton<ITreeSitterEngine, V8TreeSitterEngine>();
@@ -112,8 +119,8 @@ var syncOptions = NormalizeSyncOptions(app.Services.GetRequiredService<IOptions<
 WriteStartupInfo(
     $"Sync options loaded: SnykToken={(string.IsNullOrWhiteSpace(syncOptions.SnykToken) ? "missing" : "configured")}, " +
     $"SnykOrgId={(string.IsNullOrWhiteSpace(syncOptions.SnykOrgId) ? "missing" : "configured")}, " +
-    $"GhasToken={(string.IsNullOrWhiteSpace(syncOptions.GhasToken) ? "missing" : "configured")}, " +
-    $"GithubToken={(string.IsNullOrWhiteSpace(syncOptions.GithubToken) ? "missing" : "configured")}");
+    $"GitHubToken={(string.IsNullOrWhiteSpace(syncOptions.GitHubToken) ? "missing" : "configured")}, " +
+    $"GitHubRepo={(string.IsNullOrWhiteSpace(syncOptions.GitHubRepo) ? "missing" : "configured")}");
 
 // Inject dependencies into SarifTools
 SarifTools.FileReader = app.Services.GetRequiredService<IFileReader>();
@@ -122,6 +129,7 @@ SarifTools.StateService = sarifStateService;
 SarifTools.SnippetCache = snippetCacheService;
 SarifTools.SnippetWarmupService = snippetWarmupService;
 SarifTools.PromptAssembly = app.Services.GetRequiredService<IPromptAssemblyService>();
+SarifTools.SyncHttpClientFactory = () => app.Services.GetRequiredService<IHttpClientFactory>().CreateClient("SyncProviders");
 SarifTools.SetSyncOptions(syncOptions);
 SarifTools.SetDiscoveredSarifFiles(discovery.SarifFiles);
 SarifTools.SetLocalUiBaseUrl(string.Empty);
@@ -323,8 +331,8 @@ static SyncOptions NormalizeSyncOptions(SyncOptions? options)
     {
         SnykToken = options?.SnykToken?.Trim(),
         SnykOrgId = options?.SnykOrgId?.Trim(),
-        GhasToken = options?.GhasToken?.Trim(),
-        GithubToken = options?.GithubToken?.Trim()
+        GitHubToken = options?.GitHubToken?.Trim(),
+        GitHubRepo = options?.GitHubRepo?.Trim()
     };
 }
 

--- a/Sarifintown.AgentEngine/Program.cs
+++ b/Sarifintown.AgentEngine/Program.cs
@@ -58,6 +58,9 @@ builder.Services.Configure<SarifOptions>(
 builder.Services.Configure<PromptAssemblyOptions>(
     builder.Configuration.GetSection(PromptAssemblyOptions.SectionName));
 
+builder.Services.Configure<SyncOptions>(
+    builder.Configuration.GetSection(SyncOptions.SectionName));
+
 // Register Headless Implementations
 builder.Services.AddSingleton<IFileReader>(new NativeFileReader(discovery.WorkspaceRoot));
 builder.Services.AddSingleton<ITreeSitterEngine, V8TreeSitterEngine>();
@@ -104,6 +107,13 @@ await RunStartupStageAsync("SARIF state initialization", () => sarifStateService
 
 var snippetCacheService = app.Services.GetRequiredService<SnippetCacheService>();
 var snippetWarmupService = app.Services.GetRequiredService<SnippetWarmupService>();
+var syncOptions = NormalizeSyncOptions(app.Services.GetRequiredService<IOptions<SyncOptions>>().Value);
+
+WriteStartupInfo(
+    $"Sync options loaded: SnykToken={(string.IsNullOrWhiteSpace(syncOptions.SnykToken) ? "missing" : "configured")}, " +
+    $"SnykOrgId={(string.IsNullOrWhiteSpace(syncOptions.SnykOrgId) ? "missing" : "configured")}, " +
+    $"GhasToken={(string.IsNullOrWhiteSpace(syncOptions.GhasToken) ? "missing" : "configured")}, " +
+    $"GithubToken={(string.IsNullOrWhiteSpace(syncOptions.GithubToken) ? "missing" : "configured")}");
 
 // Inject dependencies into SarifTools
 SarifTools.FileReader = app.Services.GetRequiredService<IFileReader>();
@@ -112,6 +122,7 @@ SarifTools.StateService = sarifStateService;
 SarifTools.SnippetCache = snippetCacheService;
 SarifTools.SnippetWarmupService = snippetWarmupService;
 SarifTools.PromptAssembly = app.Services.GetRequiredService<IPromptAssemblyService>();
+SarifTools.SetSyncOptions(syncOptions);
 SarifTools.SetDiscoveredSarifFiles(discovery.SarifFiles);
 SarifTools.SetLocalUiBaseUrl(string.Empty);
 SarifTools.SetWorkspaceRoot(discovery.WorkspaceRoot);
@@ -304,6 +315,17 @@ static bool TryGetProperty(JsonElement element, string propertyName, out JsonEle
 
     value = default;
     return false;
+}
+
+static SyncOptions NormalizeSyncOptions(SyncOptions? options)
+{
+    return new SyncOptions
+    {
+        SnykToken = options?.SnykToken?.Trim(),
+        SnykOrgId = options?.SnykOrgId?.Trim(),
+        GhasToken = options?.GhasToken?.Trim(),
+        GithubToken = options?.GithubToken?.Trim()
+    };
 }
 
 var localUiBaseUrl = app.Urls.FirstOrDefault(url =>

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -3,6 +3,8 @@ using ModelContextProtocol.Protocol;
 using Microsoft.Extensions.Options;
 using Sarifintown.Core;
 using Sarifintown.AgentEngine.Configuration;
+using Sarifintown.AgentEngine.Sync;
+using Sarifintown.AgentEngine.Sync.Snyk;
 using Sarifintown.Helpers;
 using Sarifintown.Models;
 using System.ComponentModel;
@@ -23,6 +25,9 @@ namespace Sarifintown.AgentEngine
         internal static SnippetWarmupService? SnippetWarmupService { get; set; }
         internal static IPromptAssemblyService? PromptAssembly { get; set; }
         internal static TriageLedgerService? LedgerService { get; set; }
+        internal static IReadOnlyList<IUpstreamSyncProvider>? SyncProvidersOverride { get; set; }
+        internal static Func<HttpClient>? SyncHttpClientFactory { get; set; }
+        private static readonly HttpClient SharedSyncHttpClient = new();
         private static readonly object SyncRoot = new();
         public const string StateContextDelimiter = "===SARIF_STATE_CONTEXT===";
         private const int MaxEvidenceInspectCount = 25;
@@ -348,7 +353,7 @@ namespace Sarifintown.AgentEngine
 
             var now = DateTime.UtcNow;
             var ledgerItems = await BuildLedgerItemsAsync(
-                triagePayload, parsedDecision, reason, author,
+                ledger, triagePayload, parsedDecision, reason, author,
                 humanReviewed: !isAiTriage,
                 llmReasoning, now, systemPromptUsed);
 
@@ -405,6 +410,7 @@ namespace Sarifintown.AgentEngine
         /// Builds ledger entries from a completed triage payload. Shared by SarifUpdate AI and human paths.
         /// </summary>
         private static async Task<List<(string CompositeKey, LedgerEntry Entry)>> BuildLedgerItemsAsync(
+            TriageLedgerService ledger,
             ScopedTriagePayload triagePayload,
             TriageDecisionState parsedDecision,
             string reason,
@@ -416,10 +422,23 @@ namespace Sarifintown.AgentEngine
         {
             var ledgerItems = new List<(string CompositeKey, LedgerEntry Entry)>();
 
+            var keysToLoad = new List<string>();
             foreach (var findingId in triagePayload.ModifiedFindingIds)
             {
                 var toolName = await ResolveToolNameForFindingAsync(findingId);
                 var compositeKey = TriageLedgerDocument.BuildCompositeKey(toolName, findingId);
+                keysToLoad.Add(compositeKey);
+            }
+
+            var existingEntries = (await ledger.GetByKeysAsync(keysToLoad))
+                .ToDictionary(k => k.CompositeKey, v => v.Entry, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var findingId in triagePayload.ModifiedFindingIds)
+            {
+                var toolName = await ResolveToolNameForFindingAsync(findingId);
+                var compositeKey = TriageLedgerDocument.BuildCompositeKey(toolName, findingId);
+
+                existingEntries.TryGetValue(compositeKey, out var existingEntry);
 
                 string filePath = string.Empty;
                 string ruleId = string.Empty;
@@ -432,8 +451,14 @@ namespace Sarifintown.AgentEngine
                     ruleId = evidence.Evidence.RuleId;
                 }
 
+                var upstreamProvider = ResolveUpstreamProviderName(toolName);
+
                 var entry = new LedgerEntry
                 {
+                    RecordId = existingEntry?.RecordId ?? Guid.NewGuid(),
+                    PartitionKey = existingEntry?.PartitionKey ?? BuildPartitionKey(toolName),
+                    UpstreamProvider = upstreamProvider,
+                    UpstreamState = ResolveUpstreamState(upstreamProvider, parsedDecision),
                     Metadata = new LedgerMetadata
                     {
                         FindingId = findingId,
@@ -477,6 +502,13 @@ namespace Sarifintown.AgentEngine
             string target = "pending")
         {
             var ledger = GetOrCreateLedgerService();
+            var providers = GetSyncProviders();
+
+            var snykToken = Environment.GetEnvironmentVariable("SNYK_TOKEN") ?? string.Empty;
+            var snykOrgId = Environment.GetEnvironmentVariable("SNYK_ORG_ID") ?? string.Empty;
+            var ghasToken = Environment.GetEnvironmentVariable("GHAS_TOKEN")
+                            ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN")
+                            ?? string.Empty;
 
             IReadOnlyList<(string CompositeKey, LedgerEntry Entry)> entriesToSync;
             if (string.Equals(target, "pending", StringComparison.OrdinalIgnoreCase)
@@ -503,33 +535,122 @@ namespace Sarifintown.AgentEngine
             var now = DateTime.UtcNow;
             var syncedCount = 0;
             var failedCount = 0;
+            var pendingCount = 0;
+            var alreadySuppressedCount = 0;
+            var aborted = false;
             var syncedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var failedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var updatedItems = new List<(string CompositeKey, LedgerEntry Entry)>();
+            var findingsById = await LoadFindingsByIdAsync().ConfigureAwait(false);
 
             foreach (var (compositeKey, entry) in entriesToSync)
             {
+                var findingId = entry.Metadata.FindingId;
                 var platform = entry.Metadata.ToolName;
-                var (success, errorMessage) = await TrySyncToUpstreamAsync(entry);
+
+                if (!findingsById.TryGetValue(findingId, out var findingEnvelope))
+                {
+                    var missingFindingSync = entry.UpstreamSync with
+                    {
+                        Status = UpstreamSyncStatus.Failed,
+                        LastSyncAttempt = now,
+                        ErrorMessage = "Finding was not found in current SARIF state."
+                    };
+
+                    updatedItems.Add((compositeKey, entry with
+                    {
+                        UpstreamSync = missingFindingSync
+                    }));
+
+                    failedCount++;
+                    failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
+                    continue;
+                }
+
+                if (HasAcceptedSuppression(findingEnvelope))
+                {
+                    var acceptedSync = entry.UpstreamSync with
+                    {
+                        Status = UpstreamSyncStatus.Synced,
+                        LastSyncAttempt = now,
+                        ErrorMessage = null
+                    };
+
+                    updatedItems.Add((compositeKey, entry with
+                    {
+                        UpstreamState = "accepted",
+                        UpstreamSync = acceptedSync
+                    }));
+
+                    syncedCount++;
+                    alreadySuppressedCount++;
+                    syncedByPlatform[platform] = syncedByPlatform.GetValueOrDefault(platform) + 1;
+                    continue;
+                }
+
+                var toolDriverName = findingEnvelope.Run?.Tool?.Driver?.Name ?? platform;
+                var provider = providers.FirstOrDefault(candidate => candidate.CanHandle(toolDriverName));
+                if (provider == null)
+                {
+                    var unsupportedSync = entry.UpstreamSync with
+                    {
+                        Status = UpstreamSyncStatus.Failed,
+                        LastSyncAttempt = now,
+                        ErrorMessage = $"Unsupported platform: '{toolDriverName}'. No sync adapter registered."
+                    };
+
+                    updatedItems.Add((compositeKey, entry with { UpstreamSync = unsupportedSync }));
+                    failedCount++;
+                    failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
+                    continue;
+                }
+
+                var syncContext = provider.ProviderName switch
+                {
+                    "Snyk" => new SyncContext(snykToken, snykOrgId),
+                    "GitHubAdvancedSecurity" => new SyncContext(ghasToken, string.Empty),
+                    _ => new SyncContext(string.Empty, string.Empty)
+                };
+
+                var result = await provider
+                    .SyncTriageAsync(entry, findingEnvelope.Result, syncContext, CancellationToken.None)
+                    .ConfigureAwait(false);
 
                 var updatedSync = entry.UpstreamSync with
                 {
-                    Status = success ? UpstreamSyncStatus.Synced : UpstreamSyncStatus.Failed,
+                    Status = result.Status,
                     LastSyncAttempt = now,
-                    ErrorMessage = success ? null : errorMessage
+                    ErrorMessage = result.ErrorMessage
                 };
 
-                updatedItems.Add((compositeKey, entry with { UpstreamSync = updatedSync }));
+                var updatedEntry = entry with
+                {
+                    UpstreamProvider = provider.ProviderName,
+                    UpstreamState = ResolveUpstreamState(provider.ProviderName, entry.TriageDecision.State),
+                    UpstreamSync = updatedSync
+                };
 
-                if (success)
+                updatedItems.Add((compositeKey, updatedEntry));
+
+                if (result.Status == UpstreamSyncStatus.Synced)
                 {
                     syncedCount++;
                     syncedByPlatform[platform] = syncedByPlatform.GetValueOrDefault(platform) + 1;
+                }
+                else if (result.Status == UpstreamSyncStatus.Pending)
+                {
+                    pendingCount++;
                 }
                 else
                 {
                     failedCount++;
                     failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
+                }
+
+                if (result.ShouldAbortBatch)
+                {
+                    aborted = true;
+                    break;
                 }
             }
 
@@ -546,6 +667,16 @@ namespace Sarifintown.AgentEngine
                 }
             }
 
+            if (alreadySuppressedCount > 0)
+            {
+                lines.Add($"🟰 **{alreadySuppressedCount}** entries already had accepted SARIF suppressions and were marked synced.");
+            }
+
+            if (pendingCount > 0)
+            {
+                lines.Add($"⏸️ **{pendingCount}** entries remain pending (for example, rate-limited sync attempts).");
+            }
+
             if (failedCount > 0)
             {
                 lines.Add($"❌ **{failedCount}** entries failed to sync.");
@@ -558,7 +689,13 @@ namespace Sarifintown.AgentEngine
                 lines.Add("Check the triage ledger for error details. Fix credentials and retry with `sarif_sync`.");
             }
 
-            if (syncedCount == 0 && failedCount == 0)
+            if (aborted)
+            {
+                lines.Add(string.Empty);
+                lines.Add("⚠️ Batch processing stopped early due to an authentication/permissions failure.");
+            }
+
+            if (syncedCount == 0 && failedCount == 0 && pendingCount == 0)
             {
                 lines.Add("ℹ️ No entries were processed.");
             }
@@ -570,47 +707,105 @@ namespace Sarifintown.AgentEngine
             return CreatePlainTextResult(syncOutput);
         }
 
-        /// <summary>
-        /// Attempts to sync a single ledger entry to its upstream vendor platform.
-        /// Returns (success, errorMessage).
-        /// </summary>
-        private static Task<(bool Success, string? ErrorMessage)> TrySyncToUpstreamAsync(LedgerEntry entry)
+        private static IReadOnlyDictionary<string, TriageFindingEnvelope> LoadFindingsByIdAsyncResult(IReadOnlyList<TriageFindingEnvelope> findings)
         {
-            ArgumentNullException.ThrowIfNull(entry);
+            return findings
+                .GroupBy(item => item.FindingId, StringComparer.Ordinal)
+                .Select(group => group.First())
+                .ToDictionary(item => item.FindingId, item => item, StringComparer.Ordinal);
+        }
 
-            var platform = entry.Metadata.ToolName.Trim().ToLowerInvariant();
+        private static async Task<IReadOnlyDictionary<string, TriageFindingEnvelope>> LoadFindingsByIdAsync()
+        {
+            var stateService = GetOrCreateStateService();
+            var findings = await stateService.GetFindingsAsync().ConfigureAwait(false);
+            return LoadFindingsByIdAsyncResult(findings);
+        }
 
-            return platform switch
+        private static bool HasAcceptedSuppression(TriageFindingEnvelope findingEnvelope)
+        {
+            ArgumentNullException.ThrowIfNull(findingEnvelope);
+
+            var result = findingEnvelope.Result;
+            return result.Suppressions != null
+                   && result.Suppressions.Any(s => string.Equals(s.Status, "accepted", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static IReadOnlyList<IUpstreamSyncProvider> GetSyncProviders()
+        {
+            if (SyncProvidersOverride != null && SyncProvidersOverride.Count > 0)
             {
-                "snyk" or "snyk code" => TrySyncToSnykAsync(entry),
-                "github-advanced-security" or "codeql" or "github" => TrySyncToGhasAsync(entry),
-                _ => Task.FromResult<(bool, string?)>((false, $"Unsupported platform: '{entry.Metadata.ToolName}'. No sync adapter registered."))
+                return SyncProvidersOverride;
+            }
+
+            var httpClient = SyncHttpClientFactory?.Invoke() ?? SharedSyncHttpClient;
+            return new IUpstreamSyncProvider[]
+            {
+                new SnykSyncProvider(httpClient),
+                new GhasSyncProvider()
             };
         }
 
-        private static Task<(bool Success, string? ErrorMessage)> TrySyncToSnykAsync(LedgerEntry entry)
+        private static string ResolveUpstreamState(string providerName, TriageDecisionState localState)
         {
-            var token = Environment.GetEnvironmentVariable("SNYK_TOKEN");
-            if (string.IsNullOrWhiteSpace(token))
+            if (string.Equals(providerName, "Snyk", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.FromResult<(bool, string?)>((false, "SNYK_TOKEN environment variable is not set."));
+                return SnykSyncProvider.TryMapDecisionToReasonType(localState, out var reasonType, out _)
+                    ? reasonType
+                    : "local-only";
             }
 
-            // Stub: actual Snyk API integration will be implemented when vendor SDK is available.
-            return Task.FromResult<(bool, string?)>((true, null));
+            return localState switch
+            {
+                TriageDecisionState.FalsePositive => "false_positive",
+                TriageDecisionState.WontFix => "wont_fix",
+                TriageDecisionState.TestCode => "test_code",
+                TriageDecisionState.Confirmed => "confirmed",
+                TriageDecisionState.Mitigated => "mitigated",
+                _ => string.Empty
+            };
         }
 
-        private static Task<(bool Success, string? ErrorMessage)> TrySyncToGhasAsync(LedgerEntry entry)
+        private static string ResolveUpstreamProviderName(string toolName)
         {
-            var token = Environment.GetEnvironmentVariable("GHAS_TOKEN")
-                        ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-            if (string.IsNullOrWhiteSpace(token))
+            if (string.IsNullOrWhiteSpace(toolName))
             {
-                return Task.FromResult<(bool, string?)>((false, "GHAS_TOKEN (or GITHUB_TOKEN) environment variable is not set."));
+                return "unknown";
             }
 
-            // Stub: actual GitHub Advanced Security API integration will be implemented when vendor SDK is available.
-            return Task.FromResult<(bool, string?)>((true, null));
+            var normalized = toolName.Trim().ToLowerInvariant();
+
+            if (normalized.Contains("snyk", StringComparison.Ordinal))
+            {
+                return "Snyk";
+            }
+
+            if (normalized.Contains("codeql", StringComparison.Ordinal)
+                || normalized.Contains("github", StringComparison.Ordinal))
+            {
+                return "GitHubAdvancedSecurity";
+            }
+
+            return "unknown";
+        }
+
+        private static string BuildPartitionKey(string toolName)
+        {
+            var organization = Environment.GetEnvironmentVariable("SNYK_ORG_ID") ?? "local";
+            string workspaceRoot;
+            lock (SyncRoot)
+            {
+                workspaceRoot = _workspaceRoot;
+            }
+
+            var repository = Path.GetFileName(workspaceRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                repository = "workspace";
+            }
+
+            var provider = string.IsNullOrWhiteSpace(toolName) ? "unknown" : toolName.Trim().ToLowerInvariant();
+            return $"{organization}|{repository}|{provider}";
         }
 
         private static bool TryParseTriageDecisionState(string state, out TriageDecisionState parsed)
@@ -663,14 +858,46 @@ namespace Sarifintown.AgentEngine
             return service;
         }
 
+        private static SarifStateService GetOrCreateStateService()
+        {
+            var stateService = StateService;
+            if (stateService != null)
+            {
+                return stateService;
+            }
+
+            if (FileReader == null)
+            {
+                throw new InvalidOperationException("Core engines are not initialized.");
+            }
+
+            List<string> discoveredFiles;
+            string workspaceRoot;
+
+            lock (SyncRoot)
+            {
+                discoveredFiles = _discoveredSarifFiles.ToList();
+                workspaceRoot = _workspaceRoot;
+            }
+
+            stateService = new SarifStateService(
+                FileReader,
+                Options.Create(new SarifOptions
+                {
+                    Strategy = PreloadStrategy.LatestPerTool,
+                    EnableSnippetPreload = true
+                }),
+                workspaceRoot,
+                discoveredFiles);
+
+            StateService = stateService;
+            return stateService;
+        }
+
         private static async Task<string> ResolveToolNameForFindingAsync(
             string findingId)
         {
-            var stateService = StateService;
-            if (stateService == null)
-            {
-                return "unknown-tool";
-            }
+            var stateService = GetOrCreateStateService();
 
             var findings = await stateService.GetFindingsAsync();
             var finding = findings.FirstOrDefault(f => string.Equals(f.FindingId, findingId, StringComparison.Ordinal));
@@ -1966,27 +2193,15 @@ namespace Sarifintown.AgentEngine
                 throw new InvalidOperationException("Core engines are not initialized.");
             }
 
-            List<string> discoveredFiles;
             string workspaceRoot;
-            var stateService = StateService;
+            var stateService = GetOrCreateStateService();
             var snippetCache = SnippetCache;
             var snippetWarmupService = SnippetWarmupService;
 
             lock (SyncRoot)
             {
-                discoveredFiles = _discoveredSarifFiles.ToList();
                 workspaceRoot = _workspaceRoot;
             }
-
-            stateService ??= new SarifStateService(
-                FileReader,
-                Options.Create(new SarifOptions
-                {
-                    Strategy = PreloadStrategy.LatestPerTool,
-                    EnableSnippetPreload = true
-                }),
-                workspaceRoot,
-                discoveredFiles);
 
             snippetCache ??= new SnippetCacheService();
 

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -94,8 +94,8 @@ namespace Sarifintown.AgentEngine
                 {
                     SnykToken = options.SnykToken?.Trim(),
                     SnykOrgId = options.SnykOrgId?.Trim(),
-                    GhasToken = options.GhasToken?.Trim(),
-                    GithubToken = options.GithubToken?.Trim()
+                    GitHubToken = options.GitHubToken?.Trim(),
+                    GitHubRepo = options.GitHubRepo?.Trim()
                 };
             }
         }
@@ -437,6 +437,7 @@ namespace Sarifintown.AgentEngine
             DateTime timestamp,
             string? systemPromptUsed)
         {
+            var syncOptions = GetSyncOptions();
             var ledgerItems = new List<(string CompositeKey, LedgerEntry Entry)>();
 
             var keysToLoad = new List<string>();
@@ -473,7 +474,7 @@ namespace Sarifintown.AgentEngine
                 var entry = new LedgerEntry
                 {
                     RecordId = existingEntry?.RecordId ?? Guid.NewGuid(),
-                    PartitionKey = existingEntry?.PartitionKey ?? BuildPartitionKey(toolName),
+                    PartitionKey = existingEntry?.PartitionKey ?? BuildPartitionKey(toolName, syncOptions),
                     UpstreamProvider = upstreamProvider,
                     UpstreamState = ResolveUpstreamState(upstreamProvider, parsedDecision),
                     Metadata = new LedgerMetadata
@@ -522,12 +523,6 @@ namespace Sarifintown.AgentEngine
             var providers = GetSyncProviders();
             var syncOptions = GetSyncOptions();
 
-            var snykToken = syncOptions.SnykToken ?? string.Empty;
-            var snykOrgId = syncOptions.SnykOrgId ?? string.Empty;
-            var ghasToken = syncOptions.GhasToken
-                            ?? syncOptions.GithubToken
-                            ?? string.Empty;
-
             IReadOnlyList<(string CompositeKey, LedgerEntry Entry)> entriesToSync;
             if (string.Equals(target, "pending", StringComparison.OrdinalIgnoreCase)
                 || string.IsNullOrWhiteSpace(target))
@@ -551,20 +546,32 @@ namespace Sarifintown.AgentEngine
             }
 
             var now = DateTime.UtcNow;
-            var syncedCount = 0;
+            var newSyncedCount = 0;
+            var idempotentSyncedCount = 0;
+            var skippedCount = 0;
             var failedCount = 0;
             var pendingCount = 0;
-            var alreadySuppressedCount = 0;
             var aborted = false;
-            var syncedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var newSyncedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var idempotentByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var skippedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var failedByPlatform = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var updatedItems = new List<(string CompositeKey, LedgerEntry Entry)>();
             var findingsById = await LoadFindingsByIdAsync().ConfigureAwait(false);
 
+            string syncLogPath;
+            lock (SyncRoot)
+            {
+                syncLogPath = Path.Combine(Path.GetFullPath(_workspaceRoot), ".sarif", "sarif_sync_http.log");
+            }
+
+            await AppendToSyncLogAsync(
+                $"[{now:O}] Sync batch started | target={target} | entries={entriesToSync.Count} | logFile={syncLogPath}{Environment.NewLine}").ConfigureAwait(false);
+
             foreach (var (compositeKey, entry) in entriesToSync)
             {
                 var findingId = entry.Metadata.FindingId;
-                var platform = entry.Metadata.ToolName;
+                var platform = FormatPlatformLabel(entry.Metadata.ToolName);
 
                 if (!findingsById.TryGetValue(findingId, out var findingEnvelope))
                 {
@@ -582,27 +589,8 @@ namespace Sarifintown.AgentEngine
 
                     failedCount++;
                     failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
-                    continue;
-                }
-
-                if (HasAcceptedSuppression(findingEnvelope))
-                {
-                    var acceptedSync = entry.UpstreamSync with
-                    {
-                        Status = UpstreamSyncStatus.Synced,
-                        LastSyncAttempt = now,
-                        ErrorMessage = null
-                    };
-
-                    updatedItems.Add((compositeKey, entry with
-                    {
-                        UpstreamState = "accepted",
-                        UpstreamSync = acceptedSync
-                    }));
-
-                    syncedCount++;
-                    alreadySuppressedCount++;
-                    syncedByPlatform[platform] = syncedByPlatform.GetValueOrDefault(platform) + 1;
+                    await AppendToSyncLogAsync(
+                        $"  [{platform}] {findingId} -> FAILED (finding not found in SARIF state, no HTTP call){Environment.NewLine}").ConfigureAwait(false);
                     continue;
                 }
 
@@ -620,18 +608,13 @@ namespace Sarifintown.AgentEngine
                     updatedItems.Add((compositeKey, entry with { UpstreamSync = unsupportedSync }));
                     failedCount++;
                     failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
+                    await AppendToSyncLogAsync(
+                        $"  [{platform}] {findingId} -> FAILED (no sync adapter for '{toolDriverName}', no HTTP call){Environment.NewLine}").ConfigureAwait(false);
                     continue;
                 }
 
-                var syncContext = provider.ProviderName switch
-                {
-                    "Snyk" => new SyncContext(snykToken, snykOrgId),
-                    "GitHubAdvancedSecurity" => new SyncContext(ghasToken, string.Empty),
-                    _ => new SyncContext(string.Empty, string.Empty)
-                };
-
                 var result = await provider
-                    .SyncTriageAsync(entry, findingEnvelope.Result, syncContext, CancellationToken.None)
+                    .SyncTriageAsync(entry, findingEnvelope.Result, syncOptions, CancellationToken.None)
                     .ConfigureAwait(false);
 
                 var updatedSync = entry.UpstreamSync with
@@ -652,8 +635,21 @@ namespace Sarifintown.AgentEngine
 
                 if (result.Status == UpstreamSyncStatus.Synced)
                 {
-                    syncedCount++;
-                    syncedByPlatform[platform] = syncedByPlatform.GetValueOrDefault(platform) + 1;
+                    if (IsIdempotentSync(result))
+                    {
+                        idempotentSyncedCount++;
+                        idempotentByPlatform[platform] = idempotentByPlatform.GetValueOrDefault(platform) + 1;
+                    }
+                    else
+                    {
+                        newSyncedCount++;
+                        newSyncedByPlatform[platform] = newSyncedByPlatform.GetValueOrDefault(platform) + 1;
+                    }
+                }
+                else if (result.Status == UpstreamSyncStatus.Skipped)
+                {
+                    skippedCount++;
+                    skippedByPlatform[platform] = skippedByPlatform.GetValueOrDefault(platform) + 1;
                 }
                 else if (result.Status == UpstreamSyncStatus.Pending)
                 {
@@ -665,6 +661,9 @@ namespace Sarifintown.AgentEngine
                     failedByPlatform[platform] = failedByPlatform.GetValueOrDefault(platform) + 1;
                 }
 
+                await AppendToSyncLogAsync(
+                    $"  [{platform}] {findingId} | state={entry.TriageDecision.State} | provider={provider.ProviderName} -> {result.Status}{(string.IsNullOrWhiteSpace(result.ErrorMessage) ? " (HTTP call made)" : $" ({result.ErrorMessage})")}{Environment.NewLine}").ConfigureAwait(false);
+
                 if (result.ShouldAbortBatch)
                 {
                     aborted = true;
@@ -674,37 +673,42 @@ namespace Sarifintown.AgentEngine
 
             await ledger.UpsertAsync(updatedItems);
 
+            await AppendToSyncLogAsync(
+                $"[{DateTimeOffset.UtcNow:O}] Sync batch completed | synced={newSyncedCount} | idempotent={idempotentSyncedCount} | skipped={skippedCount} | failed={failedCount} | pending={pendingCount} | aborted={aborted}{Environment.NewLine}{new string('-', 80)}{Environment.NewLine}").ConfigureAwait(false);
+
             var lines = new List<string> { "## Sync Results", string.Empty };
 
-            if (syncedCount > 0)
+            lines.Add($"✅ **{newSyncedCount}** entries synced successfully.");
+            foreach (var (platform, count) in newSyncedByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
             {
-                lines.Add($"✅ **{syncedCount}** entries synced successfully.");
-                foreach (var (platform, count) in syncedByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
-                {
-                    lines.Add($"  - {platform}: {count}");
-                }
+                lines.Add($"  - {platform}: {count}");
             }
 
-            if (alreadySuppressedCount > 0)
+            lines.Add(string.Empty);
+            lines.Add($"⏭️ **{idempotentSyncedCount}** entries already ignored upstream (HTTP 409 — idempotent).");
+            foreach (var (platform, count) in idempotentByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
             {
-                lines.Add($"🟰 **{alreadySuppressedCount}** entries already had accepted SARIF suppressions and were marked synced.");
+                lines.Add($"  - {platform}: {count}");
+            }
+
+            lines.Add(string.Empty);
+            lines.Add($"🚫 **{skippedCount}** entries skipped (not applicable for this provider).");
+            foreach (var (platform, count) in skippedByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                lines.Add($"  - {platform}: {count}");
             }
 
             if (pendingCount > 0)
             {
+                lines.Add(string.Empty);
                 lines.Add($"⏸️ **{pendingCount}** entries remain pending (for example, rate-limited sync attempts).");
             }
 
-            if (failedCount > 0)
+            lines.Add(string.Empty);
+            lines.Add($"❌ **{failedCount}** entries failed to sync.");
+            foreach (var (platform, count) in failedByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
             {
-                lines.Add($"❌ **{failedCount}** entries failed to sync.");
-                foreach (var (platform, count) in failedByPlatform.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
-                {
-                    lines.Add($"  - {platform}: {count}");
-                }
-
-                lines.Add(string.Empty);
-                lines.Add("Check the triage ledger for error details. Fix credentials and retry with `sarif_sync`.");
+                lines.Add($"  - {platform}: {count}");
             }
 
             if (aborted)
@@ -713,10 +717,8 @@ namespace Sarifintown.AgentEngine
                 lines.Add("⚠️ Batch processing stopped early due to an authentication/permissions failure.");
             }
 
-            if (syncedCount == 0 && failedCount == 0 && pendingCount == 0)
-            {
-                lines.Add("ℹ️ No entries were processed.");
-            }
+            lines.Add(string.Empty);
+            lines.Add("*For full HTTP payloads and error details, inspect `.sarif/sarif_sync_http.log`.*");
 
             var syncOutput = string.Join(Environment.NewLine, lines);
             await AppendToExecutionLogAsync("sarif_sync",
@@ -740,13 +742,22 @@ namespace Sarifintown.AgentEngine
             return LoadFindingsByIdAsyncResult(findings);
         }
 
-        private static bool HasAcceptedSuppression(TriageFindingEnvelope findingEnvelope)
+        private static bool IsIdempotentSync(SyncOperationResult result)
         {
-            ArgumentNullException.ThrowIfNull(findingEnvelope);
+            return result.IsSuccess
+                   && result.Status == UpstreamSyncStatus.Synced
+                   && !string.IsNullOrWhiteSpace(result.ErrorMessage)
+                   && result.ErrorMessage.StartsWith("HTTP 409", StringComparison.OrdinalIgnoreCase);
+        }
 
-            var result = findingEnvelope.Result;
-            return result.Suppressions != null
-                   && result.Suppressions.Any(s => string.Equals(s.Status, "accepted", StringComparison.OrdinalIgnoreCase));
+        private static string FormatPlatformLabel(string platform)
+        {
+            if (string.IsNullOrWhiteSpace(platform))
+            {
+                return "unknown";
+            }
+
+            return platform.Trim().ToLowerInvariant();
         }
 
         private static IReadOnlyList<IUpstreamSyncProvider> GetSyncProviders()
@@ -772,8 +783,8 @@ namespace Sarifintown.AgentEngine
                 {
                     SnykToken = _syncOptions.SnykToken,
                     SnykOrgId = _syncOptions.SnykOrgId,
-                    GhasToken = _syncOptions.GhasToken,
-                    GithubToken = _syncOptions.GithubToken
+                    GitHubToken = _syncOptions.GitHubToken,
+                    GitHubRepo = _syncOptions.GitHubRepo
                 };
             }
         }
@@ -821,9 +832,16 @@ namespace Sarifintown.AgentEngine
             return "unknown";
         }
 
-        private static string BuildPartitionKey(string toolName)
+        private static string BuildPartitionKey(string toolName, SyncOptions syncOptions)
         {
-            var organization = Environment.GetEnvironmentVariable("SNYK_ORG_ID") ?? "local";
+            ArgumentNullException.ThrowIfNull(syncOptions);
+
+            var organization = syncOptions.SnykOrgId;
+            if (string.IsNullOrWhiteSpace(organization))
+            {
+                organization = "local";
+            }
+
             string workspaceRoot;
             lock (SyncRoot)
             {
@@ -2011,6 +2029,54 @@ namespace Sarifintown.AgentEngine
             catch
             {
                 // Silently swallow — logging must never crash the main flow
+            }
+        }
+
+        /// <summary>
+        /// Appends a diagnostic entry to the sync HTTP log for developer observability.
+        /// Also writes to stderr so MCP hosts (VS Code, etc.) can surface sync diagnostics.
+        /// File-write failures are logged to stderr rather than silently swallowed.
+        /// </summary>
+        private static async Task AppendToSyncLogAsync(string message)
+        {
+            // Always write to stderr so MCP hosts can surface sync diagnostics
+            try
+            {
+                await Console.Error.WriteAsync($"[sarifintown-sync] {message}").ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort stderr logging
+            }
+
+            try
+            {
+                string workspaceRoot;
+                lock (SyncRoot)
+                {
+                    workspaceRoot = _workspaceRoot;
+                }
+
+                var logPath = Path.Combine(Path.GetFullPath(workspaceRoot), ".sarif", "sarif_sync_http.log");
+                var logDirectory = Path.GetDirectoryName(logPath)!;
+                if (!Directory.Exists(logDirectory))
+                {
+                    Directory.CreateDirectory(logDirectory);
+                }
+
+                await File.AppendAllTextAsync(logPath, message).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Report file-write failures to stderr so they are visible in MCP output
+                try
+                {
+                    await Console.Error.WriteLineAsync($"[sarifintown-sync] WARNING: Failed to write sync log file: {ex.Message}").ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort stderr fallback
+                }
             }
         }
 

--- a/Sarifintown.AgentEngine/SarifTools.cs
+++ b/Sarifintown.AgentEngine/SarifTools.cs
@@ -34,6 +34,7 @@ namespace Sarifintown.AgentEngine
         private static List<string> _discoveredSarifFiles = new();
         private static string _localUiBaseUrl = string.Empty;
         private static string _workspaceRoot = Directory.GetCurrentDirectory();
+        private static SyncOptions _syncOptions = new();
         private static ActiveScopeFilter _activeScope = new();
         private static string _paginationScopeKey = string.Empty;
         private static int _paginationNextOffset;
@@ -80,6 +81,22 @@ namespace Sarifintown.AgentEngine
                 _paginationScopeKey = string.Empty;
                 _paginationNextOffset = 0;
                 ResetDisplayIdMappings();
+            }
+        }
+
+        public static void SetSyncOptions(SyncOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            lock (SyncRoot)
+            {
+                _syncOptions = new SyncOptions
+                {
+                    SnykToken = options.SnykToken?.Trim(),
+                    SnykOrgId = options.SnykOrgId?.Trim(),
+                    GhasToken = options.GhasToken?.Trim(),
+                    GithubToken = options.GithubToken?.Trim()
+                };
             }
         }
 
@@ -503,11 +520,12 @@ namespace Sarifintown.AgentEngine
         {
             var ledger = GetOrCreateLedgerService();
             var providers = GetSyncProviders();
+            var syncOptions = GetSyncOptions();
 
-            var snykToken = Environment.GetEnvironmentVariable("SNYK_TOKEN") ?? string.Empty;
-            var snykOrgId = Environment.GetEnvironmentVariable("SNYK_ORG_ID") ?? string.Empty;
-            var ghasToken = Environment.GetEnvironmentVariable("GHAS_TOKEN")
-                            ?? Environment.GetEnvironmentVariable("GITHUB_TOKEN")
+            var snykToken = syncOptions.SnykToken ?? string.Empty;
+            var snykOrgId = syncOptions.SnykOrgId ?? string.Empty;
+            var ghasToken = syncOptions.GhasToken
+                            ?? syncOptions.GithubToken
                             ?? string.Empty;
 
             IReadOnlyList<(string CompositeKey, LedgerEntry Entry)> entriesToSync;
@@ -744,6 +762,20 @@ namespace Sarifintown.AgentEngine
                 new SnykSyncProvider(httpClient),
                 new GhasSyncProvider()
             };
+        }
+
+        private static SyncOptions GetSyncOptions()
+        {
+            lock (SyncRoot)
+            {
+                return new SyncOptions
+                {
+                    SnykToken = _syncOptions.SnykToken,
+                    SnykOrgId = _syncOptions.SnykOrgId,
+                    GhasToken = _syncOptions.GhasToken,
+                    GithubToken = _syncOptions.GithubToken
+                };
+            }
         }
 
         private static string ResolveUpstreamState(string providerName, TriageDecisionState localState)

--- a/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
@@ -1,0 +1,38 @@
+using Sarifintown.Models;
+
+namespace Sarifintown.AgentEngine.Sync;
+
+internal sealed class GhasSyncProvider : IUpstreamSyncProvider
+{
+    public string ProviderName => "GitHubAdvancedSecurity";
+
+    public bool CanHandle(string toolDriverName)
+    {
+        if (string.IsNullOrWhiteSpace(toolDriverName))
+        {
+            return false;
+        }
+
+        var normalized = toolDriverName.Trim().ToLowerInvariant();
+        return normalized.Contains("codeql", StringComparison.Ordinal)
+               || normalized.Contains("github", StringComparison.Ordinal);
+    }
+
+    public Task<SyncOperationResult> SyncTriageAsync(
+        LedgerEntry entry,
+        Result originalSarifResult,
+        SyncContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(originalSarifResult);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.IsNullOrWhiteSpace(context.ApiToken))
+        {
+            return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "GHAS_TOKEN (or GITHUB_TOKEN) environment variable is not set."));
+        }
+
+        return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "GitHub Advanced Security sync provider is not implemented yet."));
+    }
+}

--- a/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
@@ -1,3 +1,4 @@
+using Sarifintown.AgentEngine.Configuration;
 using Sarifintown.Models;
 
 namespace Sarifintown.AgentEngine.Sync;
@@ -21,16 +22,16 @@ internal sealed class GhasSyncProvider : IUpstreamSyncProvider
     public Task<SyncOperationResult> SyncTriageAsync(
         LedgerEntry entry,
         Result originalSarifResult,
-        SyncContext context,
+        SyncOptions options,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(entry);
         ArgumentNullException.ThrowIfNull(originalSarifResult);
-        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(options);
 
-        if (string.IsNullOrWhiteSpace(context.ApiToken))
+        if (string.IsNullOrWhiteSpace(options.GitHubToken))
         {
-            return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:GhasToken (or Sync:GithubToken) is not configured."));
+            return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:GitHubToken is not configured."));
         }
 
         return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "GitHub Advanced Security sync provider is not implemented yet."));

--- a/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/GhasSyncProvider.cs
@@ -30,7 +30,7 @@ internal sealed class GhasSyncProvider : IUpstreamSyncProvider
 
         if (string.IsNullOrWhiteSpace(context.ApiToken))
         {
-            return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "GHAS_TOKEN (or GITHUB_TOKEN) environment variable is not set."));
+            return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:GhasToken (or Sync:GithubToken) is not configured."));
         }
 
         return Task.FromResult(new SyncOperationResult(false, UpstreamSyncStatus.Failed, "GitHub Advanced Security sync provider is not implemented yet."));

--- a/Sarifintown.AgentEngine/Sync/IUpstreamSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/IUpstreamSyncProvider.cs
@@ -1,0 +1,24 @@
+using Sarifintown.Models;
+
+namespace Sarifintown.AgentEngine.Sync;
+
+internal interface IUpstreamSyncProvider
+{
+    string ProviderName { get; }
+
+    bool CanHandle(string toolDriverName);
+
+    Task<SyncOperationResult> SyncTriageAsync(
+        LedgerEntry entry,
+        Result originalSarifResult,
+        SyncContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed record SyncContext(string ApiToken, string OrganizationId);
+
+internal sealed record SyncOperationResult(
+    bool IsSuccess,
+    UpstreamSyncStatus Status,
+    string? ErrorMessage,
+    bool ShouldAbortBatch = false);

--- a/Sarifintown.AgentEngine/Sync/IUpstreamSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/IUpstreamSyncProvider.cs
@@ -1,3 +1,4 @@
+using Sarifintown.AgentEngine.Configuration;
 using Sarifintown.Models;
 
 namespace Sarifintown.AgentEngine.Sync;
@@ -11,11 +12,9 @@ internal interface IUpstreamSyncProvider
     Task<SyncOperationResult> SyncTriageAsync(
         LedgerEntry entry,
         Result originalSarifResult,
-        SyncContext context,
+        SyncOptions options,
         CancellationToken cancellationToken);
 }
-
-internal sealed record SyncContext(string ApiToken, string OrganizationId);
 
 internal sealed record SyncOperationResult(
     bool IsSuccess,

--- a/Sarifintown.AgentEngine/Sync/RedactingHttpLoggingHandler.cs
+++ b/Sarifintown.AgentEngine/Sync/RedactingHttpLoggingHandler.cs
@@ -1,0 +1,137 @@
+using System.Text;
+
+namespace Sarifintown.AgentEngine.Sync;
+
+internal sealed record SyncHttpLoggingOptions(string WorkspaceRoot);
+
+internal sealed class RedactingHttpLoggingHandler : DelegatingHandler
+{
+    private static readonly SemaphoreSlim LogWriteLock = new(1, 1);
+    private readonly string _logFilePath;
+
+    public RedactingHttpLoggingHandler(SyncHttpLoggingOptions loggingOptions)
+    {
+        ArgumentNullException.ThrowIfNull(loggingOptions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(loggingOptions.WorkspaceRoot);
+
+        _logFilePath = Path.Combine(Path.GetFullPath(loggingOptions.WorkspaceRoot), ".sarif", "sarif_sync_http.log");
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var startedAt = DateTimeOffset.UtcNow;
+        string requestBody;
+        try
+        {
+            requestBody = await ReadContentAsync(request.Content, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            requestBody = "<failed to read request body>";
+        }
+
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var completedAt = DateTimeOffset.UtcNow;
+            var responseBody = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+
+            await AppendLogAsync(
+                BuildLogBlock(request, requestBody, response, responseBody, startedAt, completedAt),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort logging; never disrupt the actual HTTP operation
+        }
+
+        return response;
+    }
+
+    private static string BuildLogBlock(
+        HttpRequestMessage request,
+        string requestBody,
+        HttpResponseMessage response,
+        string responseBody,
+        DateTimeOffset startedAt,
+        DateTimeOffset completedAt)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"[{startedAt:O}] Request");
+        builder.AppendLine($"Method: {request.Method}");
+        builder.AppendLine($"Uri: {request.RequestUri}");
+
+        foreach (var header in request.Headers)
+        {
+            var value = string.Equals(header.Key, "Authorization", StringComparison.OrdinalIgnoreCase)
+                ? "[REDACTED]"
+                : string.Join(", ", header.Value);
+            builder.AppendLine($"{header.Key}: {value}");
+        }
+
+        foreach (var header in request.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+        {
+            builder.AppendLine($"{header.Key}: {string.Join(", ", header.Value)}");
+        }
+
+        builder.AppendLine("RequestBody:");
+        builder.AppendLine(string.IsNullOrWhiteSpace(requestBody) ? "<empty>" : requestBody);
+        builder.AppendLine();
+
+        builder.AppendLine($"[{completedAt:O}] Response");
+        builder.AppendLine($"StatusCode: {(int)response.StatusCode} {response.StatusCode}");
+
+        foreach (var header in response.Headers)
+        {
+            builder.AppendLine($"{header.Key}: {string.Join(", ", header.Value)}");
+        }
+
+        foreach (var header in response.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+        {
+            builder.AppendLine($"{header.Key}: {string.Join(", ", header.Value)}");
+        }
+
+        builder.AppendLine("ResponseBody:");
+        builder.AppendLine(string.IsNullOrWhiteSpace(responseBody) ? "<empty>" : responseBody);
+        builder.AppendLine(new string('-', 80));
+
+        return builder.ToString();
+    }
+
+    private static async Task<string> ReadContentAsync(HttpContent? content, CancellationToken cancellationToken)
+    {
+        if (content == null)
+        {
+            return string.Empty;
+        }
+
+        return await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task AppendLogAsync(string block, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(block))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(_logFilePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await LogWriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await File.AppendAllTextAsync(_logFilePath, block, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            LogWriteLock.Release();
+        }
+    }
+}

--- a/Sarifintown.AgentEngine/Sync/Snyk/SnykIgnoreModels.cs
+++ b/Sarifintown.AgentEngine/Sync/Snyk/SnykIgnoreModels.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace Sarifintown.AgentEngine.Sync.Snyk;
+
+internal sealed class SnykIgnorePayload
+{
+    [JsonPropertyName("data")]
+    public SnykIgnoreData Data { get; set; } = new();
+}
+
+internal sealed class SnykIgnoreData
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "ignore";
+
+    [JsonPropertyName("attributes")]
+    public SnykIgnoreAttributes Attributes { get; set; } = new();
+
+    [JsonPropertyName("relationships")]
+    public SnykIgnoreRelationships Relationships { get; set; } = new();
+}
+
+internal sealed class SnykIgnoreAttributes
+{
+    [JsonPropertyName("reason_type")]
+    public string ReasonType { get; set; } = string.Empty;
+
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+}
+
+internal sealed class SnykIgnoreRelationships
+{
+    [JsonPropertyName("issue")]
+    public SnykIssueRelationship Issue { get; set; } = new();
+}
+
+internal sealed class SnykIssueRelationship
+{
+    [JsonPropertyName("data")]
+    public SnykIssueData Data { get; set; } = new();
+}
+
+internal sealed class SnykIssueData
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "issue";
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+}
+
+internal sealed class SnykErrorResponse
+{
+    [JsonPropertyName("errors")]
+    public List<SnykErrorDetail> Errors { get; set; } = new();
+}
+
+internal sealed class SnykErrorDetail
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("detail")]
+    public string Detail { get; set; } = string.Empty;
+}

--- a/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
@@ -1,8 +1,10 @@
+using Sarifintown.AgentEngine.Configuration;
 using Sarifintown.Models;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace Sarifintown.AgentEngine.Sync.Snyk;
 
@@ -35,26 +37,30 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
     public async Task<SyncOperationResult> SyncTriageAsync(
         LedgerEntry entry,
         Result originalSarifResult,
-        SyncContext context,
+        SyncOptions options,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(entry);
         ArgumentNullException.ThrowIfNull(originalSarifResult);
-        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (HasAcceptedSuppression(originalSarifResult))
+        {
+            return new SyncOperationResult(true, UpstreamSyncStatus.Skipped, "Already suppressed in SARIF; no Snyk API call needed.");
+        }
 
         if (!TryMapDecisionToReasonType(entry.TriageDecision.State, out var reasonType, out var reasonPrefix))
         {
-            return new SyncOperationResult(true, UpstreamSyncStatus.Synced, null);
+            var skipReason = entry.TriageDecision.State == TriageDecisionState.Confirmed
+                ? "Snyk does not support syncing true positives; only FP/WontFix/Mitigated/TestCode can be pushed upstream."
+                : $"Triage state '{entry.TriageDecision.State}' is not supported by the Snyk ignore API.";
+            return new SyncOperationResult(true, UpstreamSyncStatus.Skipped, skipReason);
         }
 
-        if (string.IsNullOrWhiteSpace(context.ApiToken))
+        if (string.IsNullOrWhiteSpace(options.SnykToken)
+            || string.IsNullOrWhiteSpace(options.SnykOrgId))
         {
-            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:SnykToken is not configured.", ShouldAbortBatch: true);
-        }
-
-        if (string.IsNullOrWhiteSpace(context.OrganizationId))
-        {
-            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:SnykOrgId is not configured.");
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:SnykToken and Sync:SnykOrgId must be configured.", ShouldAbortBatch: true);
         }
 
         var fingerprints = originalSarifResult.Fingerprints;
@@ -88,7 +94,7 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
             }
         };
 
-        var url = $"https://api.snyk.io/rest/orgs/{Uri.EscapeDataString(context.OrganizationId)}/ignores?version=2024-10-15~beta";
+        var url = $"https://api.snyk.io/rest/orgs/{Uri.EscapeDataString(options.SnykOrgId)}/ignores?version=2024-10-15~beta";
 
         for (var attempt = 0; attempt <= MaxRateLimitRetries; attempt++)
         {
@@ -96,7 +102,7 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
             {
                 Content = JsonContent.Create(payload, new MediaTypeHeaderValue("application/vnd.api+json"))
             };
-            request.Headers.Authorization = new AuthenticationHeaderValue("TOKEN", context.ApiToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("TOKEN", options.SnykToken);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
 
             using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -109,17 +115,17 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
 
             if (statusCode == HttpStatusCode.Conflict)
             {
-                return new SyncOperationResult(true, UpstreamSyncStatus.Synced, "Already ignored upstream");
+                return new SyncOperationResult(true, UpstreamSyncStatus.Synced, "HTTP 409 Conflict: Already ignored upstream.");
             }
 
             if (statusCode == HttpStatusCode.NotFound)
             {
-                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Target finding not found (likely resolved in code).");
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "HTTP 404: Target finding not found.");
             }
 
             if (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden)
             {
-                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Auth/Permissions failed.", ShouldAbortBatch: true);
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "HTTP 401/403: Auth failed.", ShouldAbortBatch: true);
             }
 
             if (statusCode == (HttpStatusCode)429)
@@ -138,7 +144,7 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
             {
                 var badRequestMessage = await TryReadSnykErrorDetailAsync(response, cancellationToken).ConfigureAwait(false)
                     ?? "Snyk request validation failed.";
-                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, badRequestMessage);
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, $"HTTP 400: {badRequestMessage}");
             }
 
             var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -147,7 +153,7 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
                 error = $"Unexpected Snyk response: {(int)response.StatusCode} {response.ReasonPhrase}";
             }
 
-            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, error);
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, $"HTTP {(int)response.StatusCode}: {error}");
         }
 
         return new SyncOperationResult(false, UpstreamSyncStatus.Pending, "Rate limited.");
@@ -212,6 +218,12 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
         return DefaultRetryDelay;
     }
 
+    private static bool HasAcceptedSuppression(Result originalSarifResult)
+    {
+        return originalSarifResult.Suppressions != null
+               && originalSarifResult.Suppressions.Any(s => string.Equals(s.Status, "accepted", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static async Task<string?> TryReadSnykErrorDetailAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         try
@@ -219,7 +231,11 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
             var error = await response.Content.ReadFromJsonAsync<SnykErrorResponse>(cancellationToken: cancellationToken).ConfigureAwait(false);
             return error?.Errors.FirstOrDefault()?.Detail;
         }
-        catch
+        catch (JsonException)
+        {
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (NotSupportedException)
         {
             return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
@@ -49,12 +49,12 @@ internal sealed class SnykSyncProvider : IUpstreamSyncProvider
 
         if (string.IsNullOrWhiteSpace(context.ApiToken))
         {
-            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "SNYK_TOKEN environment variable is not set.", ShouldAbortBatch: true);
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:SnykToken is not configured.", ShouldAbortBatch: true);
         }
 
         if (string.IsNullOrWhiteSpace(context.OrganizationId))
         {
-            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "SNYK_ORG_ID environment variable is not set.");
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Sync:SnykOrgId is not configured.");
         }
 
         var fingerprints = originalSarifResult.Fingerprints;

--- a/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
+++ b/Sarifintown.AgentEngine/Sync/Snyk/SnykSyncProvider.cs
@@ -1,0 +1,227 @@
+using Sarifintown.Models;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace Sarifintown.AgentEngine.Sync.Snyk;
+
+internal sealed class SnykSyncProvider : IUpstreamSyncProvider
+{
+    private const string AssetFingerprintKey = "snyk/asset/finding/v1";
+    private const int MaxRateLimitRetries = 3;
+    private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromSeconds(2);
+
+    private readonly HttpClient _httpClient;
+
+    internal SnykSyncProvider(HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public string ProviderName => "Snyk";
+
+    public bool CanHandle(string toolDriverName)
+    {
+        if (string.IsNullOrWhiteSpace(toolDriverName))
+        {
+            return false;
+        }
+
+        var normalized = toolDriverName.Trim().ToLowerInvariant();
+        return normalized.Contains("snyk", StringComparison.Ordinal);
+    }
+
+    public async Task<SyncOperationResult> SyncTriageAsync(
+        LedgerEntry entry,
+        Result originalSarifResult,
+        SyncContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(originalSarifResult);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!TryMapDecisionToReasonType(entry.TriageDecision.State, out var reasonType, out var reasonPrefix))
+        {
+            return new SyncOperationResult(true, UpstreamSyncStatus.Synced, null);
+        }
+
+        if (string.IsNullOrWhiteSpace(context.ApiToken))
+        {
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "SNYK_TOKEN environment variable is not set.", ShouldAbortBatch: true);
+        }
+
+        if (string.IsNullOrWhiteSpace(context.OrganizationId))
+        {
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "SNYK_ORG_ID environment variable is not set.");
+        }
+
+        var fingerprints = originalSarifResult.Fingerprints;
+        if (fingerprints == null || !fingerprints.TryGetValue(AssetFingerprintKey, out var issueId) || string.IsNullOrWhiteSpace(issueId))
+        {
+            return new SyncOperationResult(
+                false,
+                UpstreamSyncStatus.Failed,
+                "Missing 'snyk/asset/finding/v1' fingerprint. Consistent ignores requires this asset identifier.");
+        }
+
+        var payload = new SnykIgnorePayload
+        {
+            Data = new SnykIgnoreData
+            {
+                Attributes = new SnykIgnoreAttributes
+                {
+                    ReasonType = reasonType,
+                    Reason = BuildReason(entry, reasonPrefix)
+                },
+                Relationships = new SnykIgnoreRelationships
+                {
+                    Issue = new SnykIssueRelationship
+                    {
+                        Data = new SnykIssueData
+                        {
+                            Id = issueId
+                        }
+                    }
+                }
+            }
+        };
+
+        var url = $"https://api.snyk.io/rest/orgs/{Uri.EscapeDataString(context.OrganizationId)}/ignores?version=2024-10-15~beta";
+
+        for (var attempt = 0; attempt <= MaxRateLimitRetries; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(payload, new MediaTypeHeaderValue("application/vnd.api+json"))
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("TOKEN", context.ApiToken);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var statusCode = response.StatusCode;
+
+            if (statusCode == HttpStatusCode.Created)
+            {
+                return new SyncOperationResult(true, UpstreamSyncStatus.Synced, null);
+            }
+
+            if (statusCode == HttpStatusCode.Conflict)
+            {
+                return new SyncOperationResult(true, UpstreamSyncStatus.Synced, "Already ignored upstream");
+            }
+
+            if (statusCode == HttpStatusCode.NotFound)
+            {
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Target finding not found (likely resolved in code).");
+            }
+
+            if (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden)
+            {
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, "Auth/Permissions failed.", ShouldAbortBatch: true);
+            }
+
+            if (statusCode == (HttpStatusCode)429)
+            {
+                if (attempt == MaxRateLimitRetries)
+                {
+                    return new SyncOperationResult(false, UpstreamSyncStatus.Pending, "Rate limited.");
+                }
+
+                var retryDelay = ResolveRetryDelay(response.Headers.RetryAfter);
+                await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (statusCode == HttpStatusCode.BadRequest)
+            {
+                var badRequestMessage = await TryReadSnykErrorDetailAsync(response, cancellationToken).ConfigureAwait(false)
+                    ?? "Snyk request validation failed.";
+                return new SyncOperationResult(false, UpstreamSyncStatus.Failed, badRequestMessage);
+            }
+
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                error = $"Unexpected Snyk response: {(int)response.StatusCode} {response.ReasonPhrase}";
+            }
+
+            return new SyncOperationResult(false, UpstreamSyncStatus.Failed, error);
+        }
+
+        return new SyncOperationResult(false, UpstreamSyncStatus.Pending, "Rate limited.");
+    }
+
+    internal static bool TryMapDecisionToReasonType(TriageDecisionState decisionState, out string reasonType, out string reasonPrefix)
+    {
+        reasonType = string.Empty;
+        reasonPrefix = string.Empty;
+
+        switch (decisionState)
+        {
+            case TriageDecisionState.FalsePositive:
+                reasonType = "not-vulnerable";
+                return true;
+            case TriageDecisionState.WontFix:
+                reasonType = "wont-fix";
+                return true;
+            case TriageDecisionState.Mitigated:
+                reasonType = "temporary-ignore";
+                return true;
+            case TriageDecisionState.TestCode:
+                reasonType = "not-vulnerable";
+                reasonPrefix = "[Test Code] ";
+                return true;
+            case TriageDecisionState.Confirmed:
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static string BuildReason(LedgerEntry entry, string reasonPrefix)
+    {
+        var reason = entry.TriageDecision.ShortReason;
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            reason = "Updated by sarif_sync";
+        }
+
+        return string.IsNullOrWhiteSpace(reasonPrefix)
+            ? reason
+            : string.Concat(reasonPrefix, reason);
+    }
+
+    private static TimeSpan ResolveRetryDelay(RetryConditionHeaderValue? retryAfter)
+    {
+        if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+        {
+            return delta;
+        }
+
+        if (retryAfter?.Date is { } retryDate)
+        {
+            var dateDelay = retryDate - DateTimeOffset.UtcNow;
+            if (dateDelay > TimeSpan.Zero)
+            {
+                return dateDelay;
+            }
+        }
+
+        return DefaultRetryDelay;
+    }
+
+    private static async Task<string?> TryReadSnykErrorDetailAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var error = await response.Content.ReadFromJsonAsync<SnykErrorResponse>(cancellationToken: cancellationToken).ConfigureAwait(false);
+            return error?.Errors.FirstOrDefault()?.Detail;
+        }
+        catch
+        {
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Sarifintown.AgentEngine/TriageLedger.cs
+++ b/Sarifintown.AgentEngine/TriageLedger.cs
@@ -35,6 +35,9 @@ internal enum UpstreamSyncStatus
     [JsonStringEnumMemberName("synced")]
     Synced,
 
+    [JsonStringEnumMemberName("skipped")]
+    Skipped,
+
     [JsonStringEnumMemberName("failed")]
     Failed
 }
@@ -125,8 +128,36 @@ internal sealed record LedgerEntry
     [JsonPropertyName("partition_key")]
     public string PartitionKey { get; init; } = string.Empty;
 
+    [JsonPropertyName("finding_id")]
+    public string FindingId
+    {
+        get => Metadata.FindingId;
+        init => Metadata = Metadata with { FindingId = value ?? string.Empty };
+    }
+
+    [JsonPropertyName("local_state")]
+    public TriageDecisionState LocalState
+    {
+        get => TriageDecision.State;
+        init => TriageDecision = TriageDecision with { State = value };
+    }
+
     [JsonPropertyName("upstream_provider")]
     public string UpstreamProvider { get; init; } = string.Empty;
+
+    [JsonPropertyName("sync_status")]
+    public UpstreamSyncStatus SyncStatus
+    {
+        get => UpstreamSync.Status;
+        init => UpstreamSync = UpstreamSync with { Status = value };
+    }
+
+    [JsonPropertyName("sync_error_message")]
+    public string? SyncErrorMessage
+    {
+        get => UpstreamSync.ErrorMessage;
+        init => UpstreamSync = UpstreamSync with { ErrorMessage = value };
+    }
 
     [JsonPropertyName("upstream_state")]
     public string UpstreamState { get; init; } = string.Empty;
@@ -151,7 +182,7 @@ internal sealed record LedgerEntry
 internal sealed record TriageLedgerDocument
 {
     [JsonPropertyName("schema_version")]
-    public int SchemaVersion { get; init; } = 1;
+    public int SchemaVersion { get; init; } = 2;
 
     [JsonPropertyName("entries")]
     public Dictionary<string, LedgerEntry> Entries { get; init; } = new(StringComparer.Ordinal);

--- a/Sarifintown.AgentEngine/TriageLedger.cs
+++ b/Sarifintown.AgentEngine/TriageLedger.cs
@@ -119,6 +119,18 @@ internal sealed record LedgerUpstreamSync
 /// </summary>
 internal sealed record LedgerEntry
 {
+    [JsonPropertyName("record_id")]
+    public Guid RecordId { get; init; } = Guid.NewGuid();
+
+    [JsonPropertyName("partition_key")]
+    public string PartitionKey { get; init; } = string.Empty;
+
+    [JsonPropertyName("upstream_provider")]
+    public string UpstreamProvider { get; init; } = string.Empty;
+
+    [JsonPropertyName("upstream_state")]
+    public string UpstreamState { get; init; } = string.Empty;
+
     [JsonPropertyName("metadata")]
     public LedgerMetadata Metadata { get; init; } = new();
 


### PR DESCRIPTION
Introduce upstream sync framework and Snyk/GHAS adapters used by sarif_sync. Adds IUpstreamSyncProvider, SyncContext/SyncOperationResult, Snyk API models and a SnykSyncProvider (with retry, rate-limit handling, payload building and decision mapping) and a placeholder GhasSyncProvider. Integrates provider selection and sync flow into SarifTools: new SyncProvidersOverride, SyncHttpClientFactory, SharedSyncHttpClient, loading findings by id, skipping entries with accepted SARIF suppressions, resolving provider names/states, batching results (synced/pending/failed/aborted) and updating the triage ledger. Adds helpers (LoadFindingsByIdAsync, HasAcceptedSuppression, GetSyncProviders, ResolveUpstreamState/ProviderName, BuildPartitionKey) and adjusts state/service initialization to support the new flow. Updates LedgerEntry with record_id, partition_key, upstream_provider and upstream_state fields. Adds tests covering accepted-suppression and confirmed-local sync behavior.